### PR TITLE
Refactor crawler and add "survey" mode

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -266,7 +266,7 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
     def clear_data(self):
         """Clear the training data Privacy Badger starts with."""
         self.load_extension_page(OPTIONS)
-        self.js("badger.storage.clearTrackerData();")
+        self.driver.execute_script("badger.storage.clearTrackerData();")
 
     def timeout_workaround(self):
         """
@@ -301,6 +301,10 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
         time.sleep(self.wait_time)
         return url
 
+    def start_browser(self, data):
+        self.start_driver()
+        self.clear_data()
+
     def restart_browser(self, data):
         self.logger.info('restarting browser...')
 
@@ -317,7 +321,7 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
                 pass
 
             try:
-                self.start_driver()
+                self.start_browser()
                 self.load_user_data(data)
                 self.logger.error('Success')
                 break
@@ -351,7 +355,7 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
         # create an XVFB virtual display (to avoid opening an actual browser)
         self.vdisplay = Xvfb(width=1280, height=720)
         self.vdisplay.start()
-        self.start_driver()
+        self.start_browser()
 
         # list of domains we actually visited
         visited = []
@@ -460,9 +464,8 @@ chrome.runtime.sendMessage({
 });'''
         self.driver.execute_script(script)
 
-    def start_driver(self):
-        super(SurveyCrawler, self).start_driver()
-
+    def start_browser(self):
+        self.start_driver()
         # don't block anything, just listen and log
         self.set_passive_mode()
 
@@ -499,7 +502,7 @@ chrome.runtime.sendMessage({
         # create an XVFB virtual display (to avoid opening an actual browser)
         self.vdisplay = Xvfb(width=1280, height=720)
         self.vdisplay.start()
-        self.start_driver()
+        self.start_browser()
 
         # list of domains we actually visited
         visited = []

--- a/crawler.py
+++ b/crawler.py
@@ -301,7 +301,7 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
         time.sleep(self.wait_time)
         return url
 
-    def start_browser(self, data):
+    def start_browser(self):
         self.start_driver()
         self.clear_data()
 
@@ -394,7 +394,7 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
         self.vdisplay.stop()
 
         self.cleanup(domains, data)
-        self.save(self.merge_saved_data())
+        self.save(data)
 
     def cleanup(self, domains, data):
         """

--- a/crawler.py
+++ b/crawler.py
@@ -98,7 +98,7 @@ def get_chrome_extension_id(crx_file):
     return str.translate(digest[:32], trans)
 
 
-def get_domain_list(n_sites, out_path):
+def get_domain_list(logger, n_sites, out_path):
     """Load the top million domains from disk or the web"""
     top_1m_file = os.path.join(out_path, MAJESTIC_URL.split('/')[-1])
     pyfunc_cache_file = os.path.join(out_path, 'pyfunceable_cache.json')
@@ -349,7 +349,7 @@ badger.storage.%s.merge(data.%s);''' % (obj, obj)
         virtual browser with Privacy Badger installed. Afterwards, save the
         action_map and snitch_map that the Badger learned.
         """
-        domains = get_domain_list(self.n_sites, self.out_path)
+        domains = get_domain_list(self.logger, self.n_sites, self.out_path)
         self.logger.info('starting new crawl with timeout %s n_sites %s',
                          self.timeout, self.n_sites)
 

--- a/crawler.py
+++ b/crawler.py
@@ -83,7 +83,10 @@ var crash = badptr.contents;""")
 
 
 def get_chrome_extension_id(crx_file):
-    """Interpret a .crx file's extension ID"""
+    """
+    Interpret a .crx file's extension ID
+    TODO: update for CRX3
+    """
     with open(crx_file, 'rb') as f:
         data = f.read()
     header = struct.unpack('<4sIII', data[:16])
@@ -157,6 +160,7 @@ class Crawler(object):
                  out_path, ext_path, chromedriver_path, firefox_path,
                  **kwargs):
         self.browser = browser
+        assert self.browser in (CHROME, FIREFOX)
         self.n_sites = n_sites
         self.timeout = timeout
         self.wait_time = wait_time
@@ -215,9 +219,6 @@ class Crawler(object):
                                                  'temporary': True})
             time.sleep(2)
 
-        else:
-            raise ValueError("%s is not a valid browser" % self.browser)
-
         # apply timeout settings
         self.driver.set_page_load_timeout(self.timeout)
         self.driver.set_script_timeout(self.timeout)
@@ -229,7 +230,7 @@ class Crawler(object):
         """
         if self.browser == CHROME:
             ext_url = (CHROME_URL_FMT + page) % get_chrome_extension_id(ext_path)
-        else:
+        elif self.browser == FIREFOX:
             ext_url = (FF_URL_FMT + page) % FF_UUID
 
         for _ in range(retries):

--- a/crawler.py
+++ b/crawler.py
@@ -18,6 +18,7 @@ from selenium.common.exceptions import TimeoutException, WebDriverException,\
                                        NoSuchWindowException,\
                                        SessionNotCreatedException
 from selenium.webdriver.chrome.options import Options
+from tldextract import TLDExtract
 from xvfbwrapper import Xvfb
 
 
@@ -189,6 +190,12 @@ def load_extension_page(driver, browser, ext_path, page, retries=3):
         raise err
 
 
+def clear_user_data(driver, browser, ext_path):
+    load_extension_page(driver, browser, ext_path, OPTIONS)
+    script = 'chrome.runtime.sendMessage({type: "removeAllData"});'
+    driver.execute_script(script)
+
+
 def load_user_data(driver, browser, ext_path, data):
     load_extension_page(driver, browser, ext_path, OPTIONS)
     script = '''
@@ -295,9 +302,14 @@ def crawl(browser, out_path, ext_path, chromedriver_path, firefox_path, n_sites,
         logger.info('visiting %d: %s', i + 1, domain)
 
         try:
-            # If we can't load the options page for some reason, treat it like
-            # any other failure.
+            # This script could fail during the data dump (trying to get the
+            # options page), the data cleaning, or while trying to load the next
+            # domain.
             last_data = dump_data(driver, browser, ext_path)
+            clean_data = cleanup(last_data)
+            if last_data != clean_data:
+                clear_data(driver, browser, ext_path)
+                load_user_data(clean_data)
             url = get_domain(driver, domain, wait_time)
             visited.append(url)
         except TimeoutException:
@@ -326,17 +338,17 @@ def crawl(browser, out_path, ext_path, chromedriver_path, firefox_path, n_sites,
     vdisplay.stop()
 
     logger.info('Cleaning data...')
-    cleanup(domains, data)
     return data
 
 
-def cleanup(domains, data):
+def cleanup(d1, d2, data):
     """
     Remove from snitch map any domains that appear to have been added as a
     result of bugs.
     """
-    snitch_map = data['snitch_map']
-    action_map = data['action_map']
+    new_data = data.deepcopy()
+    snitch_map = new_data['snitch_map']
+    action_map = new_data['action_map']
 
     # handle blank domain bug
     if '' in action_map:
@@ -347,28 +359,34 @@ def cleanup(domains, data):
         logger.info('Deleting blank domain from snitch map')
         del snitch_map['']
 
+    extract = TLDExtract()
+    d1_base = extract(d1).registered_domain
+
     # handle the domain-attribution bug (Privacy Badger issue #1997).
-    for i in range(len(domains) - 1):
-        d1, d2 = domains[i:i+2]
+    # If a domain we visited was recorded as a tracker on the domain we
+    # visited immediately after it, it's probably a bug
+    if d1_base in snitch_map and d2 in snitch_map[d1_base]:
+        logger.info('Reported domain %s tracking on %s', d1_base, d2)
+        del snitch_map[d1_base][d2]
 
-        # If a domain we visited was recorded as a tracker on the domain we
-        # visited immediately after it, it's probably a bug
-        if d1 in snitch_map and d2 in snitch_map[d1]:
-            logger.info('Reported domain %s tracking on %s', d1, d2)
-            snitch_map[d1].remove(d2)
-
-            # if the bug caused d1 to be added to the action map, remove it
-            if not snitch_map[d1]:
-                logger.info('Deleting domain %s from action and snitch maps',
-                            d1)
+        # if the bug caused d1 to be added to the action map, remove it
+        if not snitch_map[d1_base]:
+            logger.info('Deleting domain %s from action & snitch maps', d1_base)
+            if d1 in action_map:
                 del action_map[d1]
-                del snitch_map[d1]
+            if d1_base in action_map:
+                del action_map[d1_base]
+            del snitch_map[d1_base]
 
-            # if the bug caused d1 to be blocked, unblock it
-            elif len(snitch_map[d1]) == 2:
-                logger.info('Downgrading domain %s from "block" to "allow"',
-                            d1)
+        # if the bug caused d1 to be blocked, unblock it
+        elif len(snitch_map[d1_base]) == 2:
+            logger.info('Downgrading domain %s from "block" to "allow"', d1_base)
+            if d1 in action_map:
                 action_map[d1]['heuristicAction'] = 'allow'
+            if d1_base in action_map:
+                action_map[d1_base]['heuristicAction'] = 'allow'
+
+    return new_data
 
 
 if __name__ == '__main__':

--- a/crawler.py
+++ b/crawler.py
@@ -54,7 +54,7 @@ ap.add_argument('--log-stdout', action='store_true', default=False,
                 help='If set, log to stdout as well as log.txt')
 ap.add_argument('--survey', action='store_true', default=False,
                 help="If set, don't block anything or store action_map data")
-ap.add_argument('--max-data-size', type=int, default=5e5,
+ap.add_argument('--max-data-size', type=int, default=2e6,
                 help='Maximum size of serialized localstorage data')
 
 # Arguments below here should never have to be used within the docker container.
@@ -460,6 +460,12 @@ chrome.runtime.sendMessage({
 });'''
         self.driver.execute_script(script)
 
+    def start_driver(self):
+        super(SurveyCrawler, self).start_driver()
+
+        # don't block anything, just listen and log
+        self.set_passive_mode()
+
     def merge_saved_data(self):
         paths = glob.glob(os.path.join(self.out_path, 'results-*.json'))
         snitch_map = {}
@@ -494,9 +500,6 @@ chrome.runtime.sendMessage({
         self.vdisplay = Xvfb(width=1280, height=720)
         self.vdisplay.start()
         self.start_driver()
-
-        # don't block anything, just listen and log
-        self.set_passive_mode()
 
         # list of domains we actually visited
         visited = []
@@ -541,7 +544,6 @@ chrome.runtime.sendMessage({
         self.logger.info('Getting data from browser storage...')
 
         try:
-            self.logger.info('Getting data from browser storage...')
             data = self.dump_data()
         except WebDriverException:
             if last_data:

--- a/crawler.py
+++ b/crawler.py
@@ -69,14 +69,13 @@ ap.add_argument('--firefox-path', default=FF_BIN_PATH,
 def test_crash(driver):
     driver.set_context("chrome")
     driver.execute_script("""
-      // Copied from crash me simple
-      Components.utils.import("resource://gre/modules/ctypes.jsm");
+// Copied from crash me simple
+Components.utils.import("resource://gre/modules/ctypes.jsm");
 
-      // ctypes checks for NULL pointer derefs, so just go near-NULL.
-      var zero = new ctypes.intptr_t(8);
-      var badptr = ctypes.cast(zero, ctypes.PointerType(ctypes.int32_t));
-      var crash = badptr.contents;
-    """)
+// ctypes checks for NULL pointer derefs, so just go near-NULL.
+var zero = new ctypes.intptr_t(8);
+var badptr = ctypes.cast(zero, ctypes.PointerType(ctypes.int32_t));
+var crash = badptr.contents;""")
 
 
 def get_chrome_extension_id(crx_file):
@@ -144,263 +143,246 @@ def get_domain_list(n_sites, out_path):
 
     return domains
 
+class Crawler(object):
+    def __init__(self, browser, out_path, ext_path, chromedriver_path,
+                 firefox_path, n_sites, timeout, wait_time, **kwargs):
+        self.browser = browser
+        self.out_path = out_path
+        self.ext_path = ext_path
+        self.chromedriver_path = chromedriver_path
+        self.firefox_path = firefox_path
+        self.n_sites = n_sites
+        self.timeout = timeout
+        self.wait_time = wait_time
 
-def start_driver_chrome(ext_path, chromedriver_path):
-    """Start a new Selenium web driver for Chrome and install the bundled extension."""
-    opts = Options()
-    opts.add_argument('--no-sandbox')
-    opts.add_extension(ext_path)
-    opts.add_experimental_option("prefs", {"profile.block_third_party_cookies": False})
-    opts.add_argument('--dns-prefetch-disable')
-    return webdriver.Chrome(chromedriver_path, chrome_options=opts)
+    def start_driver(self):
+        """Start a new Selenium web driver and install the bundled extension."""
+        if self.browser == CHROME:
+            opts = Options()
+            opts.add_argument('--no-sandbox')
+            opts.add_extension(self.ext_path)
+            prefs = {"profile.block_third_party_cookies": False}
+            opts.add_experimental_option("prefs", prefs)
+            opts.add_argument('--dns-prefetch-disable')
+            self.driver = webdriver.Chrome(self.chromedriver_path,
+                                           chrome_options=opts)
 
+        elif self.browser == FIREFOX:
+            profile = webdriver.FirefoxProfile()
+            profile.set_preference('extensions.webextensions.uuids',
+                                   '{"%s": "%s"}' % (FF_EXT_ID, FF_UUID))
 
-def start_driver_firefox(ext_path, browser_path):
-    """Start a new Selenium web driver and install the bundled extension."""
-    profile = webdriver.FirefoxProfile()
-    profile.set_preference('extensions.webextensions.uuids',
-                           '{"%s": "%s"}' % (FF_EXT_ID, FF_UUID))
+            # this is kind of a hack; eventually the functionality to install an
+            # extension should be part of Selenium. See
+            # https://github.com/SeleniumHQ/selenium/issues/4215
+            self.driver = webdriver.Firefox(firefox_profile=profile,
+                                            firefox_binary=self.firefox_path)
+            command = 'addonInstall'
+            info = ('POST', '/session/$sessionId/moz/addon/install')
+            self.driver.command_executor._commands[command] = info
+            self.driver.execute(command, params={'path': self.ext_path,
+                                                 'temporary': True})
+            time.sleep(2)
 
-    # this is kind of a hack; eventually the functionality to install an
-    # extension should be part of Selenium. See
-    # https://github.com/SeleniumHQ/selenium/issues/4215
-    driver = webdriver.Firefox(firefox_profile=profile, firefox_binary=browser_path)
-    command = 'addonInstall'
-    driver.command_executor._commands[command] = ('POST', '/session/$sessionId/moz/addon/install')
-    driver.execute(command, params={'path': ext_path, 'temporary': True})
-    time.sleep(2)
-    return driver
+        else:
+            raise ValueError("%s is not a valid browser" % self.browser)
 
+        # apply timeout settings
+        self.driver.set_page_load_timeout(self.timeout)
+        self.driver.set_script_timeout(self.timeout)
 
-def load_extension_page(driver, browser, ext_path, page, retries=3):
-    """
-    Load a page in the Privacy Badger extension. `page` should either be
-    BACKGROUND or OPTIONS.
-    """
-    if browser == CHROME:
-        ext_url = (CHROME_URL_FMT + page) % get_chrome_extension_id(ext_path)
-    else:
-        ext_url = (FF_URL_FMT + page) % FF_UUID
+    def load_extension_page(self, page, retries=3):
+        """
+        Load a page in the Privacy Badger extension. `page` should either be
+        BACKGROUND or OPTIONS.
+        """
+        if self.browser == CHROME:
+            ext_url = (CHROME_URL_FMT + page) % get_chrome_extension_id(ext_path)
+        else:
+            ext_url = (FF_URL_FMT + page) % FF_UUID
 
-    for _ in range(retries):
-        try:
-            driver.get(ext_url)
-            break
-        except WebDriverException as e:
-            err = e
-    else:
-        logger.error('Error loading extension page: %s', err.msg)
-        raise err
+        for _ in range(retries):
+            try:
+                self.driver.get(ext_url)
+                break
+            except WebDriverException as e:
+                err = e
+        else:
+            logger.error('Error loading extension page: %s', err.msg)
+            raise err
 
-
-def clear_user_data(driver, browser, ext_path):
-    load_extension_page(driver, browser, ext_path, OPTIONS)
-    script = 'chrome.runtime.sendMessage({type: "removeAllData"});'
-    driver.execute_script(script)
-
-
-def load_user_data(driver, browser, ext_path, data):
-    load_extension_page(driver, browser, ext_path, OPTIONS)
-    script = '''
+    def load_user_data(self, data):
+        """Load saved user data into Privacy Badger after a restart"""
+        self.load_extension_page(OPTIONS)
+        script = '''
 data = JSON.parse(arguments[0]);
 badger.storage.action_map.merge(data.action_map);
 for (let tracker in data.snitch_map) {
     badger.storage.snitch_map._store[tracker] = data.snitch_map[tracker];
 }'''
-    driver.execute_script(script, json.dumps(data))
-    time.sleep(2)   # wait for localstorage to sync
+        self.driver.execute_script(script, json.dumps(data))
+        time.sleep(2)   # wait for localstorage to sync
 
+    def dump_data(self):
+        """Extract the objects Privacy Badger learned during its training run."""
+        self.load_extension_page(BACKGROUND)
 
-def dump_data(driver, browser, ext_path):
-    """Extract the objects Privacy Badger learned during its training run."""
-    load_extension_page(driver, browser, ext_path, BACKGROUND)
+        data = {}
+        for obj in OBJECTS:
+            script = 'return badger.storage.%s.getItemClones()' % obj
+            data[obj] = self.driver.execute_script(script)
+        return data
 
-    data = {}
-    for obj in OBJECTS:
-        script = 'return badger.storage.%s.getItemClones()' % obj
-        data[obj] = driver.execute_script(script)
-    return data
+    def timeout_workaround(self):
+        """
+        Selenium has a bug where a tab that raises a timeout exception can't
+        recover gracefully. So we kill the tab and make a new one.
+        TODO: find actual bug ticket
+        """
+        self.driver.close()  # kill the broken site
+        self.driver.switch_to_window(driver.window_handles.pop())
+        before = set(self.driver.window_handles)
+        self.driver.execute_script('window.open()')
 
-def clear_data(driver, browser, ext_path):
-    """Clear the training data Privacy Badger starts with."""
-    load_extension_page(driver, browser, ext_path, OPTIONS)
-    driver.execute_script("badger.storage.clearTrackerData();")
+        new_window = (set(self.driver.window_handles) ^ before).pop()
+        self.driver.switch_to_window(new_window)
 
-def timeout_workaround(driver):
-    """
-    Selenium has a bug where a tab that raises a timeout exception can't
-    recover gracefully. So we kill the tab and make a new one.
-    TODO: find actual bug ticket
-    """
-    driver.close()  # kill the broken site
-    driver.switch_to_window(driver.window_handles.pop())
-    before = set(driver.window_handles)
-    driver.execute_script('window.open()')
-    driver.switch_to_window((set(driver.window_handles) ^ before).pop())
+    def get_domain(self, domain):
+        """
+        Try to load a domain over https, and fall back to http if the initial load
+        times out. Then sleep `wait_time` seconds on the site to wait for AJAX calls
+        to complete.
+        """
+        try:
+            url = "https://%s/" % domain
+            self.driver.get(url)
+        except TimeoutException:
+            logger.info('timeout on %s ', url)
+            self.timeout_workaround()
+            url = "http://%s/" % domain
+            logger.info('trying %s', url)
+            self.driver.get(url)
 
+        time.sleep(self.wait_time)
+        return url
 
-def get_domain(driver, domain, wait_time):
-    """
-    Try to load a domain over https, and fall back to http if the initial load
-    times out. Then sleep `wait_time` seconds on the site to wait for AJAX calls
-    to complete.
-    """
-    try:
-        url = "https://%s/" % domain
-        driver.get(url)
-    except TimeoutException:
-        logger.info('timeout on %s ', url)
-        timeout_workaround(driver)
-        url = "http://%s/" % domain
-        logger.info('trying %s', url)
-        driver.get(url)
-
-    time.sleep(wait_time)
-    return url
-
-
-def crawl(browser, out_path, ext_path, chromedriver_path, firefox_path, n_sites,
-          timeout, wait_time, **kwargs):
-    """
-    Visit the top `n_sites` websites in the Majestic Million, in order, in a
-    virtual browser with Privacy Badger installed. Afterwards, save the
-    action_map and snitch_map that the Badger learned.
-    """
-    domains = get_domain_list(n_sites, out_path)
-    logger.info('starting new crawl with timeout %s n_sites %s',
-                timeout, n_sites)
-
-    # create an XVFB virtual display (to avoid opening an actual browser)
-    vdisplay = Xvfb(width=1280, height=720)
-    vdisplay.start()
-
-    if browser == CHROME:
-        driver = start_driver_chrome(ext_path, chromedriver_path)
-    else:
-        driver = start_driver_firefox(ext_path, firefox_path)
-
-    driver.set_page_load_timeout(timeout)
-    driver.set_script_timeout(timeout)
-    clear_data(driver, browser, ext_path)
-
-    def restart_browser(data):
+    def restart_browser(self, data):
         logger.info('restarting browser...')
+
         for _ in range(RESTART_RETRIES):
             try:
-                driver = start_driver_firefox(ext_path, firefox_path)
-                load_user_data(driver, browser, ext_path, data)
+                self.driver.quit()
+                self.start_driver()
+                self.load_user_data(data)
             except Exception as e:
                 logger.error('Error restarting browser. Trying again...')
                 logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
         else:
             logger.error('Could not restart browser.')
 
-        return driver
-
     # determine whether we need to restart the webdriver after an error
-    def should_restart(e):
+    def should_restart(self, e):
         return (type(e) == NoSuchWindowException or
             type(e) == SessionNotCreatedException or
             'response from marionette' in e.msg)
 
-    # list of domains we actually visited
-    visited = []
+    def crawl(self):
+        """
+        Visit the top `n_sites` websites in the Majestic Million, in order, in a
+        virtual browser with Privacy Badger installed. Afterwards, save the
+        action_map and snitch_map that the Badger learned.
+        """
+        domains = get_domain_list(self.n_sites, self.out_path)
+        logger.info('starting new crawl with timeout %s n_sites %s',
+                    self.timeout, self.n_sites)
 
-    for i, domain in enumerate(domains):
-        logger.info('visiting %d: %s', i + 1, domain)
+        # create an XVFB virtual display (to avoid opening an actual browser)
+        self.vdisplay = Xvfb(width=1280, height=720)
+        self.vdisplay.start()
+        self.start_driver()
+
+        # list of domains we actually visited
+        visited = []
+
+        for i, domain in enumerate(domains):
+            logger.info('visiting %d: %s', i + 1, domain)
+
+            try:
+                # If we can't load the options page for some reason, treat it like
+                # any other failure.
+                last_data = self.dump_data()
+                url = self.get_domain(domain)
+                visited.append(url)
+            except TimeoutException:
+                logger.info('timeout on %s ', domain)
+                # TODO: how to get rid of this nested try?
+                try:
+                    self.timeout_workaround()
+                except WebDriverException as e:
+                    if self.should_restart(e):
+                        self.restart_browser(last_data)
+            except WebDriverException as e:
+                logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
+                if self.should_restart(e):
+                    self.restart_browser(last_data)
+
+        logger.info('Finished scan. Visited %d sites and errored on %d.',
+                    len(visited), len(domains) - len(visited))
 
         try:
-            # This script could fail during the data dump (trying to get the
-            # options page), the data cleaning, or while trying to load the next
-            # domain.
-            last_data = dump_data(driver, browser, ext_path)
+            logger.info('Getting data from browser storage...')
+            data = self.dump_data()
+        except WebDriverException:
+            # If we can't load the background page here, just quit :(
+            logger.error('Could not get badger storage.')
+            sys.exit(1)
 
-            # try to fix misattribution errors
-            if i >= 2:
-                clean_data = cleanup(domains[i-2], domains[i-1], last_data)
-                if last_data != clean_data:
-                    clear_user_data(driver, browser, ext_path)
-                    load_user_data(driver, browser, ext_path, clean_data)
+        self.driver.quit()
+        self.vdisplay.stop()
 
-            url = get_domain(driver, domain, wait_time)
-            visited.append(url)
-        except TimeoutException:
-            logger.info('timeout on %s ', domain)
-            # TODO: how to get rid of this nested try?
-            try:
-                timeout_workaround(driver)
-            except WebDriverException as e:
-                if should_restart(e):
-                    driver = restart_browser(last_data)
-        except WebDriverException as e:
-            logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
-            if should_restart(e):
-                driver = restart_browser(last_data)
+        logger.info('Cleaning data...')
+        self.cleanup(domains, data)
+        return data
 
-    logger.info('Finished scan. Visited %d sites and errored on %d.',
-                len(visited), len(domains) - len(visited))
-    logger.info('Getting data from browser storage...')
-    # If we can't load the background page here, there's a serious problem
-    try:
-        data = dump_data(driver, browser, ext_path)
-    except WebDriverException:
-        logger.error('Could not get badger storage.')
-        sys.exit(1)
-    driver.quit()
-    vdisplay.stop()
+    def cleanup(self, domains, data):
+        """
+        Remove from snitch map any domains that appear to have been added as a
+        result of bugs.
+        """
+        snitch_map = data['snitch_map']
+        action_map = data['action_map']
 
-    logger.info('Cleaning data...')
-    return data
+        # handle blank domain bug
+        if '' in action_map:
+            logger.info('Deleting blank domain from action map')
+            del action_map['']
 
+        if '' in snitch_map:
+            logger.info('Deleting blank domain from snitch map')
+            del snitch_map['']
 
-def cleanup(d1, d2, data):
-    """
-    Remove from snitch map any domains that appear to have been added as a
-    result of bugs.
-    """
-    new_data = copy.deepcopy(data)
-    snitch_map = new_data['snitch_map']
-    action_map = new_data['action_map']
+        # handle the domain-attribution bug (Privacy Badger issue #1997).
+        for i in range(len(domains) - 1):
+            d1, d2 = domains[i:i+2]
 
-    # handle blank domain bug
-    if '' in action_map:
-        logger.info('Deleting blank domain from action map')
-        del action_map['']
+            # If a domain we visited was recorded as a tracker on the domain we
+            # visited immediately after it, it's probably a bug
+            if d1 in snitch_map and d2 in snitch_map[d1]:
+                logger.info('Reported domain %s tracking on %s', d1, d2)
+                snitch_map[d1].remove(d2)
 
-    if '' in snitch_map:
-        logger.info('Deleting blank domain from snitch map')
-        del snitch_map['']
+                # if the bug caused d1 to be added to the action map, remove it
+                if not snitch_map[d1]:
+                    logger.info('Deleting domain %s from action and snitch maps',
+                                d1)
+                    del action_map[d1]
+                    del snitch_map[d1]
 
-    extract = TLDExtract()
-    d1_base = extract(d1).registered_domain
-
-    # handle the domain-attribution bug (Privacy Badger issue #1997).
-    # If a domain we visited was recorded as a tracker on the domain we
-    # visited immediately after it, it's probably a bug
-    if d1_base in snitch_map and d2 in snitch_map[d1_base]:
-        logger.info('Reported domain %s tracking on %s', d1_base, d2)
-        snitch_map[d1_base].remove(d2)
-
-        # if the bug caused d1 to be added to the action map, remove it
-        if not snitch_map[d1_base]:
-            logger.info('Deleting domain %s from action & snitch maps', d1_base)
-            if d1 in action_map:
-                del action_map[d1]
-            if d1_base in action_map:
-                del action_map[d1_base]
-            del snitch_map[d1_base]
-
-        # if the bug caused d1 to be blocked, unblock it
-        elif len(snitch_map[d1_base]) == 2:
-            if d1 in action_map:
-                logger.info('Downgrading domain %s from "block" to "allow"', d1)
-                action_map[d1]['heuristicAction'] = 'allow'
-            if d1_base in action_map:
-                logger.info('Downgrading domain %s from "block" to "allow"',
-                            d1_base)
-                action_map[d1_base]['heuristicAction'] = 'allow'
-
-    return new_data
+                # if the bug caused d1 to be blocked, unblock it
+                elif len(snitch_map[d1]) == 2:
+                    logger.info('Downgrading domain %s from "block" to "allow"',
+                                d1)
+                    action_map[d1]['heuristicAction'] = 'allow'
 
 
 if __name__ == '__main__':
@@ -426,7 +408,8 @@ if __name__ == '__main__':
     version = time.strftime('%Y.%-m.%-d', time.localtime())
 
     # the argparse arguments must match the function signature of crawl()
-    results = crawl(**vars(args))
+    crawler = Crawler(**vars(args))
+    results = crawler.crawl()
     results['version'] = version
 
     logger.info('Saving seed data version %s...', version)

--- a/crawler.py
+++ b/crawler.py
@@ -17,7 +17,8 @@ from PyFunceble import test as PyFunceble
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException, WebDriverException,\
                                        NoSuchWindowException,\
-                                       SessionNotCreatedException
+                                       SessionNotCreatedException,\
+                                       JavascriptException
 from selenium.webdriver.chrome.options import Options
 from tldextract import TLDExtract
 from xvfbwrapper import Xvfb
@@ -38,6 +39,7 @@ FIREFOX = 'firefox'
 OBJECTS = ['action_map', 'snitch_map']
 MAJESTIC_URL = "http://downloads.majesticseo.com/majestic_million.csv"
 WEEK_IN_SECONDS = 604800
+RESTART_RETRIES = 5
 
 ap = argparse.ArgumentParser()
 ap.add_argument('--browser', choices=[FIREFOX, CHROME], default=FIREFOX,
@@ -283,11 +285,16 @@ def crawl(browser, out_path, ext_path, chromedriver_path, firefox_path, n_sites,
 
     def restart_browser(data):
         logger.info('restarting browser...')
-        driver = start_driver_firefox(ext_path, firefox_path)
-        driver.set_page_load_timeout(timeout)
-        driver.set_script_timeout(timeout)
-        clear_data(driver, browser, ext_path)
-        load_user_data(driver, browser, ext_path, data)
+        for _ in range(RESTART_RETRIES):
+            try:
+                driver = start_driver_firefox(ext_path, firefox_path)
+                load_user_data(driver, browser, ext_path, data)
+            except Exception as e:
+                logger.error('Error restarting browser. Trying again...')
+                logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
+        else:
+            logger.error('Could not restart browser.')
+
         return driver
 
     # determine whether we need to restart the webdriver after an error

--- a/crawler.py
+++ b/crawler.py
@@ -36,7 +36,6 @@ OPTIONS = 'skin/options.html'
 CHROME = 'chrome'
 FIREFOX = 'firefox'
 
-OBJECTS = ['action_map', 'snitch_map']
 MAJESTIC_URL = "http://downloads.majesticseo.com/majestic_million.csv"
 WEEK_IN_SECONDS = 604800
 RESTART_RETRIES = 5
@@ -52,6 +51,10 @@ ap.add_argument('--wait-time', type=float, default=5,
                 help='Amount of time to wait on each site after it loads, in seconds')
 ap.add_argument('--log-stdout', action='store_true', default=False,
                 help='If set, log to stdout as well as log.txt')
+ap.add_argument('--survey', action='store_true', default=False,
+                help="If set, don't block anything or store action_map data")
+ap.add_argument('--max-data-size', type=int, default=5e5,
+                help='Maximum size of serialized localstorage data')
 
 # Arguments below here should never have to be used within the docker container.
 ap.add_argument('--out-path', default='./',
@@ -143,6 +146,11 @@ def get_domain_list(n_sites, out_path):
 
     return domains
 
+def size_of(data):
+    """Get the size (in bytes) of the serialized data structure"""
+    return len(json.dumps(data))
+
+
 class Crawler(object):
     def __init__(self, browser, out_path, ext_path, chromedriver_path,
                  firefox_path, n_sites, timeout, wait_time, **kwargs):
@@ -154,6 +162,27 @@ class Crawler(object):
         self.n_sites = n_sites
         self.timeout = timeout
         self.wait_time = wait_time
+
+        # version is based on when the crawl started
+        self.version = time.strftime('%Y.%-m.%-d', time.localtime())
+
+        # set up logging
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.INFO)
+        log_fmt = logging.Formatter('%(asctime)s %(message)s')
+
+        # by default, just log to file
+        fh = logging.FileHandler(os.path.join(args.out_path, 'log.txt'))
+        fh.setFormatter(log_fmt)
+        self.logger.addHandler(fh)
+
+        # log to stdout if configured
+        if args.log_stdout:
+            sh = logging.StreamHandler(sys.stdout)
+            sh.setFormatter(log_fmt)
+            self.logger.addHandler(sh)
+
+        self.storage_objects = ['action_map', 'snitch_map']
 
     def start_driver(self):
         """Start a new Selenium web driver and install the bundled extension."""
@@ -208,19 +237,18 @@ class Crawler(object):
             except WebDriverException as e:
                 err = e
         else:
-            logger.error('Error loading extension page: %s', err.msg)
+            self.logger.error('Error loading extension page: %s', err.msg)
             raise err
 
     def load_user_data(self, data):
         """Load saved user data into Privacy Badger after a restart"""
         self.load_extension_page(OPTIONS)
-        script = '''
+        for obj in OBJECTS:
+            script = '''
 data = JSON.parse(arguments[0]);
-badger.storage.action_map.merge(data.action_map);
-for (let tracker in data.snitch_map) {
-    badger.storage.snitch_map._store[tracker] = data.snitch_map[tracker];
-}'''
-        self.driver.execute_script(script, json.dumps(data))
+badger.storage.%s.merge(data.%s);''' % (obj, obj)
+            self.driver.execute_script(script, json.dumps(data))
+
         time.sleep(2)   # wait for localstorage to sync
 
     def dump_data(self):
@@ -232,6 +260,11 @@ for (let tracker in data.snitch_map) {
             script = 'return badger.storage.%s.getItemClones()' % obj
             data[obj] = self.driver.execute_script(script)
         return data
+
+    def clear_data(self):
+        """Clear the training data Privacy Badger starts with."""
+        self.load_extension_page(OPTIONS)
+        self.js("badger.storage.clearTrackerData();")
 
     def timeout_workaround(self):
         """
@@ -257,17 +290,17 @@ for (let tracker in data.snitch_map) {
             url = "https://%s/" % domain
             self.driver.get(url)
         except TimeoutException:
-            logger.info('timeout on %s ', url)
+            self.logger.info('timeout on %s ', url)
             self.timeout_workaround()
             url = "http://%s/" % domain
-            logger.info('trying %s', url)
+            self.logger.info('trying %s', url)
             self.driver.get(url)
 
         time.sleep(self.wait_time)
         return url
 
     def restart_browser(self, data):
-        logger.info('restarting browser...')
+        self.logger.info('restarting browser...')
 
         for _ in range(RESTART_RETRIES):
             try:
@@ -275,10 +308,10 @@ for (let tracker in data.snitch_map) {
                 self.start_driver()
                 self.load_user_data(data)
             except Exception as e:
-                logger.error('Error restarting browser. Trying again...')
-                logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
+                self.logger.error('Error restarting browser. Trying again...')
+                self.logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
         else:
-            logger.error('Could not restart browser.')
+            self.logger.error('Could not restart browser.')
 
     # determine whether we need to restart the webdriver after an error
     def should_restart(self, e):
@@ -293,8 +326,8 @@ for (let tracker in data.snitch_map) {
         action_map and snitch_map that the Badger learned.
         """
         domains = get_domain_list(self.n_sites, self.out_path)
-        logger.info('starting new crawl with timeout %s n_sites %s',
-                    self.timeout, self.n_sites)
+        self.logger.info('starting new crawl with timeout %s n_sites %s',
+                         self.timeout, self.n_sites)
 
         # create an XVFB virtual display (to avoid opening an actual browser)
         self.vdisplay = Xvfb(width=1280, height=720)
@@ -305,16 +338,13 @@ for (let tracker in data.snitch_map) {
         visited = []
 
         for i, domain in enumerate(domains):
-            logger.info('visiting %d: %s', i + 1, domain)
-
             try:
-                # If we can't load the options page for some reason, treat it like
-                # any other failure.
                 last_data = self.dump_data()
+                self.logger.info('visiting %d: %s', i + 1, domain)
                 url = self.get_domain(domain)
                 visited.append(url)
             except TimeoutException:
-                logger.info('timeout on %s ', domain)
+                self.logger.info('timeout on %s ', domain)
                 # TODO: how to get rid of this nested try?
                 try:
                     self.timeout_workaround()
@@ -322,43 +352,44 @@ for (let tracker in data.snitch_map) {
                     if self.should_restart(e):
                         self.restart_browser(last_data)
             except WebDriverException as e:
-                logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
+                self.logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
                 if self.should_restart(e):
                     self.restart_browser(last_data)
 
-        logger.info('Finished scan. Visited %d sites and errored on %d.',
+        self.logger.info('Finished scan. Visited %d sites and errored on %d.',
                     len(visited), len(domains) - len(visited))
 
         try:
-            logger.info('Getting data from browser storage...')
+            self.logger.info('Getting data from browser storage...')
             data = self.dump_data()
         except WebDriverException:
             # If we can't load the background page here, just quit :(
-            logger.error('Could not get badger storage.')
+            self.logger.error('Could not get badger storage.')
             sys.exit(1)
 
         self.driver.quit()
         self.vdisplay.stop()
 
-        logger.info('Cleaning data...')
         self.cleanup(domains, data)
-        return data
+        self.save(self.merge_saved_data())
 
     def cleanup(self, domains, data):
         """
         Remove from snitch map any domains that appear to have been added as a
         result of bugs.
         """
+        self.logger.info('Cleaning data...')
+
         snitch_map = data['snitch_map']
         action_map = data['action_map']
 
         # handle blank domain bug
         if '' in action_map:
-            logger.info('Deleting blank domain from action map')
+            self.logger.info('Deleting blank domain from action map')
             del action_map['']
 
         if '' in snitch_map:
-            logger.info('Deleting blank domain from snitch map')
+            self.logger.info('Deleting blank domain from snitch map')
             del snitch_map['']
 
         # handle the domain-attribution bug (Privacy Badger issue #1997).
@@ -368,55 +399,153 @@ for (let tracker in data.snitch_map) {
             # If a domain we visited was recorded as a tracker on the domain we
             # visited immediately after it, it's probably a bug
             if d1 in snitch_map and d2 in snitch_map[d1]:
-                logger.info('Reported domain %s tracking on %s', d1, d2)
+                self.logger.info('Reported domain %s tracking on %s', d1, d2)
                 snitch_map[d1].remove(d2)
 
                 # if the bug caused d1 to be added to the action map, remove it
                 if not snitch_map[d1]:
-                    logger.info('Deleting domain %s from action and snitch maps',
+                    self.logger.info('Deleting domain %s from action and snitch maps',
                                 d1)
                     del action_map[d1]
                     del snitch_map[d1]
 
                 # if the bug caused d1 to be blocked, unblock it
                 elif len(snitch_map[d1]) == 2:
-                    logger.info('Downgrading domain %s from "block" to "allow"',
+                    self.logger.info('Downgrading domain %s from "block" to "allow"',
                                 d1)
                     action_map[d1]['heuristicAction'] = 'allow'
 
+    def save(self, data, name='results.json'):
+        data['version'] = self.version
+
+        self.logger.info('Saving seed data version %s...', self.version)
+        # save the snitch_map in a human-readable JSON file
+        with open(os.path.join(self.out_path, name), 'w') as f:
+            json.dump(data, f, indent=2, sort_keys=True, separators=(',', ': '))
+        self.logger.info('Saved data to %s.', name)
+
+
+class SurveyCrawler(Crawler):
+    def __init__(self, **kwargs):
+        super(SurveyCrawler, self).__init__(**kwargs)
+
+        self.max_data_size = kwargs.get('max_data_size')
+        self.storage_objects = ['snitch_map']
+
+    def set_passive_mode(self):
+        self.load_extension_page(OPTIONS)
+        script = '''
+chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: { passiveMode: true }
+});'''
+        self.driver.execute_script(script)
+
+    def merge_saved_data(self):
+        paths = glob.glob(os.path.join(self.out_path, 'results-*.json'))
+        snitch_map = {}
+        for p in paths:
+            with open(p) as f:
+                sm = json.load(f)['snitch_map']
+            for tracker, snitches in sm.items():
+                if tracker not in snitch_map:
+                    snitch_map[tracker] = snitches
+                    continue
+
+                for snitch, data in snitches.items():
+                    if snitch == 'length':
+                        snitch_map[tracker]['length'] = \
+                            int(snitch_map[tracker]['length']) + int(data)
+                        continue
+                    snitch_map[tracker][snitch] = data
+
+        return {'version': self.version, 'snitch_map': snitch_map}
+
+    def crawl():
+        """
+        Visit the top `n_sites` websites in the Majestic Million, in order, in a
+        virtual browser with Privacy Badger installed. Afterwards, save the
+        and snitch_map that the Badger learned.
+        """
+        domains = get_domain_list(n_sites, self.out_path)
+        self.logger.info('starting new crawl with timeout %s n_sites %s',
+                         timeout, n_sites)
+
+        # create an XVFB virtual display (to avoid opening an actual browser)
+        self.vdisplay = Xvfb(width=1280, height=720)
+        self.vdisplay.start()
+        self.start_driver()
+
+        # don't block anything, just listen and log
+        self.set_passive_mode()
+
+        # list of domains we actually visited
+        visited = []
+        last_data = None
+        first_i = 0
+
+        for i, domain in enumerate(domains):
+            # If we can't load the options page for some reason, treat it like
+            # any other error
+            try:
+                # save the state of privacy badger before we do anything else
+                last_data = self.dump_data()
+
+                # If the localstorage data is getting too big, dump it and restart
+                if size_of(last_data) > self.max_data_size:
+                    self.save(last_data, 'results-%d-%d.json' % (first_i, i))
+                    first_i = i + 1
+                    last_data = {}
+                    driver = self.restart_browser(last_data)
+
+                self.logger.info('visiting %d: %s', i + 1, domain)
+                url = self.get_domain(domain)
+                visited.append(url)
+            except TimeoutException:
+                self.logger.info('timeout on %s ', domain)
+                # TODO: how to get rid of this nested try?
+                try:
+                    self.timeout_workaround()
+                except WebDriverException as e:
+                    if self.should_restart(e):
+                        self.restart_browser(last_data)
+            except WebDriverException as e:
+                self.logger.error('%s %s: %s', domain, type(e).__name__, e.msg)
+                if self.should_restart(e):
+                    self.restart_browser(last_data)
+            except KeyboardInterrupt:
+                self.logger.warn('Keyboard interrupt. Ending scan after %d sites.', i+1)
+                break
+
+        self.logger.info('Finished scan. Visited %d sites and errored on %d.',
+                    len(visited), i + 1 - len(visited))
+        self.logger.info('Getting data from browser storage...')
+
+        try:
+            self.logger.info('Getting data from browser storage...')
+            data = self.dump_data()
+        except WebDriverException:
+            if last_data:
+                self.logger.error('Could not get badger storage. Using cached data...')
+                data = last_data
+            else:
+                self.logger.error('Could not export data. Exiting.')
+                sys.exit(1)
+
+        self.driver.quit()
+        self.vdisplay.stop()
+
+        self.save(data, 'results-%d-%d.json' % (first_i, i))
+        self.save(self.merge_saved_data())
+
 
 if __name__ == '__main__':
+    # the argparse arguments must match the function signature of crawl()
     args = ap.parse_args()
 
-    # set up logging
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
-    log_fmt = logging.Formatter('%(asctime)s %(message)s')
+    if args.survey:
+        crawler = SurveyCrawler(**vars(ap.parse_args()))
+    else:
+        crawler = Crawler(**vars(ap.parse_args()))
 
-    # by default, just log to file
-    fh = logging.FileHandler(os.path.join(args.out_path, 'log.txt'))
-    fh.setFormatter(log_fmt)
-    logger.addHandler(fh)
-
-    # log to stdout if configured
-    if args.log_stdout:
-        sh = logging.StreamHandler(sys.stdout)
-        sh.setFormatter(log_fmt)
-        logger.addHandler(sh)
-
-    # version is based on when the crawl started
-    version = time.strftime('%Y.%-m.%-d', time.localtime())
-
-    # the argparse arguments must match the function signature of crawl()
-    crawler = Crawler(**vars(args))
-    results = crawler.crawl()
-    results['version'] = version
-
-    logger.info('Saving seed data version %s...', version)
-    # save the action_map and snitch_map in a human-readable JSON file
-    with open(os.path.join(args.out_path, 'results.json'), 'w') as f:
-        json.dump(results, f, indent=2, sort_keys=True, separators=(',', ': '))
-    logger.info('Saved data to results.json.')
-
-else:
-    logger = logging.getLogger()
+    crawler.crawl()

--- a/results-prev.json
+++ b/results-prev.json
@@ -1,15 +1,9 @@
 {
   "action_map": {
-    "006-lrt-285.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537548340548,
-      "userAction": ""
-    },
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537512812427,
+      "nextUpdateTime": 1537523787722,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -24,52 +18,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "126.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "127.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "142-uel-347.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537683173653,
-      "userAction": ""
-    },
-    "15gifts.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "161-oln-990.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537658833719,
-      "userAction": ""
-    },
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537469924908,
-      "userAction": ""
-    },
-    "1996823.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537637386452,
+      "nextUpdateTime": 1537882843856,
       "userAction": ""
     },
     "1dmp.io": {
@@ -78,153 +36,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "1rx.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "20508497p.rfihub.com": {
+    "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537720947508,
-      "userAction": ""
-    },
-    "20587159p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537456617984,
-      "userAction": ""
-    },
-    "20761665p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537648906254,
-      "userAction": ""
-    },
-    "20761668p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537350129267,
-      "userAction": ""
-    },
-    "23video.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "243-mrr-459.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537353375375,
-      "userAction": ""
-    },
-    "247-inc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537605774759,
       "userAction": ""
     },
     "247realmedia.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "2677521.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537363566866,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537817946504,
+      "nextUpdateTime": 1537672087946,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537671899857,
+      "nextUpdateTime": 1537759773496,
       "userAction": ""
     },
-    "2mdnsys.com": {
+    "2ecd5.v.fwmrm.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537525630119,
       "userAction": ""
     },
     "2o7.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "33across.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360buyimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360yield.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "3733772.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799649153,
-      "userAction": ""
-    },
-    "3738527.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537344114258,
-      "userAction": ""
-    },
-    "3797690.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537703536553,
-      "userAction": ""
-    },
-    "3822063.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537536558450,
-      "userAction": ""
-    },
-    "3944448.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537766944179,
-      "userAction": ""
-    },
-    "3gimg.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537731756159,
-      "userAction": ""
-    },
-    "3gl.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -234,658 +78,220 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "403-agf-920.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537682061664,
-      "userAction": ""
-    },
-    "407-oyz-482.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537742305462,
-      "userAction": ""
-    },
     "4139589.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537509066633,
-      "userAction": ""
-    },
-    "4197153.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537609661508,
+      "nextUpdateTime": 1537489663543,
       "userAction": ""
     },
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537589566422,
+      "nextUpdateTime": 1537839020503,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537715326020,
+      "nextUpdateTime": 1537806789164,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537358833819,
-      "userAction": ""
-    },
-    "4457720.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537662695124,
-      "userAction": ""
-    },
-    "4487060.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537817821234,
+      "nextUpdateTime": 1537550836808,
       "userAction": ""
     },
     "4488211.fls.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537705745832,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537634827185,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537794833428,
+      "nextUpdateTime": 1537660954849,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537746599771,
-      "userAction": ""
-    },
-    "4704202.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537692032102,
-      "userAction": ""
-    },
-    "4816425.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537495072294,
-      "userAction": ""
-    },
-    "4924464.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537527637386,
-      "userAction": ""
-    },
-    "4996523.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537490080716,
+      "nextUpdateTime": 1537616474930,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537837526567,
+      "nextUpdateTime": 1537903679851,
       "userAction": ""
     },
-    "4dsply.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "50bang.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "5285806.fls.doubleclick.net": {
+    "5035317.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537554533465,
+      "nextUpdateTime": 1537641921682,
       "userAction": ""
     },
-    "542-fmf-412.mktoresp.com": {
+    "516-dgm-318.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537446846449,
+      "nextUpdateTime": 1537562933555,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537531394162,
-      "userAction": ""
-    },
-    "5490350.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537716286714,
+      "nextUpdateTime": 1537758474854,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537603396226,
-      "userAction": ""
-    },
-    "5566805.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537391746396,
-      "userAction": ""
-    },
-    "5581089.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537673200750,
-      "userAction": ""
-    },
-    "5669311.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537396338150,
+      "nextUpdateTime": 1537647432807,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537508717765,
-      "userAction": ""
-    },
-    "58.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "5805365.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537745769620,
-      "userAction": ""
-    },
-    "58cdn.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "590-pcb-241.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537397348678,
-      "userAction": ""
-    },
-    "5945017.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537674501870,
-      "userAction": ""
-    },
-    "5p4rk13.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537658367928,
       "userAction": ""
     },
     "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537709581875,
-      "userAction": ""
-    },
-    "6127650.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537843512821,
-      "userAction": ""
-    },
-    "6249361.collect.igodigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537559175872,
-      "userAction": ""
-    },
-    "6261917.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537632916330,
-      "userAction": ""
-    },
-    "6279534.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537406872469,
-      "userAction": ""
-    },
-    "6284171.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537653596013,
-      "userAction": ""
-    },
-    "6321597.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537530082181,
-      "userAction": ""
-    },
-    "6357902.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537339251908,
-      "userAction": ""
-    },
-    "689-lnq-855.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537544339078,
+      "nextUpdateTime": 1537467654547,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537487211964,
+      "nextUpdateTime": 1537755076104,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537832279701,
-      "userAction": ""
-    },
-    "6sc.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "7226027.collect.igodigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537449068464,
-      "userAction": ""
-    },
-    "7eer.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "7grid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "8007189.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537515818970,
-      "userAction": ""
-    },
-    "8055587.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537699016358,
-      "userAction": ""
-    },
-    "8105471.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537476825261,
+      "nextUpdateTime": 1537709469941,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537833463322,
+      "nextUpdateTime": 1537696294907,
       "userAction": ""
     },
     "8136595.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537681626469,
-      "userAction": ""
-    },
-    "8166291.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537407075824,
-      "userAction": ""
-    },
-    "8178006.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537552716897,
+      "nextUpdateTime": 1537582726061,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537548563723,
+      "nextUpdateTime": 1537660816632,
       "userAction": ""
     },
     "8329645.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537788457428,
-      "userAction": ""
-    },
-    "8468614.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537431532692,
-      "userAction": ""
-    },
-    "8478693.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537803351518,
-      "userAction": ""
-    },
-    "867-slg-901.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537686010633,
-      "userAction": ""
-    },
-    "8720601.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537710724333,
+      "nextUpdateTime": 1537554078620,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537643919182,
-      "userAction": ""
-    },
-    "8763171.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537441009523,
+      "nextUpdateTime": 1537684895391,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537711282344,
-      "userAction": ""
-    },
-    "9nohczmy1mejzkr-hulu.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537762293523,
-      "userAction": ""
-    },
-    "a.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537717760680,
-      "userAction": ""
-    },
-    "a.cdn.intentmedia.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537453814885,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537837354591,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537691907466,
-      "userAction": ""
-    },
-    "a.quora.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537492208615,
+      "nextUpdateTime": 1537515526187,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537430226745,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537636809064,
+      "userAction": ""
+    },
+    "a.tribalfusion.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537958298176,
+      "userAction": ""
+    },
+    "a.volvelle.tech": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537841163145,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537385747747,
+      "nextUpdateTime": 1537476962673,
       "userAction": ""
     },
-    "a1.zassets.com": {
+    "a2.zassets.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537655349123,
-      "userAction": ""
-    },
-    "a1512971416.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537576263736,
-      "userAction": ""
-    },
-    "a152450673.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537382305881,
-      "userAction": ""
-    },
-    "a1625899514.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537618904135,
-      "userAction": ""
-    },
-    "a166211981.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537434135765,
-      "userAction": ""
-    },
-    "a1706490390.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537807275748,
-      "userAction": ""
-    },
-    "a2.adform.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537774357346,
-      "userAction": ""
-    },
-    "a22866392.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537712358686,
+      "nextUpdateTime": 1537619523629,
       "userAction": ""
     },
     "a2352870194.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537585756848,
+      "nextUpdateTime": 1537899708209,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537559119822,
-      "userAction": ""
-    },
-    "a255008327.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537596024936,
-      "userAction": ""
-    },
-    "a339552423.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537389935269,
-      "userAction": ""
-    },
-    "a3698060313.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537479287741,
-      "userAction": ""
-    },
-    "a539341702.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537620079697,
-      "userAction": ""
-    },
-    "a5763640713.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537832708970,
-      "userAction": ""
-    },
-    "a591102174.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537718172345,
-      "userAction": ""
-    },
-    "a6194150173.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537656867916,
+      "nextUpdateTime": 1537759103890,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537773332824,
-      "userAction": ""
-    },
-    "a6558036.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537847262065,
+      "nextUpdateTime": 1537776388617,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537499901385,
-      "userAction": ""
-    },
-    "a8169733917.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537459502836,
-      "userAction": ""
-    },
-    "a8270235338.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537746593721,
-      "userAction": ""
-    },
-    "a8306101470.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537657656962,
-      "userAction": ""
-    },
-    "a8447815042.cdn-pci.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537364932335,
-      "userAction": ""
-    },
-    "a8508271295.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537642659612,
+      "nextUpdateTime": 1537630083868,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537408551594,
-      "userAction": ""
-    },
-    "aamcftag.aamsitecertifier.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537450807509,
-      "userAction": ""
-    },
-    "aamsitecertifier.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537555408578,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537839824699,
-      "userAction": ""
-    },
-    "aax-fe-pek.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537663889767,
-      "userAction": ""
-    },
-    "aax-fe.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537405204759,
+      "nextUpdateTime": 1537905178162,
       "userAction": ""
     },
     "aax-us-east.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537549786658,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537913502506,
       "userAction": ""
     },
     "aax.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537750651320,
-      "userAction": ""
-    },
-    "aaxads.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "abmr.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ac.mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537475947542,
-      "userAction": ""
-    },
-    "accessatlanta.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537906291842,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -894,40 +300,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537485071286,
-      "userAction": ""
-    },
     "accounts.us1.gigya.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537388153056,
-      "userAction": ""
-    },
-    "accuweather.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537601074233,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537357348497,
-      "userAction": ""
-    },
-    "acint.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aclu.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537609459512,
+      "nextUpdateTime": 1537557514250,
       "userAction": ""
     },
     "acpm.fr": {
@@ -936,159 +318,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "acquia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "actionnetwork.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1534640190001,
-      "userAction": ""
-    },
-    "activate.tronc.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537629669298,
-      "userAction": ""
-    },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537569994972,
+      "nextUpdateTime": 1537770198983,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537748429496,
-      "userAction": ""
-    },
-    "acuityplatform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "acw.elsevier.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537800338896,
-      "userAction": ""
-    },
-    "acw.evise.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537619722005,
-      "userAction": ""
-    },
-    "acw.mendeley.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537506953414,
-      "userAction": ""
-    },
-    "acw.sciverse.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537374750795,
-      "userAction": ""
-    },
-    "acw.scopus.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537847968370,
-      "userAction": ""
-    },
-    "acxiomapac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-emea.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537797737731,
-      "userAction": ""
-    },
-    "ad-hatena.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-stir.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-survey.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad.360yield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537408813915,
-      "userAction": ""
-    },
-    "ad.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537680200878,
-      "userAction": ""
-    },
-    "ad.atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537350092973,
+      "nextUpdateTime": 1537767132056,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537473948289,
+      "nextUpdateTime": 1537485350920,
       "userAction": ""
     },
-    "ad.yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537816603609,
-      "userAction": ""
-    },
-    "adapf.com": {
+    "ad.wsod.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adaraanalytics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adc-srv.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adclear.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537516510407,
       "userAction": ""
     },
     "addroplet.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1098,63 +354,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "addtoany.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adentifi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adfox.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adfront.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adidas.fi": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adingo.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adition.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adjust-net.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1164,37 +366,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adlmerge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adm.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admaster.com.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "admiral.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537737157370,
-      "userAction": ""
-    },
     "admission.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "admixer.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1206,25 +384,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adobe.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adotmob.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adriver.ru": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1236,76 +396,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.adfox.ru": {
+    "ads.investingchannel.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537357908373,
-      "userAction": ""
-    },
-    "ads.pro-market.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537684129914,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537516218769,
       "userAction": ""
     },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537389382088,
-      "userAction": ""
-    },
-    "ads.revjet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537565267377,
+      "nextUpdateTime": 1537626134365,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537394000489,
+      "nextUpdateTime": 1537724241784,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537439693736,
-      "userAction": ""
-    },
-    "ads.supplyframe.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537595327510,
-      "userAction": ""
-    },
-    "ads.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537708667158,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537486989192,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537768700163,
-      "userAction": ""
-    },
-    "adscale.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537708083756,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537391897796,
+      "nextUpdateTime": 1537655918135,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537576375258,
+      "nextUpdateTime": 1537843092747,
       "userAction": ""
     },
     "adsnative.com": {
@@ -1314,19 +444,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsniper.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1338,49 +456,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtags.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adtdp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "advertising.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "advertur.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adwstats.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx.com.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx.ligadx.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537549251809,
-      "userAction": ""
-    },
-    "adx1.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1392,105 +468,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aetnd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "afilio.com.br": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aid-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "aidata.io": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aili.com": {
+    "aimfar.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537722347207,
       "userAction": ""
     },
     "aimfr.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537416952338,
-      "userAction": ""
-    },
-    "ajax.microsoft.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537389820736,
-      "userAction": ""
-    },
-    "ajx130.online": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537807566362,
       "userAction": ""
     },
     "akamaihd.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "akamaized.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "al-com.c.richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537824025575,
-      "userAction": ""
-    },
-    "albacross.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alibaba.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alicdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alipay.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aliyun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1500,33 +504,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "am15.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "amap.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "amazon.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "amazon.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1536,52 +516,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ameba.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537822274739,
+      "nextUpdateTime": 1537524155167,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537683031983,
+      "nextUpdateTime": 1537553863674,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537796602561,
+      "nextUpdateTime": 1537697793123,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537483109061,
-      "userAction": ""
-    },
-    "an.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537567391495,
-      "userAction": ""
-    },
-    "and.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "answcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537579018050,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -1590,100 +546,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "antdsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aol.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aol.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ap.lijit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537354259389,
-      "userAction": ""
-    },
-    "ap.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "apester.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537594235413,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537536216222,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537632246708,
       "userAction": ""
     },
-    "api-cache.adsnative.com": {
+    "api-iam.intercom.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537678263693,
+      "userAction": ""
+    },
+    "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537387503718,
+      "nextUpdateTime": 1537568296851,
+      "userAction": ""
+    },
+    "api.adsnative.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537621901239,
+      "userAction": ""
+    },
+    "api.bounceexchange.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537740805532,
       "userAction": ""
     },
     "api.circularhub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537628897822,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537919792740,
       "userAction": ""
     },
-    "api.company-target.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537710337667,
-      "userAction": ""
-    },
-    "api.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537446880423,
-      "userAction": ""
-    },
-    "api.nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537827775635,
-      "userAction": ""
-    },
-    "api.ooyala.com": {
+    "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537467277113,
       "userAction": ""
     },
-    "api.pinterest.com": {
+    "api.pymx5.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537709707264,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537525258759,
       "userAction": ""
     },
-    "api.share.baidu.com": {
+    "api.viglink.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537584342000,
-      "userAction": ""
-    },
-    "api.viafoura.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537618524506,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537628885397,
       "userAction": ""
     },
     "apis.google.com": {
@@ -1692,75 +612,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "apn.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "app-abd.marketo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537417456784,
-      "userAction": ""
-    },
-    "app-sj13.marketo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537351575196,
-      "userAction": ""
-    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537402274247,
-      "userAction": ""
-    },
-    "appdynamics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "apple.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aps.hearstnp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537348273382,
-      "userAction": ""
-    },
-    "aqtracker.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "arcgis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537815247633,
       "userAction": ""
     },
     "architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "areyouahuman.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "arrivalist.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1773,85 +633,31 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537711203141,
+      "nextUpdateTime": 1537452967901,
       "userAction": ""
     },
     "as.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537462879618,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537604250626,
       "userAction": ""
     },
-    "asos-media.com": {
+    "assets-gulfnews.sportz.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "asqliberation.nuggad.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537366165998,
+      "nextUpdateTime": 1537535218026,
       "userAction": ""
     },
     "assets.adobedtm.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537511031984,
-      "userAction": ""
-    },
-    "assets.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537360774849,
-      "userAction": ""
-    },
-    "assets.purch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537585623155,
-      "userAction": ""
-    },
-    "atdmt.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atemda.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atgsvcs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ati-host.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537685560379,
       "userAction": ""
     },
     "atlasobscura-travel.t.domdex.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537839940035,
-      "userAction": ""
-    },
-    "att.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "att.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537662181737,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537769347318,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -1860,82 +666,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "au.pixel.newscgp.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537470177567,
+      "userAction": ""
+    },
     "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537626578277,
+      "nextUpdateTime": 1537753859069,
       "userAction": ""
     },
-    "audtd.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "auth.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "autoimg.cn": {
+    "avn.innity.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "automatad-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537702492844,
-      "userAction": ""
-    },
-    "automate.linksynergy.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537553465360,
-      "userAction": ""
-    },
-    "autopilothq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537492777061,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537640730401,
+      "nextUpdateTime": 1537781953417,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537634606423,
-      "userAction": ""
-    },
-    "b.travelsmarter.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537369995993,
-      "userAction": ""
-    },
-    "b1img.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537708713404,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537664158936,
-      "userAction": ""
-    },
-    "b92.yahoo.co.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537836035197,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537850537520,
       "userAction": ""
     },
     "baidu.com": {
@@ -1944,115 +708,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bam-x.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537368223796,
-      "userAction": ""
-    },
-    "bankofamerica.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537713625332,
-      "userAction": ""
-    },
-    "banners.adfox.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537389677820,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537861157001,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537658756967,
-      "userAction": ""
-    },
-    "bazaarvoice.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbb.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbbpromos.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbc.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbelements.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbnaut.ibillboard.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537583047454,
-      "userAction": ""
-    },
-    "bdimg.share.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537518457949,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537750898790,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537453696417,
+      "nextUpdateTime": 1537689859400,
       "userAction": ""
     },
     "beacon.sojern.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537351338433,
-      "userAction": ""
-    },
-    "beatport.com": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "beemray.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537672342487,
       "userAction": ""
     },
     "beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "benchtag2.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "betweendigital.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2064,46 +744,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bfmtv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537743191714,
+      "nextUpdateTime": 1537876030242,
       "userAction": ""
     },
     "bid.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537485219379,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537727034118,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537454966821,
-      "userAction": ""
-    },
-    "bid.pubmatic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537420038605,
+      "nextUpdateTime": 1537674443840,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537777635830,
-      "userAction": ""
-    },
-    "biddingx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537764450557,
       "userAction": ""
     },
     "bidr.io": {
@@ -2118,43 +780,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bigmining.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bigmir.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bing.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bitbucket.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bizible.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizibly.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizographics.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2169,49 +801,7 @@
     "block.lp1block.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537721253872,
-      "userAction": ""
-    },
-    "blogos.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bloomberg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluecava.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluemix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluetoad.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bnidx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537539284902,
       "userAction": ""
     },
     "boldchat.com": {
@@ -2232,33 +822,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boston.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "botradar.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "boudja.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537428775083,
-      "userAction": ""
-    },
-    "brandcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2268,148 +834,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "brightcove.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "brightcove.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "britishairways.d3.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537602895824,
-      "userAction": ""
-    },
     "bs.serving-sys.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537517245137,
-      "userAction": ""
-    },
-    "bs.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537743938498,
-      "userAction": ""
-    },
-    "bshare.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bshare.optimix.asia": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537808364788,
-      "userAction": ""
-    },
-    "btlr.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537742361328,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537847715087,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537780849982,
-      "userAction": ""
-    },
-    "btttag.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bumlam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "by2.uservoice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537787778393,
-      "userAction": ""
-    },
-    "c-ctrip.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537560032812,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537814472450,
+      "nextUpdateTime": 1537515889831,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537370818420,
+      "nextUpdateTime": 1537837415606,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799245245,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537858571539,
       "userAction": ""
     },
-    "c.jsrdn.com": {
+    "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537607263518,
+      "nextUpdateTime": 1537866121849,
       "userAction": ""
     },
-    "c.lytics.io": {
+    "c.pub.network": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537746982561,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537906295980,
       "userAction": ""
     },
-    "c.ooyala.com": {
+    "c.statcounter.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537569480916,
       "userAction": ""
     },
-    "c.wrating.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537663807794,
+    "c1.neweggimages.com": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537830208904,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537413098915,
-      "userAction": ""
-    },
-    "c212.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "c3tag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cadreon.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537459132298,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -2418,34 +900,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "candlewoodsuites.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537539107890,
-      "userAction": ""
-    },
-    "capturehighered.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "carambo.la": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537860188041,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -2454,298 +912,118 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cbjs.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537661615895,
-      "userAction": ""
-    },
-    "cbsi.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cbsi.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537444877106,
-      "userAction": ""
-    },
-    "cbsistatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ccgateway.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-akamai.mookie1.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537652233092,
-      "userAction": ""
-    },
-    "cdn-apple.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537601985432,
-      "userAction": ""
-    },
-    "cdn-hotels.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-net.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537952708382,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537558834169,
-      "userAction": ""
-    },
-    "cdn.blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537632838572,
-      "userAction": ""
-    },
-    "cdn.cohesionapps.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537836595484,
-      "userAction": ""
-    },
-    "cdn.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537777026674,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537894424784,
       "userAction": ""
     },
     "cdn.conversant.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537577177929,
+      "nextUpdateTime": 1537839731513,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537371948545,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537882453116,
       "userAction": ""
     },
     "cdn.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537462294395,
+      "nextUpdateTime": 1537652824451,
       "userAction": ""
     },
     "cdn.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537454028682,
-      "userAction": ""
-    },
-    "cdn.engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537740949535,
-      "userAction": ""
-    },
-    "cdn.flipboard.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537458192392,
-      "userAction": ""
-    },
-    "cdn.hypemarks.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537784587282,
-      "userAction": ""
-    },
-    "cdn.justuno.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537775449393,
+      "nextUpdateTime": 1537702491205,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537717430858,
-      "userAction": ""
-    },
-    "cdn.mg2connext.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537715526965,
-      "userAction": ""
-    },
-    "cdn.nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537361741827,
-      "userAction": ""
-    },
-    "cdn.native.ai": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1529084908284,
+      "nextUpdateTime": 1537558524129,
       "userAction": ""
     },
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537657789321,
+      "nextUpdateTime": 1537636079695,
       "userAction": ""
     },
     "cdn.onthe.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537721244617,
-      "userAction": ""
-    },
-    "cdn.pardot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537539569872,
-      "userAction": ""
-    },
-    "cdn.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537459829411,
-      "userAction": ""
-    },
-    "cdn.rutarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537786120312,
+      "nextUpdateTime": 1537786940871,
       "userAction": ""
     },
     "cdn.selectablemedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537540016269,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537631039742,
       "userAction": ""
     },
     "cdn.siftscience.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537447344673,
+      "nextUpdateTime": 1537918282363,
       "userAction": ""
     },
     "cdn.static.zdbb.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537334827283,
+      "nextUpdateTime": 1537690344667,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537581842159,
-      "userAction": ""
-    },
-    "cdn.tinypass.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537803118586,
-      "userAction": ""
-    },
-    "cdn.treasuredata.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537493858096,
+      "nextUpdateTime": 1537519408272,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537459949423,
+      "nextUpdateTime": 1537558429193,
       "userAction": ""
     },
     "cdn.tynt.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537357461152,
+      "nextUpdateTime": 1537664574694,
+      "userAction": ""
+    },
+    "cdn.useproof.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537581699904,
       "userAction": ""
     },
     "cdn.viglink.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537848124719,
-      "userAction": ""
-    },
-    "cdn.wbtrk.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537699771609,
-      "userAction": ""
-    },
-    "cdn.yldbt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537537214157,
+      "nextUpdateTime": 1537893245832,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537678178957,
-      "userAction": ""
-    },
-    "cdn2.lockerdome.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537622318849,
-      "userAction": ""
-    },
-    "cdns.gigya.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537504825144,
-      "userAction": ""
-    },
-    "cdnwidget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cern.ch": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537510786988,
       "userAction": ""
     },
     "changeagain.me": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "charitynavigator.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537608291316,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -2757,43 +1035,13 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537530487205,
+      "nextUpdateTime": 1537543528064,
       "userAction": ""
     },
-    "chei.com.cn": {
+    "chirp.bizrate.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chicagotribune.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinajob.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinaso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinavivaki.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "choozle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537767361677,
       "userAction": ""
     },
     "circularhub.com": {
@@ -2802,82 +1050,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "civicscience.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cj.dotomi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537376570342,
-      "userAction": ""
-    },
     "ck.connatix.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537826467841,
+      "nextUpdateTime": 1537813214078,
       "userAction": ""
     },
     "ckies.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ckmap.mediav.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537613335949,
-      "userAction": ""
-    },
-    "cleveland-com.c.richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537520752541,
-      "userAction": ""
-    },
-    "cleveland.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "click.wrating.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537441669655,
+      "nextUpdateTime": 1537727954791,
       "userAction": ""
     },
     "clickability.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clicktale.net": {
-      "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clicktripz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "client.a.pxi.pub": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537624105066,
-      "userAction": ""
-    },
-    "client.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537347000147,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -2892,76 +1080,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "clmbtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cloudflare.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cm.adform.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537441315638,
-      "userAction": ""
-    },
-    "cm.e.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537518266013,
-      "userAction": ""
-    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537700502095,
+      "nextUpdateTime": 1537874053443,
       "userAction": ""
     },
     "cm.ipinyou.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537828850780,
+      "nextUpdateTime": 1537867900784,
       "userAction": ""
     },
-    "cm.l.qq.com": {
+    "cm.pos.baidu.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537753036939,
+      "nextUpdateTime": 1537608629045,
       "userAction": ""
     },
     "cmp.smartadserver.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537453993830,
-      "userAction": ""
-    },
-    "cms.tanx.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537390478731,
-      "userAction": ""
-    },
-    "cnet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537552077164,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537526231087,
-      "userAction": ""
-    },
-    "cnn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537834017634,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -2970,100 +1116,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cnzz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cnzz.mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537783712360,
-      "userAction": ""
-    },
     "cobaltgroup.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "coherentpath.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cohesionapps.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collect-eu-central-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537461329672,
-      "userAction": ""
-    },
     "collect-eu-west-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537692228071,
+      "nextUpdateTime": 1537881878643,
       "userAction": ""
     },
-    "collect.tealiumiq.com": {
+    "collecte.audience.acpm.fr": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537471991857,
-      "userAction": ""
-    },
-    "collector-1564.tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537547411467,
-      "userAction": ""
-    },
-    "collector-963.tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537712102147,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537839202775,
       "userAction": ""
     },
     "collector-pxbecn7fqx.perimeterx.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537821111367,
-      "userAction": ""
-    },
-    "collector-pxszbkva5m.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537853462475,
-      "userAction": ""
-    },
-    "collector-pxxgcxm9by.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537597342701,
-      "userAction": ""
-    },
-    "collegenet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "com-theknot.netmng.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537411568601,
-      "userAction": ""
-    },
-    "comm100.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537708477519,
       "userAction": ""
     },
     "commander1.com": {
@@ -3078,16 +1152,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "complex.com": {
+    "condenast.demdex.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "conative.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537532540484,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -3096,16 +1164,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "conductrics.com": {
+    "config.lrcontent.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537725971184,
       "userAction": ""
     },
     "configusa.veinteractive.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537588133774,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537500033910,
       "userAction": ""
     },
     "connatix.com": {
@@ -3117,13 +1185,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537372116861,
-      "userAction": ""
-    },
-    "connexity.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537748225044,
       "userAction": ""
     },
     "consensu.org": {
@@ -3132,10 +1194,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consent.cmp.oath.com": {
+    "consent-pref.trustarc.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537641085186,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537709448258,
       "userAction": ""
     },
     "consent.google.com": {
@@ -3144,34 +1206,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "consumer.krxd.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537348941170,
-      "userAction": ""
-    },
-    "content.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537463177854,
-      "userAction": ""
-    },
-    "contentabc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537501606547,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537587161511,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537773991938,
       "userAction": ""
     },
     "contextweb.com": {
@@ -3180,88 +1224,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "contributor.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537726918982,
-      "userAction": ""
-    },
     "conv-blizzard-emea.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537493221889,
+      "nextUpdateTime": 1537925186078,
       "userAction": ""
     },
     "conv-blizzard-na.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537650849338,
-      "userAction": ""
-    },
-    "convertful.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "convertro.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "convio.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cookie.sync.ad.cpe.dotomi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537760534564,
-      "userAction": ""
-    },
-    "cookiex.ngd.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537531098710,
+      "nextUpdateTime": 1537555515485,
       "userAction": ""
     },
     "core.connatix.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537825763265,
-      "userAction": ""
-    },
-    "cornell.edu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537786354696,
       "userAction": ""
     },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537775062459,
-      "userAction": ""
-    },
-    "cox.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "coxbusiness.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cpex.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537671549081,
       "userAction": ""
     },
     "cpx.to": {
@@ -3276,22 +1260,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cr-nielsen.com": {
+    "cr.frontend.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creativecdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creativecommons.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537492445133,
       "userAction": ""
     },
     "criteo.com": {
@@ -3300,70 +1272,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "croissed.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "crowneplaza.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "crsspxl.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537613129543,
       "userAction": ""
     },
-    "cssrvsync.com": {
+    "csi.gstatic.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537727420108,
       "userAction": ""
     },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537794610133,
-      "userAction": ""
-    },
-    "ct.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537671522477,
-      "userAction": ""
-    },
-    "ctv.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "curse.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "custhelp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cx.atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537708352394,
+      "nextUpdateTime": 1537815897116,
       "userAction": ""
     },
     "cxense.com": {
@@ -3372,112 +1296,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "d.adroll.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537760155029,
+      "userAction": ""
+    },
     "d.agkn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537367862270,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537624262906,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537787945546,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537517182021,
       "userAction": ""
     },
-    "d.nativendo.de": {
+    "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537575904787,
-      "userAction": ""
-    },
-    "d.socdm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537804191736,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537841732692,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537502881080,
-      "userAction": ""
-    },
-    "d1af033869koo7.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d1rv23qj5kas56.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d2-apps.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537846817170,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537775385589,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537748341344,
       "userAction": ""
     },
-    "d41.co": {
+    "data.dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537599056552,
       "userAction": ""
     },
-    "d9.flashtalking.com": {
+    "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537656792406,
-      "userAction": ""
-    },
-    "da-ads.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dailymail.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dailymotion.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dallasnews-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537525413775,
+      "nextUpdateTime": 1537601944767,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537750706342,
-      "userAction": ""
-    },
-    "datamind.ru": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "datasteam.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537599995118,
       "userAction": ""
     },
     "daum.net": {
@@ -3486,58 +1356,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "daumcdn.net": {
+    "delivery.zidtech.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daumdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dc-storm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dc.ads.linkedin.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537838603993,
-      "userAction": ""
-    },
-    "de.ioam.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537673143037,
-      "userAction": ""
-    },
-    "deep.bi": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "delivery-cdn-cf.adswizz.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537753209326,
-      "userAction": ""
-    },
-    "delivery.h.switchadhub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537394963548,
-      "userAction": ""
-    },
-    "dell.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537523645440,
       "userAction": ""
     },
     "demdex.net": {
@@ -3546,27 +1368,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "departapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deqwas.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "developermedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3582,45 +1386,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dhs.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "di-dtaectolog-us-prod-1.appspot.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537608056657,
-      "userAction": ""
-    },
     "dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dictionary.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "digikulture-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537586301339,
-      "userAction": ""
-    },
-    "digitaladsystems.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537523129525,
       "userAction": ""
     },
     "digitaltarget.ru": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3630,34 +1410,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "direct.ad.cpe.dotomi.com": {
+    "dis.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537525801607,
+      "nextUpdateTime": 1537527991706,
       "userAction": ""
     },
-    "disney.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "display.apester.com": {
+    "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537794277701,
-      "userAction": ""
-    },
-    "disqus.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "distiltag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537834942901,
       "userAction": ""
     },
     "districtm.io": {
@@ -3666,57 +1428,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "djv99sxoqpv11.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dm.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537563092053,
-      "userAction": ""
-    },
     "dmg.digitaltarget.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537505468933,
-      "userAction": ""
-    },
-    "dmp.theadex.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537493534602,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537599597142,
       "userAction": ""
     },
     "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537375585157,
-      "userAction": ""
-    },
-    "dmxleo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dnnapi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537456298791,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dol.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3732,46 +1458,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dotsub.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "doublemax.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "doublepimpssl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "doubleverify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "dpm.demdex.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537474880205,
-      "userAction": ""
-    },
-    "dpmsrv.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537753424164,
       "userAction": ""
     },
     "drive.google.com": {
@@ -3780,34 +1476,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ds.microsoft.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537484118773,
-      "userAction": ""
-    },
-    "dsp-rambler.ru": {
+    "dt.admission.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537509834569,
+      "nextUpdateTime": 1537648146014,
       "userAction": ""
     },
-    "dtm.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537493888307,
-      "userAction": ""
-    },
-    "dx.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537661864157,
-      "userAction": ""
-    },
-    "dynad.net": {
+    "dt.cobaltgroup.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537780764105,
+      "userAction": ""
+    },
+    "dudintrec.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537533439543,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -3816,37 +1500,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dynatrace-managed.com": {
+    "e-2072.adzerk.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dyntrk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "e.monetate.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537354595792,
+      "nextUpdateTime": 1537905006966,
       "userAction": ""
     },
     "eb2.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537703786960,
+      "nextUpdateTime": 1537507933433,
       "userAction": ""
     },
     "ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.co.uk": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3864,52 +1530,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ebdr3.com": {
+    "echo.intergient.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebis.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ecdn.firstimpression.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537709178763,
-      "userAction": ""
-    },
-    "econda-monitor.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ecustomeropinions.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "edge-cdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537592599902,
       "userAction": ""
     },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537684335859,
-      "userAction": ""
-    },
-    "edmunds.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537936892363,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -3924,46 +1554,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "elsevier.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "elsevierhealth.com": {
+    "em.licasd.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537958553018,
       "userAction": ""
     },
-    "emc.com": {
+    "embed.sendtonews.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emlgrid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emxdgt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537911579947,
       "userAction": ""
     },
     "engage.commander1.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537391804198,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537768821556,
       "userAction": ""
     },
-    "envato.com": {
+    "engine.addroplet.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537919419023,
       "userAction": ""
     },
     "epicurious.com": {
@@ -3972,70 +1584,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "equalstyle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "eset.marketlinc.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537564198531,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537501049394,
       "userAction": ""
     },
     "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537397731814,
+      "nextUpdateTime": 1537948559383,
       "userAction": ""
     },
-    "espn.com": {
+    "events.mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "estara.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "estat.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "etracker.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "etsystudio.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eus.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537563601841,
-      "userAction": ""
-    },
-    "evenhotels.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eventsabout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537902234192,
       "userAction": ""
     },
     "everesttech.net": {
@@ -4044,64 +1608,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "everyaction.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537797834558,
-      "userAction": ""
-    },
-    "evise.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "evolok.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "evyy.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ew3.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ewscripps.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537810947070,
-      "userAction": ""
-    },
-    "exactag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "excite.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "exe.bid": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537909681312,
       "userAction": ""
     },
     "exelator.com": {
@@ -4110,33 +1620,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "exosrv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "expedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537481760197,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537914393364,
       "userAction": ""
     },
     "eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eyereturn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4146,70 +1638,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ezoic.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "f1.media.brightcove.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537596124509,
-      "userAction": ""
-    },
     "facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537763311331,
-      "userAction": ""
-    },
-    "facetz.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fairfax.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "farm-uk.plista.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537655196696,
-      "userAction": ""
-    },
-    "fastcompany.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537501170365,
+      "nextUpdateTime": 1537575820847,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537466305937,
-      "userAction": ""
-    },
-    "fdlstatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "feathr.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537545195020,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -4224,58 +1668,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ffx.io": {
+    "fls-na.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fidelity-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "filepicker.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "firstimpression.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flashtalking.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flickr.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flipboard.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537946679180,
       "userAction": ""
     },
     "fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537691787467,
-      "userAction": ""
-    },
-    "flyercity.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537876172595,
       "userAction": ""
     },
     "flyertown.ca": {
@@ -4284,124 +1686,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fo-api.omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537615238838,
-      "userAction": ""
-    },
-    "fo-ssp.omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537479266552,
-      "userAction": ""
-    },
-    "fontawesome.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foresee.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "forms.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537503010839,
-      "userAction": ""
-    },
-    "formstack.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "forretres.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537446496097,
-      "userAction": ""
-    },
-    "fourseasonshotels.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537454257857,
-      "userAction": ""
-    },
-    "fout.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fox.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxbusiness.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537763096096,
-      "userAction": ""
-    },
-    "foxnews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxsports.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxycart.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "freeskreen.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "freshdesk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "friendbuy.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "funcaptcha.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "funnyordie.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537689231760,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -4416,100 +1704,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.cn.miaozhen.com": {
+    "g.ign.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537636274596,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537541650706,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537344494672,
-      "userAction": ""
-    },
-    "g2crowd.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537627486048,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537633746184,
-      "userAction": ""
-    },
-    "gamer-network.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537665925657,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537461125506,
+      "nextUpdateTime": 1537702487137,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537706103519,
+      "nextUpdateTime": 1537759846881,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537364402796,
-      "userAction": ""
-    },
-    "ganon.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537379552722,
-      "userAction": ""
-    },
-    "garu.hit.gemius.pl": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537823954331,
+      "nextUpdateTime": 1537478628987,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537561295535,
-      "userAction": ""
-    },
-    "gateway.foresee.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537375797878,
-      "userAction": ""
-    },
-    "gemius.pl": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537711670087,
       "userAction": ""
     },
-    "gentags.net": {
+    "geocoding.internetbrands.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "geo.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537496208149,
+      "nextUpdateTime": 1537874591769,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537510348476,
+      "userAction": ""
+    },
+    "geosync.solution.weborama.fr": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537483523101,
+      "nextUpdateTime": 1537682619526,
       "userAction": ""
     },
     "getclicky.com": {
@@ -4518,51 +1770,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "getdrip.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getpocket.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getsmartcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gfycat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gg.google.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537433276062,
-      "userAction": ""
-    },
     "gigya.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "giphy.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "github.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4578,39 +1788,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gmossp-sp.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "goetheinstitut01.webtrekk.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537374329341,
-      "userAction": ""
-    },
     "golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "goo.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "google.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4623,7 +1809,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537841584409,
+      "nextUpdateTime": 1537812333564,
       "userAction": ""
     },
     "gq.com": {
@@ -4635,25 +1821,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537568231444,
-      "userAction": ""
-    },
-    "gridsumdissector.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "groupon.btttag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537576673758,
-      "userAction": ""
-    },
-    "groupondata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537913818401,
       "userAction": ""
     },
     "groups.google.com": {
@@ -4662,52 +1830,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gruppoespresso01.webtrekk.net": {
+    "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537353285439,
-      "userAction": ""
-    },
-    "gsimedia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537826644903,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537773623900,
+      "nextUpdateTime": 1537616533756,
       "userAction": ""
     },
-    "gsp0.baidu.com": {
+    "gstatic.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537409755142,
-      "userAction": ""
-    },
-    "gsp1.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537729908142,
-      "userAction": ""
-    },
-    "gssprt.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gtags.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537699179738,
+      "nextUpdateTime": 1537604908756,
       "userAction": ""
     },
     "gumgum.com": {
@@ -4716,322 +1860,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "guoshipartners.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gurgle.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537820793491,
-      "userAction": ""
-    },
     "gwallet.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gwiqcdn.globalwebindex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537426162495,
-      "userAction": ""
-    },
-    "hao123.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537833612922,
-      "userAction": ""
-    },
-    "hatena.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hatena.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hbevents.1rx.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537376091193,
-      "userAction": ""
-    },
-    "hbopenbid.pubmatic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537447308083,
-      "userAction": ""
-    },
-    "healte.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hearstnp.com": {
+    "gwiq-v3.globalwebindex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537903525761,
       "userAction": ""
     },
-    "help.com": {
+    "hdslb.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "heredeutschlandgmbh.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537653882956,
-      "userAction": ""
-    },
-    "hiexpress.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "highwire.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hitslink.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hive.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hlserve.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "hm.baidu.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537567498875,
+      "userAction": ""
+    },
+    "hmcdn.baidu.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537485650578,
-      "userAction": ""
-    },
-    "hnsa.hugedata.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537795510353,
-      "userAction": ""
-    },
-    "holidayinn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "holidayinnresorts.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "horyzon-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hotelindigo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hotelsapi.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "htmedia.in": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huffingtonpost.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huffingtonpost.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hugedata.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huihui.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hwcdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hypemarks.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537776901148,
       "userAction": ""
     },
     "i.connatix.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537616776639,
+      "nextUpdateTime": 1537762278852,
+      "userAction": ""
+    },
+    "i.liadm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537847658666,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537622904235,
-      "userAction": ""
-    },
-    "i.simpli.fi": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537611917217,
-      "userAction": ""
-    },
-    "i.tianqi.com": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537719274662,
+      "nextUpdateTime": 1537816173449,
       "userAction": ""
     },
-    "i.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "i.yldbt.com": {
+    "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537840572771,
-      "userAction": ""
-    },
-    "i1img.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ib-ibi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537663039777,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537645521593,
+      "nextUpdateTime": 1537686738742,
       "userAction": ""
     },
-    "ibclick.stream": {
+    "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537700409337,
-      "userAction": ""
-    },
-    "ibillboard.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ibt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iclick.cm.admaster.com.cn": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537425325895,
+      "nextUpdateTime": 1537737731849,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537803498974,
-      "userAction": ""
-    },
-    "id5-sync.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537753646271,
-      "userAction": ""
-    },
-    "idealmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537451086715,
       "userAction": ""
     },
     "identityssl.newscdn.com.au": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537505919771,
+      "nextUpdateTime": 1537809654954,
       "userAction": ""
     },
-    "idm.bce.baidu.com": {
+    "idpix.media6degrees.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537531715722,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537739576272,
       "userAction": ""
     },
     "idsync.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537387719294,
+      "nextUpdateTime": 1537842333111,
       "userAction": ""
     },
     "ign.com": {
@@ -5040,46 +1956,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "igodigital.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ih.adscale.de": {
+    "image2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537824645979,
+      "nextUpdateTime": 1537592083467,
       "userAction": ""
     },
-    "iheart.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "im-apps.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imagetopng.club": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imedia.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "img.ak.impact-ad.jp": {
+    "image4.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537410755052,
+      "nextUpdateTime": 1537704450079,
+      "userAction": ""
+    },
+    "image6.pubmatic.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537653168221,
+      "userAction": ""
+    },
+    "images.taboola.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537513469490,
       "userAction": ""
     },
     "img.purch.com": {
@@ -5088,22 +1986,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "imgfarm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imgur.com": {
+    "img.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "impact-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537501222395,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -5112,43 +1998,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "infinity-tracking.net": {
+    "in.getclicky.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537565558881,
       "userAction": ""
     },
     "infinityid.condenastdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537815599785,
-      "userAction": ""
-    },
-    "infolinks.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "innovid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "inq.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537568428156,
       "userAction": ""
     },
-    "inquisitr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "inside-graph.com": {
+    "innity.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5157,7 +2019,7 @@
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537516954962,
+      "nextUpdateTime": 1537950838582,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -5166,31 +2028,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "instagram.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537771022680,
+      "nextUpdateTime": 1537956619651,
       "userAction": ""
     },
     "instinctiveads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "intentiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "intentmedia.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -5217,30 +2061,12 @@
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537751310277,
+      "nextUpdateTime": 1537528784057,
       "userAction": ""
     },
     "investingchannel.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "investis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "invoc.us": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ioam.de": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5252,7 +2078,7 @@
     },
     "iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5262,147 +2088,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ipredictive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ips-invite.iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537379208309,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537869247546,
       "userAction": ""
     },
-    "irqs.ioam.de": {
+    "ir-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537822702685,
+      "nextUpdateTime": 1537912596310,
       "userAction": ""
     },
-    "irs01.com": {
+    "italiaonline01.wt-eu02.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "italiaonline-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537586239989,
-      "userAction": ""
-    },
-    "izooto.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "j.6sc.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537647385711,
+      "nextUpdateTime": 1537811450996,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537397102501,
-      "userAction": ""
-    },
-    "janrainsso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jd.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jquery.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jrs5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537570038384,
       "userAction": ""
     },
     "js.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537445667906,
+      "nextUpdateTime": 1537524595439,
       "userAction": ""
     },
     "js.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537847321583,
-      "userAction": ""
-    },
-    "js.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537462670466,
+      "nextUpdateTime": 1537709002002,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1529472262192,
-      "userAction": ""
-    },
-    "js.stripe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537546974568,
+      "nextUpdateTime": 1537453750117,
       "userAction": ""
     },
     "jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "justpremium.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "justuno.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jword.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jyxo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kakao.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kameleoon.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5448,52 +2178,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "kinja.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kiwiirc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "knet.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kraken.rambler.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537595786388,
-      "userAction": ""
-    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kxlogo.knet.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537798598867,
-      "userAction": ""
-    },
-    "l.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "labs-cdn.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537446318406,
       "userAction": ""
     },
     "labs.google.com": {
@@ -5502,46 +2190,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ladsp.com": {
+    "lcidc.liadm.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537480178306,
       "userAction": ""
     },
     "leadintel.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537526964354,
       "userAction": ""
     },
-    "leaf.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "legocdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lejwaengv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lenovo.demdex.net": {
+    "li.pxl.ace.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537722894618,
-      "userAction": ""
-    },
-    "lentainform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537690362083,
       "userAction": ""
     },
     "liadm.com": {
@@ -5550,33 +2214,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "libero.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "licasd.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lift3assets.lift.acquia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537600336494,
-      "userAction": ""
-    },
-    "ligadx.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5592,63 +2232,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lincoln.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "link-page.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "linksynergy.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "list-manage.com": {
+    "live.sekindo.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "listrakbi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "live.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537661966910,
       "userAction": ""
     },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "livedoor.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "livejournal.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5658,142 +2256,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "livingly-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537521195236,
-      "userAction": ""
-    },
-    "lkqd.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lmi.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537348530005,
-      "userAction": ""
-    },
     "load.instinctiveads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537825666897,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537887139462,
       "userAction": ""
     },
-    "load.sumo.com": {
+    "load77.exelator.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537359529552,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537607433156,
       "userAction": ""
     },
-    "loadeu.exelator.com": {
+    "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537669267158,
+      "nextUpdateTime": 1537695354708,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537805031291,
-      "userAction": ""
-    },
-    "loc.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537858987653,
       "userAction": ""
     },
     "lockerdome.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537615982886,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537628767640,
       "userAction": ""
     },
-    "log.mmstat.com": {
+    "loggingapi.spingo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537665588199,
-      "userAction": ""
-    },
-    "logc187.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537700822188,
-      "userAction": ""
-    },
-    "logc211.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537485080427,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537519313806,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537623582885,
-      "userAction": ""
-    },
-    "login.live.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537688130608,
-      "userAction": ""
-    },
-    "login.wikimedia.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537809374617,
-      "userAction": ""
-    },
-    "logly.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537938495129,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537806583174,
-      "userAction": ""
-    },
-    "logs1091.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537611410006,
-      "userAction": ""
-    },
-    "logs1136.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537802516960,
-      "userAction": ""
-    },
-    "logs1187.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537565686371,
-      "userAction": ""
-    },
-    "logs1242.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537756693821,
-      "userAction": ""
-    },
-    "logs1406.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537805308631,
-      "userAction": ""
-    },
-    "logws1344.ati-host.net": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537393536856,
+      "nextUpdateTime": 1537529381640,
       "userAction": ""
     },
     "lp1block.com": {
@@ -5805,13 +2313,7 @@
     "lptag.liveperson.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537844969135,
-      "userAction": ""
-    },
-    "lqm.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537673205510,
       "userAction": ""
     },
     "lrcontent.com": {
@@ -5820,58 +2322,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lucklayed.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lwcal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lytics.io": {
+    "m.addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "m.reachmax.cn": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537472636103,
-      "userAction": ""
-    },
-    "m6r.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "madeleine.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mail.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mailchimp.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mantisadnetwork.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537931773797,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -5884,6 +2338,12 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "maps.gstatic.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537817500851,
       "userAction": ""
     },
     "mapsengine.google.com": {
@@ -5900,38 +2360,20 @@
     },
     "marketlinc.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "match.adsrvr.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537630572455,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537611772016,
       "userAction": ""
     },
     "match.prod.bidr.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537421833071,
-      "userAction": ""
-    },
-    "match.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537377782169,
-      "userAction": ""
-    },
-    "matheranalytics.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537695592254,
       "userAction": ""
     },
     "mathtag.com": {
@@ -5943,37 +2385,19 @@
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537549047663,
-      "userAction": ""
-    },
-    "mcclatchy.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537547673210,
-      "userAction": ""
-    },
-    "mcclatchy.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537455046957,
-      "userAction": ""
-    },
-    "me-ssl.effectivemeasure.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537375090256,
-      "userAction": ""
-    },
-    "media.cleveland.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537728476846,
+      "nextUpdateTime": 1537781513983,
       "userAction": ""
     },
     "media.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "media.workandmoney.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537772218821,
       "userAction": ""
     },
     "media6degrees.com": {
@@ -5985,42 +2409,18 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537739742597,
+      "nextUpdateTime": 1537450926060,
       "userAction": ""
     },
-    "mediaforge.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medialand.ru": {
+    "mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mediaplex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediav.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "mediawallahscript.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6030,85 +2430,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "medscape.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medtargetsystem.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mendeley.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "messenger.live.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "meta.wikimedia.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537535469301,
-      "userAction": ""
-    },
-    "metadsp.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "metrics.brightcove.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537707330164,
-      "userAction": ""
-    },
-    "mg2connext.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mgid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "miamiherald.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microad.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microsoft.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microsoftonline.com": {
+    "mfadsrvr.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -6116,14 +2438,8 @@
     },
     "mid.rkdms.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537519842607,
-      "userAction": ""
-    },
-    "mirtesen.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537740252391,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -6135,115 +2451,19 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537652054184,
+      "nextUpdateTime": 1537595374693,
       "userAction": ""
     },
-    "mlb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mlive-com.c.richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537490804182,
-      "userAction": ""
-    },
-    "mlive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mmtro.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "molefefiseranis.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monetate.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monster.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monster.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537479714504,
-      "userAction": ""
-    },
-    "monsterworldwide.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537599184938,
-      "userAction": ""
-    },
-    "mookie1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mouseflow.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mpnrs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mpp.vindicosuite.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537415961201,
-      "userAction": ""
-    },
-    "mrpfd.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "msgapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "msn.com": {
+    "mps.nbcuni.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537756493707,
       "userAction": ""
     },
     "mssl.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537597045064,
+      "nextUpdateTime": 1537765088056,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -6258,18 +2478,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mthsense.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtrx.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537822342823,
-      "userAction": ""
-    },
     "mts0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6279,36 +2487,6 @@
     "mts1.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtty.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtvnservices.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "multiview.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "musthird.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "muumuu-domain.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6324,118 +2502,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mybuys.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myfamilycominc.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537383572573,
-      "userAction": ""
-    },
-    "myhard.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mynativeplatform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myregistry.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myspacecdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myvisualiq.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nasdaq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nationalgeographic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "native.ai": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "native.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537519118977,
-      "userAction": ""
-    },
-    "nativendo.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "naver.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "naver.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "navitastarget.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537782079670,
-      "userAction": ""
-    },
-    "nbcnews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "nbcu.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537729551081,
+      "nextUpdateTime": 1537675565343,
       "userAction": ""
     },
     "nbcuni.com": {
@@ -6444,51 +2514,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "netdna-ssl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newatlas.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "neweggimages.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newjobs.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537551536408,
-      "userAction": ""
-    },
-    "news.chinaso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537460188012,
-      "userAction": ""
-    },
-    "news.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6513,37 +2541,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537476028619,
-      "userAction": ""
-    },
-    "newsday.d2.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537476978167,
-      "userAction": ""
-    },
-    "newsinc.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsmemory.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsvine.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsweekgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537550690745,
       "userAction": ""
     },
     "newyorker.com": {
@@ -6558,46 +2556,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ngpvan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nih.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nineto5mac-d.openx.net": {
+    "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537363999204,
+      "nextUpdateTime": 1537899672597,
       "userAction": ""
     },
-    "nintendoofamerica.tt.omtrdc.net": {
+    "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537557900640,
-      "userAction": ""
-    },
-    "nokia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nola-com.c.richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537343492736,
-      "userAction": ""
-    },
-    "norton.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537802452858,
       "userAction": ""
     },
     "nr-data.net": {
@@ -6606,148 +2574,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ns.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537649827712,
-      "userAction": ""
-    },
-    "nsaudience.pl": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nscontext.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nuggad.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nxtck.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nymag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nzaza.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "o0bg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "oasc10.247realmedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537389406210,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537927451218,
       "userAction": ""
     },
-    "oath.com": {
+    "oclc.112.2o7.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537516141999,
+      "userAction": ""
+    },
+    "odb.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "observermedia-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537837605583,
-      "userAction": ""
-    },
-    "ocdn.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oclc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ofapes.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "offaces-butional.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537816218967,
-      "userAction": ""
-    },
-    "office.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "office365.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ojrq.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ok.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "olark.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "olympicchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omkt.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omnidsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537837698830,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -6756,63 +2598,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "onclickmega.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onecount.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oneroof.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onet.hit.gemius.pl": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537722732670,
-      "userAction": ""
-    },
-    "onet.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onetag.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537718863450,
-      "userAction": ""
-    },
     "onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onevision.com.tw": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "online-metrix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onsugar.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6822,69 +2610,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "openhub.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "openstat.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "openx.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "opf.ooyala.com": {
+    "ophan.theguardian.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537645962946,
+      "userAction": ""
+    },
+    "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "opinionstage.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optaim.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimix.asia": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimized-by.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537358171112,
+      "nextUpdateTime": 1537751703960,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimove.events": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6894,64 +2640,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oracleimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "orange.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537827661746,
-      "userAction": ""
-    },
-    "orangeads.fr": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oregonlive-com.c.richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537442750718,
-      "userAction": ""
-    },
-    "oreilly.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "otm-r.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "otto.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ovh.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ovh.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537359090928,
       "userAction": ""
     },
     "owneriq.net": {
@@ -6960,58 +2652,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "owox.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "p.adsymptotic.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537829675814,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537706817051,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537832405795,
+      "nextUpdateTime": 1537845404551,
+      "userAction": ""
+    },
+    "p.cquotient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537936279314,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537573744583,
+      "nextUpdateTime": 1537493433158,
       "userAction": ""
     },
-    "p.nxtck.com": {
+    "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537547627506,
+      "nextUpdateTime": 1537487063788,
       "userAction": ""
     },
-    "p.tanx.com": {
+    "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537651389323,
+      "nextUpdateTime": 1537505785246,
       "userAction": ""
     },
-    "p1.zemanta.com": {
+    "p.yotpo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537657609664,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537699522129,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537553797447,
-      "userAction": ""
-    },
-    "paddle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537845781986,
       "userAction": ""
     },
     "pardot.com": {
@@ -7028,62 +2714,14 @@
     },
     "partner.mediawallahscript.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537529619745,
-      "userAction": ""
-    },
-    "passport.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537468064058,
-      "userAction": ""
-    },
-    "paypal.com": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "paypalobjects.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "payroll.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pb.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537440523761,
-      "userAction": ""
-    },
-    "pbskids.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pcmag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537679554534,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537727075617,
-      "userAction": ""
-    },
-    "pdmp.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537675608382,
       "userAction": ""
     },
     "performgroup.com": {
@@ -7098,28 +2736,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pewresearch.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "phonograph2.voxmedia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537397936653,
-      "userAction": ""
-    },
-    "phs.tanx.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537606598294,
-      "userAction": ""
-    },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537514191920,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537856276772,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -7134,118 +2754,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "pipes.yahoo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pitchfork.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pittpostgazette-d.openx.net": {
+    "pixel-sc2.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537763620757,
+      "nextUpdateTime": 1537605179109,
       "userAction": ""
     },
-    "pixanalytics.com": {
+    "pixel-sync.sitescout.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537687745697,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537728361892,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537661479633,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537752103253,
-      "userAction": ""
-    },
-    "pixel.everesttech.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537836183588,
+      "nextUpdateTime": 1537936618740,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537696404409,
+      "nextUpdateTime": 1537885552749,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537417518831,
+      "nextUpdateTime": 1537802852606,
+      "userAction": ""
+    },
+    "pixel.mtrcs.samba.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537539611639,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537617661463,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537793705979,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537517537313,
+      "nextUpdateTime": 1537853122548,
       "userAction": ""
     },
-    "pixel.s3xified.com": {
+    "pixel.servebom.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537634706617,
+      "nextUpdateTime": 1537887790446,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537352082298,
-      "userAction": ""
-    },
-    "pixel.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537387767697,
+      "nextUpdateTime": 1537516043381,
       "userAction": ""
     },
     "pixel.zprk.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537444092035,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537669815103,
       "userAction": ""
     },
-    "piximedia.com": {
+    "pixeltrack.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pixnet.cc": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "placed.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537574398798,
       "userAction": ""
     },
     "placelocal.com": {
@@ -7257,25 +2847,19 @@
     "platform-api.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537626033146,
+      "nextUpdateTime": 1537618692470,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537526648353,
-      "userAction": ""
-    },
-    "platform.tumblr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537626103994,
+      "nextUpdateTime": 1537458677035,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537800409757,
       "userAction": ""
     },
     "play.google.com": {
@@ -7284,46 +2868,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.ooyala.com": {
+    "player.performgroup.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "player.vimeo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537443951136,
-      "userAction": ""
-    },
-    "players.brightcove.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537896826240,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537353203014,
-      "userAction": ""
-    },
-    "playwire.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "plista.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537773917321,
       "userAction": ""
     },
     "plugin.tianqijun.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537597401865,
+      "nextUpdateTime": 1537748776986,
       "userAction": ""
     },
     "plus.google.com": {
@@ -7334,32 +2894,8 @@
     },
     "po.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "polymorphicads.jp": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "popin.cc": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "popsugar-assets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537425357605,
+      "nextUpdateTime": 1537500258193,
       "userAction": ""
     },
     "postrelease.com": {
@@ -7368,82 +2904,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "powerlinks.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "prebid-server.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537724002437,
-      "userAction": ""
-    },
-    "prebid.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537482313414,
-      "userAction": ""
-    },
-    "pressboard.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "prfct.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "privacy.purch.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537580005665,
-      "userAction": ""
-    },
-    "pro-market.net": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pro.fontawesome.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537465232067,
-      "userAction": ""
-    },
-    "prod-mng-proxy-connext.azurewebsites.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537410860681,
-      "userAction": ""
-    },
-    "proparm.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "propermedia-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537589012341,
-      "userAction": ""
-    },
-    "provenpixel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "providesupport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537879271663,
       "userAction": ""
     },
     "proximus.be": {
@@ -7455,25 +2919,13 @@
     "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537530060204,
-      "userAction": ""
-    },
-    "proximustv.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537649779975,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537473820970,
-      "userAction": ""
-    },
-    "pscp.tv": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537770609852,
       "userAction": ""
     },
     "pub.network": {
@@ -7485,19 +2937,13 @@
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537384498312,
+      "nextUpdateTime": 1537688216070,
       "userAction": ""
     },
-    "pubgalaxy-d.openx.net": {
+    "pubmatic-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537626345218,
-      "userAction": ""
-    },
-    "publishme.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537799110233,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -7506,28 +2952,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubmine.com": {
+    "pubmatic2waycm-atl.netmng.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537511161551,
       "userAction": ""
     },
-    "pulpix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pulsar.ebay.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537371472655,
-      "userAction": ""
-    },
-    "pulsar.xlisting.jp": {
+    "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537660260706,
+      "nextUpdateTime": 1537491674953,
+      "userAction": ""
+    },
+    "purch-sync.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537615213593,
       "userAction": ""
     },
     "purch.com": {
@@ -7536,141 +2976,57 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "purechat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "push.zhanzhang.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537775719251,
-      "userAction": ""
-    },
-    "px.adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537808474437,
-      "userAction": ""
-    },
     "px.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537695885111,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537796909603,
       "userAction": ""
     },
-    "px.spiceworks.com": {
+    "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537441921493,
+      "nextUpdateTime": 1537576171296,
       "userAction": ""
     },
-    "pxf.io": {
+    "px.owneriq.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537837144843,
       "userAction": ""
     },
-    "pxi.pub": {
+    "px.steelhousemedia.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537627831473,
       "userAction": ""
     },
-    "pxtres.com": {
+    "pxlsfvwe-a.akamaihd.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxuno.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxzwei.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537456582086,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537628865085,
+      "nextUpdateTime": 1537534907217,
       "userAction": ""
     },
-    "qa.assets.purch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537437519947,
-      "userAction": ""
-    },
-    "qantas.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537744721869,
-      "userAction": ""
-    },
-    "qnsr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qq.com": {
+    "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qsstats.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qtmojo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537631387420,
       "userAction": ""
     },
     "quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537786312378,
+      "nextUpdateTime": 1537550668996,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantummetric.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quickbooks.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quickbooksonline.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7680,148 +3036,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537665844822,
-      "userAction": ""
-    },
     "r.dmp.sina.com.cn": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537453361980,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537556220411,
       "userAction": ""
     },
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537491771720,
+      "nextUpdateTime": 1537777511413,
       "userAction": ""
     },
-    "rackcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "radiotime.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rakuten.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rambler.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ramp.purch.com": {
+    "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537607386579,
+      "nextUpdateTime": 1537632510659,
       "userAction": ""
     },
-    "rbnt.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rc.rlcdn.com": {
+    "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537387396318,
+      "nextUpdateTime": 1537739633160,
       "userAction": ""
     },
-    "rcsmetrics.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reachmax.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reddit.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "redirect.frontend.weborama.fr": {
+    "rd.frontend.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537402809276,
+      "nextUpdateTime": 1537866844315,
       "userAction": ""
     },
-    "redlink.com": {
+    "registercom.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537950836227,
       "userAction": ""
     },
-    "reference.com": {
+    "registercom.tt.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "regmedia.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "relap.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "republer.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537482418879,
       "userAction": ""
     },
     "res.suning.cn": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537664061776,
-      "userAction": ""
-    },
-    "researchintel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reson8.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "responsetap.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reutersmedia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537813301024,
       "userAction": ""
     },
     "revcontent.com": {
@@ -7830,45 +3090,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "revjet.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rezync.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ria.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "richrelevance.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rightnowtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7884,76 +3108,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rnengage.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rockyou.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "roomkey.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "roymorgan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtax.criteo.com": {
+    "rp.gwallet.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537813335135,
+      "nextUpdateTime": 1537908971962,
       "userAction": ""
     },
-    "rtb-csync.smartadserver.com": {
+    "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537589832477,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537804281708,
       "userAction": ""
     },
-    "rtb.com.ru": {
+    "rss.art19.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537506168486,
       "userAction": ""
     },
     "rtb.connatix.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537751361629,
+      "nextUpdateTime": 1537662261105,
       "userAction": ""
     },
-    "rtb.gumgum.com": {
+    "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537538861956,
+      "nextUpdateTime": 1537891050192,
       "userAction": ""
     },
-    "rtk.io": {
+    "rtb.mfadsrvr.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537514930749,
       "userAction": ""
     },
     "rtve.d1.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537522201960,
-      "userAction": ""
-    },
-    "ru4.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537766130426,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -7965,25 +3159,7 @@
     "rudy.adsnative.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537855603406,
-      "userAction": ""
-    },
-    "rundsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rutarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ryanair.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537377356756,
+      "nextUpdateTime": 1537806612737,
       "userAction": ""
     },
     "s-static.ak.facebook.com": {
@@ -7992,171 +3168,105 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "s-vop.sundaysky.com": {
+    "s-v6exp1-ds.metric.gstatic.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537770284206,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537824622166,
       "userAction": ""
     },
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537406783302,
+      "nextUpdateTime": 1537718290259,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537609439733,
+      "nextUpdateTime": 1537774137149,
       "userAction": ""
     },
     "s.clickability.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537629977965,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537615272003,
       "userAction": ""
     },
-    "s.dpmsrv.com": {
+    "s.cpx.to": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537369328653,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537650324477,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537379488836,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537704922531,
+      "userAction": ""
+    },
+    "s.jsrdn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537846016887,
+      "userAction": ""
+    },
+    "s.nexac.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537448578396,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537525277089,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537510193603,
+      "userAction": ""
+    },
+    "s.spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537567561362,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537557153026,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537637515918,
       "userAction": ""
     },
-    "s.yimg.com": {
+    "s1.hdslb.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537669759881,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537678226590,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537774440899,
-      "userAction": ""
-    },
-    "s1107560253.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537390671173,
+      "nextUpdateTime": 1537894278733,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537796317614,
-      "userAction": ""
-    },
-    "s1777052651.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537477789797,
-      "userAction": ""
-    },
-    "s2033604275.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537382302622,
-      "userAction": ""
-    },
-    "s2044559064.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537540763364,
-      "userAction": ""
-    },
-    "s2150.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537675589425,
+      "nextUpdateTime": 1537945122061,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537624902439,
-      "userAction": ""
-    },
-    "s3-us-west-2.amazonaws.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "s3xified.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "s43975733.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537487160999,
-      "userAction": ""
-    },
-    "s657486201.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537460790340,
-      "userAction": ""
-    },
-    "s661931745.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537628429053,
+      "nextUpdateTime": 1537781342146,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537365593071,
-      "userAction": ""
-    },
-    "s795651218.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537584665419,
-      "userAction": ""
-    },
-    "sabavision.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537811788622,
       "userAction": ""
     },
     "salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "salesloft.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "salesmanago.pl": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -8166,94 +3276,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "saxp.zedo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537400072651,
-      "userAction": ""
-    },
-    "saymedia-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537468734261,
-      "userAction": ""
-    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537781528285,
+      "nextUpdateTime": 1537578272771,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537813786365,
-      "userAction": ""
-    },
-    "sbal4kp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537823324902,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537814611784,
-      "userAction": ""
-    },
-    "sbsaustralia.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537350973466,
-      "userAction": ""
-    },
-    "scarabresearch.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537733366525,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537368222095,
-      "userAction": ""
-    },
-    "scholarlyiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciencedirect.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciencedirectassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciverse.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scoop.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scopus.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537618963583,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -8262,58 +3306,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "scout-cdn.salesloft.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537827716713,
-      "userAction": ""
-    },
-    "scribblelive.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537755241515,
+      "nextUpdateTime": 1537533436741,
       "userAction": ""
     },
-    "scripps.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537523676284,
-      "userAction": ""
-    },
-    "script.ioam.de": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sddan.com": {
+    "sdc-qczj.pingan.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "se.monetate.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537814604620,
-      "userAction": ""
-    },
-    "seadform.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537450956832,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537781305368,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537656187416,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -8322,154 +3330,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "searchmarketing.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537590735453,
+      "nextUpdateTime": 1537671345425,
+      "userAction": ""
+    },
+    "secfld.vmmpxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537786730710,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537754082054,
-      "userAction": ""
-    },
-    "secure-cf-c.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "secure-chn.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537429000443,
+      "nextUpdateTime": 1537738916180,
       "userAction": ""
     },
     "secure-dcr.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537648777437,
-      "userAction": ""
-    },
-    "secure-drm.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537483815647,
+      "nextUpdateTime": 1537699103277,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537679114026,
+      "nextUpdateTime": 1537597100597,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537473349226,
+      "nextUpdateTime": 1537856608472,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537455873142,
-      "userAction": ""
-    },
-    "secure-nz.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537417911344,
-      "userAction": ""
-    },
-    "secure-uk.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537736380027,
+      "nextUpdateTime": 1537818295597,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537611165280,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537766934140,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537497005436,
-      "userAction": ""
-    },
-    "secure.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537653916481,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537525528622,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537758674209,
-      "userAction": ""
-    },
-    "secure.leadback.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537704487497,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537738077212,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537356022662,
-      "userAction": ""
-    },
-    "secure.p01.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537571466770,
+      "nextUpdateTime": 1537715006767,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537803059668,
-      "userAction": ""
-    },
-    "secure.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537747472209,
-      "userAction": ""
-    },
-    "securedvisit.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537949451895,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537736133131,
-      "userAction": ""
-    },
-    "seekingalpha.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537771009211,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537402758441,
+      "nextUpdateTime": 1537799252076,
+      "userAction": ""
+    },
+    "segments.company-target.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537705585446,
       "userAction": ""
     },
     "sekindo.com": {
@@ -8490,12 +3438,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "semasio.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sendtonews.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -8508,28 +3450,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servedby-buysellads.com": {
+    "servicer.traffic-media.co": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "servedby.flashtalking.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537698859587,
-      "userAction": ""
-    },
-    "serverbid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "servicer.lentainform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537628904782,
+      "nextUpdateTime": 1537770562636,
       "userAction": ""
     },
     "serving-sys.com": {
@@ -8540,17 +3464,11 @@
     },
     "session.timecommerce.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537538042191,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537902227193,
       "userAction": ""
     },
     "sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shareaholic.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -8562,46 +3480,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sheego.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sheknows-d.openx.net": {
+    "sharethrough.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537773631725,
-      "userAction": ""
-    },
-    "shop.pe": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537799399517,
-      "userAction": ""
-    },
-    "shopify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "show-g.mediav.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799384587,
-      "userAction": ""
-    },
-    "siemens.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537432827667,
+      "nextUpdateTime": 1537848455982,
       "userAction": ""
     },
     "siftscience.com": {
@@ -8610,37 +3492,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simplereach.com": {
+    "simage2.pubmatic.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "simpli.fi": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sina.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1537498910884,
       "userAction": ""
     },
     "sina.com.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sinoptik.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitehelix.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -8649,24 +3507,6 @@
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "siteimproveanalytics.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitelabweb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitelock.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -8682,79 +3522,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sjs.bizographics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537424691403,
-      "userAction": ""
-    },
     "skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sky.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "slack.sp1.convertro.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537839602847,
-      "userAction": ""
-    },
-    "slashdotmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartadserver.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartclip.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537666525902,
-      "userAction": ""
-    },
-    "smashing-delivery.herokuapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smi2.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537590634754,
       "userAction": ""
     },
     "smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smithsonian.museum": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smyte.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -8766,85 +3546,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "snapwidget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "snplow.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "so.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "socdm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sociomantic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "soflopxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "softonic-analytics.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sogou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sohu.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sojern.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sokrati.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solarwinds.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537696660663,
-      "userAction": ""
-    },
-    "soliditet.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solocpm.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -8856,64 +3558,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sonyentertainmentnetwork.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sourceforge.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sp.analytics.yahoo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537558519340,
-      "userAction": ""
-    },
-    "sp.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sp0.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537745670303,
-      "userAction": ""
-    },
-    "spectate.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sphereup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spiceworks.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spineuniverse.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537785069352,
       "userAction": ""
     },
     "spingo.com": {
@@ -8923,24 +3577,6 @@
       "userAction": ""
     },
     "sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spot.im": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spotify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spots.im": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -8964,148 +3600,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "springernature.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "springserve.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sprinklr.com": {
+    "src.ebay-us.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537556536901,
       "userAction": ""
     },
-    "srv-2018-09-18-04.config.parsely.com": {
+    "srv-2018-09-19-11.config.parsely.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537439900186,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537798885889,
       "userAction": ""
     },
-    "srv-2018-09-18-04.pixel.parsely.com": {
+    "srv-2018-09-19-11.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537709844418,
+      "nextUpdateTime": 1537840754975,
       "userAction": ""
     },
-    "srv-2018-09-18-05.config.parsely.com": {
+    "srv-2018-09-19-12.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537703555496,
-      "userAction": ""
-    },
-    "srv-2018-09-18-05.pixel.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537822171993,
-      "userAction": ""
-    },
-    "srv-2018-09-18-06.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537684229851,
-      "userAction": ""
-    },
-    "srv-2018-09-18-07.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537684692503,
-      "userAction": ""
-    },
-    "srv-2018-09-18-07.pixel.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537344043758,
-      "userAction": ""
-    },
-    "srv-2018-09-18-08.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537714028548,
+      "nextUpdateTime": 1537742571634,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537653199967,
+      "nextUpdateTime": 1537457643347,
       "userAction": ""
     },
-    "srv.stackadapt.com": {
+    "ssl.gstatic.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537753420086,
-      "userAction": ""
-    },
-    "srx.com.sg": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ss3.zedo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537568947172,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537647056340,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537558592289,
-      "userAction": ""
-    },
-    "ssp.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537691225967,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537451072989,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537739277220,
+      "nextUpdateTime": 1537693049279,
       "userAction": ""
     },
-    "ssum.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537644197130,
-      "userAction": ""
-    },
-    "stackadapt.com": {
+    "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537823064117,
       "userAction": ""
     },
     "stanza-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537561707483,
-      "userAction": ""
-    },
-    "staples-sparx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "staples-static.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "starfieldtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537829817249,
       "userAction": ""
     },
     "statcounter.com": {
@@ -9114,64 +3666,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "static.addtoany.com": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1529315030088,
-      "userAction": ""
-    },
-    "static.adsnative.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537728976668,
-      "userAction": ""
-    },
-    "static.apester.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537825635487,
-      "userAction": ""
-    },
-    "static.bshare.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537575925389,
-      "userAction": ""
-    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537344853144,
-      "userAction": ""
-    },
-    "static.getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537573759044,
-      "userAction": ""
-    },
-    "static.mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537693233687,
+      "nextUpdateTime": 1537800009124,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550476650,
+      "nextUpdateTime": 1537792793168,
       "userAction": ""
     },
-    "static.vilynx.com": {
+    "static.quantcast.mgr.consensu.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537788371676,
-      "userAction": ""
-    },
-    "staticimgfarm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537692165307,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -9183,72 +3693,18 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537634221541,
+      "nextUpdateTime": 1537699249146,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537482563710,
-      "userAction": ""
-    },
-    "staybridge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537944166201,
       "userAction": ""
     },
     "steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "steepto.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stg-sp.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stg8.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stickyadstv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "storage.googleapis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "storygize.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "streem.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "streetscout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -9261,7 +3717,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537426863342,
+      "nextUpdateTime": 1537816897557,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -9276,154 +3732,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "suning.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sunrtb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "suntimes-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537439392997,
-      "userAction": ""
-    },
-    "supplyframe.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "survata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537700658925,
-      "userAction": ""
-    },
-    "surveymonkey.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537489764549,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537645900352,
+      "nextUpdateTime": 1537910804572,
       "userAction": ""
     },
-    "switchadhub.com": {
+    "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537852480724,
       "userAction": ""
     },
-    "symantec.com": {
+    "sync.1dmp.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537632266172,
       "userAction": ""
     },
-    "synacor.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sync.1rx.io": {
+    "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537756736121,
+      "nextUpdateTime": 1537655833858,
       "userAction": ""
     },
-    "sync.audtd.com": {
+    "sync.adkernel.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537553149540,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537809960844,
       "userAction": ""
     },
-    "sync.commander1.com": {
+    "sync.bfmio.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537683475125,
-      "userAction": ""
-    },
-    "sync.datamind.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537510538013,
-      "userAction": ""
-    },
-    "sync.fox.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537715650846,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537547540738,
       "userAction": ""
     },
     "sync.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537737586325,
+      "nextUpdateTime": 1537713247533,
       "userAction": ""
     },
-    "sync.ligadx.com": {
+    "sync.mathtag.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537675130279,
-      "userAction": ""
-    },
-    "sync.republer.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537368029758,
-      "userAction": ""
-    },
-    "sync.richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537373667725,
-      "userAction": ""
-    },
-    "sync.rtk.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537438607619,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537572759329,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537746332850,
+      "nextUpdateTime": 1537835499899,
       "userAction": ""
     },
-    "sync.smartadserver.com": {
+    "sync.teads.tv": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537766547773,
-      "userAction": ""
-    },
-    "synchrobox.adswizz.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537439021499,
-      "userAction": ""
-    },
-    "syndicate.purch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537775007522,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537624685346,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -9432,16 +3804,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "t.go.sohu.com": {
+    "t.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537429225959,
-      "userAction": ""
-    },
-    "t.myvisualiq.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537836131650,
+      "nextUpdateTime": 1537621436426,
       "userAction": ""
     },
     "taboola.com": {
@@ -9450,100 +3816,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tacdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tag-st.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537797203868,
-      "userAction": ""
-    },
-    "tag.1rx.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537585272654,
-      "userAction": ""
-    },
-    "tag.audience.acpm.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537369303732,
-      "userAction": ""
-    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537457560422,
-      "userAction": ""
-    },
-    "tag.crsspxl.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537414702710,
-      "userAction": ""
-    },
-    "tag.marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537361910910,
+      "nextUpdateTime": 1537914093330,
       "userAction": ""
     },
     "tag.mtrcs.samba.tv": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537761990796,
+      "nextUpdateTime": 1537709296119,
       "userAction": ""
     },
-    "tag.simpli.fi": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799787981,
-      "userAction": ""
-    },
-    "tag.yieldoptimizer.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537481702986,
-      "userAction": ""
-    },
-    "tag4arm.com": {
+    "tag.placelocal.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tagdelivery.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537534262582,
       "userAction": ""
     },
     "tags.news.com.au": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537825585746,
-      "userAction": ""
-    },
-    "tags.tiqcdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537390203950,
-      "userAction": ""
-    },
-    "tailtarget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tajs.qq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537795036993,
+      "nextUpdateTime": 1537538118661,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -9552,64 +3846,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tamgrt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tanx.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "taobao.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537792100705,
+      "nextUpdateTime": 1537538702540,
       "userAction": ""
     },
-    "tapad.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tapestry.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537802206816,
-      "userAction": ""
-    },
-    "targetimg1.com": {
+    "target.smi2.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537577942085,
       "userAction": ""
     },
     "tawk.to": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tcell.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tcr.tynt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537422227391,
       "userAction": ""
     },
     "teads.tv": {
@@ -9624,51 +3876,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "technolutions.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "techweb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "telegraph.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "telekom.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tenmax.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "theadex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "theatlas.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -9678,67 +3888,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "theglobeandmail.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "theguardian.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thesaurus.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thinkgeek.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537608202466,
-      "userAction": ""
-    },
-    "thomsonreuters.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thor.rtk.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537764216764,
-      "userAction": ""
-    },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537739186815,
-      "userAction": ""
-    },
-    "tianqi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537640116700,
       "userAction": ""
     },
     "tianqijun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tidaltv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tidelinedata.io": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -9753,13 +3915,7 @@
     "timeinc.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537637598661,
-      "userAction": ""
-    },
-    "timewarnercable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537729256682,
       "userAction": ""
     },
     "tinypass.com": {
@@ -9768,34 +3924,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tiqcdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tl813.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537475678086,
-      "userAction": ""
-    },
-    "tm-awx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tmall.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537937981013,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -9804,91 +3936,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "toutapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tr.snapchat.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537509861759,
-      "userAction": ""
-    },
-    "tracc.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537465663923,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537432463431,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537563288279,
       "userAction": ""
     },
-    "track.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537794217305,
-      "userAction": ""
-    },
-    "trackad.cz": {
+    "track.tiara.daum.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trackalyzer.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537497236250,
       "userAction": ""
     },
     "tracker.marinsm.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537519381223,
-      "userAction": ""
-    },
-    "tracking.g2crowd.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537651186961,
-      "userAction": ""
-    },
-    "tradedoubler.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tradelab.fr": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537499812373,
       "userAction": ""
     },
     "traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficgate.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficjam.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficjunky.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -9900,34 +3972,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "travelsmarter.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "travelzoo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trb.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "trc.taboola.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537654829828,
-      "userAction": ""
-    },
-    "treasuredata.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537523400406,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -9944,8 +3992,8 @@
     },
     "trends.revcontent.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537473262788,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537901532266,
       "userAction": ""
     },
     "tribalfusion.com": {
@@ -9954,46 +4002,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tribl.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537727228092,
-      "userAction": ""
-    },
-    "tribune-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537793636673,
-      "userAction": ""
-    },
-    "tripadvisor.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "trk.connatix.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537646261561,
-      "userAction": ""
-    },
-    "tronc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trumba.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "truoptik.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537686193338,
       "userAction": ""
     },
     "trustarc.com": {
@@ -10002,57 +4014,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trustev.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustpilot.com": {
+    "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trvl-px.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tumblr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tunein-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537615441924,
+      "nextUpdateTime": 1537581901703,
       "userAction": ""
     },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tutorialize.me": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "twimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -10068,172 +4038,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "u.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537677503216,
-      "userAction": ""
-    },
-    "ubi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ubm.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537705898178,
-      "userAction": ""
-    },
-    "ubmtech.d3.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537437892324,
-      "userAction": ""
-    },
-    "uc.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uciservice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uconnect.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537521871493,
-      "userAction": ""
-    },
-    "ucoz.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "udc.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537701535395,
-      "userAction": ""
-    },
     "udmserve.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537830458005,
-      "userAction": ""
-    },
-    "udnfunlife.com": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537562185323,
       "userAction": ""
     },
-    "uefa.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ufpcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ugdturner.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "undertone.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unicc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unity.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "universal.iperceptions.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537766557540,
-      "userAction": ""
-    },
-    "unrulymedia.com": {
+    "uid1.vindicosuite.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "upload.wikimedia.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537765558445,
-      "userAction": ""
-    },
-    "upravel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ups.xplosion.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537564083854,
-      "userAction": ""
-    },
-    "upsellit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uptolike.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "urbandictionary.store": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537610408164,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537544399857,
+      "nextUpdateTime": 1537452363796,
       "userAction": ""
     },
-    "usa.gov": {
+    "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537575881910,
       "userAction": ""
     },
-    "use.fontawesome.com": {
+    "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537518629707,
+      "nextUpdateTime": 1537608830235,
       "userAction": ""
     },
     "useproof.com": {
@@ -10242,76 +4074,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "usergram.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "usermatch.krxd.net": {
+    "usw-lax.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537768416740,
-      "userAction": ""
-    },
-    "userreport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uservoice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ustream.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537763324807,
       "userAction": ""
     },
     "utarget.pro": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537715148141,
       "userAction": ""
     },
     "utarget.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537682726445,
       "userAction": ""
     },
     "uuidksinc.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "v-biz.com.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537691187295,
-      "userAction": ""
-    },
-    "v.admaster.com.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537760885729,
-      "userAction": ""
-    },
-    "v12group.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537618704274,
       "userAction": ""
     },
     "va.tawk.to": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537721859977,
+      "nextUpdateTime": 1537805440945,
+      "userAction": ""
+    },
+    "va.v.liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537878052703,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -10320,55 +4116,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vdna.exelator.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537771496545,
-      "userAction": ""
-    },
     "veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "velaro.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "velemh.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vendorlist.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537403676675,
-      "userAction": ""
-    },
-    "verticalhealth.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "veruta.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viafoura.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viafoura.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -10380,51 +4128,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "video.unrulymedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537782142671,
-      "userAction": ""
-    },
-    "videoamp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "videohub.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vidible.tv": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "vidthm.ora.tv": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537477029499,
+      "nextUpdateTime": 1537694615731,
       "userAction": ""
     },
     "viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vilynx.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vimeo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -10434,39 +4146,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "virgilio.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "visitor-service.tealiumiq.com": {
+    "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537799150088,
+      "nextUpdateTime": 1537952472327,
       "userAction": ""
     },
-    "visualstudio.com": {
+    "vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vizury.com": {
+    "vmss.boldchat.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vk.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537484944655,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537657186694,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -10476,106 +4176,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "vop.sundaysky.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537667727470,
+      "userAction": ""
+    },
     "voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vra.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537372893107,
-      "userAction": ""
-    },
-    "vt.myvisualiq.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537392092577,
-      "userAction": ""
-    },
-    "vtracy.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "w.estat.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537390527951,
-      "userAction": ""
-    },
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537704386281,
+      "nextUpdateTime": 1537733912036,
       "userAction": ""
     },
-    "w55c.net": {
+    "wal.wolfram.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537708569754,
       "userAction": ""
     },
     "walker.zdbb.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537551711649,
+      "nextUpdateTime": 1537817167307,
       "userAction": ""
     },
-    "wallst.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "waptime.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "warnerbros.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wbtrk.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wcfbc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "weather.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "web.hb.ad.cpe.dotomi.com": {
+    "wamfactory.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537534654400,
-      "userAction": ""
-    },
-    "webapi.amap.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537808140820,
-      "userAction": ""
-    },
-    "webmd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537870871496,
       "userAction": ""
     },
     "weborama.fr": {
@@ -10584,33 +4218,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "webpush.jp": {
+    "webservices.webspectator.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "websimages.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537861304752,
       "userAction": ""
     },
     "webspectator.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webtrekk.net": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -10620,55 +4236,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "weibo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "welt.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "whistleout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "widget.intercom.io": {
+    "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537639408737,
-      "userAction": ""
-    },
-    "widget.trustpilot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537670990997,
-      "userAction": ""
-    },
-    "wikia-services.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wikimedia.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537948250508,
       "userAction": ""
     },
     "wired.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wise.space": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -10680,42 +4254,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wishpond.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wishpond.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wistia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wistia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wkxppshj-qx.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1534814085104,
-      "userAction": ""
-    },
     "wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -10725,13 +4263,7 @@
     "wms-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537611241426,
-      "userAction": ""
-    },
-    "wnyc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537745601171,
       "userAction": ""
     },
     "wolfram.com": {
@@ -10740,52 +4272,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "woobi.com": {
+    "workandmoney.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "woopic.com": {
+    "ws.sessioncam.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wordpress.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wpa.b.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537448937513,
-      "userAction": ""
-    },
-    "wrating.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537883425353,
       "userAction": ""
     },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537665034342,
-      "userAction": ""
-    },
-    "wsj.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wsj.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537679101909,
       "userAction": ""
     },
     "wsod.com": {
@@ -10800,40 +4302,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wurfl.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "www.adobe.com": {
+    "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537540833671,
+      "nextUpdateTime": 1537627118861,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799321575,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537706516009,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537461039809,
-      "userAction": ""
-    },
-    "www.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537574970651,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537908698667,
       "userAction": ""
     },
     "www.beian.gov.cn": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537480285803,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537855591308,
       "userAction": ""
     },
     "www.bing.com": {
@@ -10844,50 +4334,56 @@
     },
     "www.bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537851521637,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537879830064,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537365353809,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537909715373,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537520910008,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537937591373,
       "userAction": ""
     },
-    "www.dianomi.com": {
+    "www.dezeenjobs.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537640298123,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537949042270,
+      "userAction": ""
+    },
+    "www.ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537620501826,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537724529833,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537576232432,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537464851481,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537544039300,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537760960508,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537485773610,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537799445735,
       "userAction": ""
     },
     "www.google.com": {
@@ -10898,247 +4394,127 @@
     },
     "www.gq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537354236819,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537796743624,
       "userAction": ""
     },
-    "www.i.matheranalytics.com": {
+    "www.gstatic.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537402536555,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1537700151945,
+      "userAction": ""
+    },
+    "www.iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537685163688,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537615612808,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537892903107,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537846847698,
+      "nextUpdateTime": 1537512827112,
       "userAction": ""
     },
     "www.mediawiki.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537533602826,
+      "nextUpdateTime": 1537848643853,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537546486685,
-      "userAction": ""
-    },
-    "www.oneroof.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537526938662,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537683006702,
       "userAction": ""
     },
     "www.ora.tv": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537734634546,
-      "userAction": ""
-    },
-    "www.pitchfork.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537448172452,
+      "nextUpdateTime": 1537655020701,
       "userAction": ""
     },
     "www.proximus.be": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537731946589,
+      "nextUpdateTime": 1537909677592,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537423549639,
-      "userAction": ""
-    },
-    "www.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537618728365,
-      "userAction": ""
-    },
-    "www.storygize.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537685152059,
-      "userAction": ""
-    },
-    "www.surveymonkey.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537347584940,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537623685582,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537680393073,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537917019886,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537822090803,
-      "userAction": ""
-    },
-    "www.uc.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537409103798,
-      "userAction": ""
-    },
-    "www.upsellit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537508994767,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537575717845,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537800911503,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537930791168,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537399082566,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537876466089,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537800034799,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1537491819248,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537703552969,
-      "userAction": ""
-    },
-    "www.youtube-nocookie.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537401779022,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537678614153,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537660398102,
-      "userAction": ""
-    },
-    "www.youvisit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537642530250,
-      "userAction": ""
-    },
-    "www6.smartadserver.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537409222520,
-      "userAction": ""
-    },
-    "wwwimages.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wwwimages2.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537378943643,
-      "userAction": ""
-    },
-    "wywyuserservice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537896897167,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537334715420,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1537567605963,
       "userAction": ""
     },
-    "x.dlx.addthis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537642192469,
-      "userAction": ""
-    },
-    "xad.com": {
+    "x01.aidata.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537635458423,
       "userAction": ""
     },
     "xe19io.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537688733133,
-      "userAction": ""
-    },
-    "xg4ken.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xinhuanet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537820696009,
       "userAction": ""
     },
     "xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xlisting.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xplosion.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xs4all.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xsdownload.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xxxlutz.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -11154,21 +4530,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yads.yjtag.yahoo.co.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537757512577,
-      "userAction": ""
-    },
-    "yahoo.co.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "yahoo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -11178,75 +4542,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yandex.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yastatic.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537640604689,
-      "userAction": ""
-    },
-    "yieldify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yieldoptimizer.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yjtag.yahoo.co.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537561557913,
-      "userAction": ""
-    },
-    "yldbt.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ymetrica1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1534873369486,
-      "userAction": ""
-    },
-    "yoox.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "yotpo.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "youtube-nocookie.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -11256,34 +4554,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "youvisit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ypcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yudu.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537714456731,
+      "nextUpdateTime": 1537634465236,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537495785296,
+      "nextUpdateTime": 1537573698898,
       "userAction": ""
     },
     "zassets.com": {
@@ -11295,13 +4575,7 @@
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537784435648,
-      "userAction": ""
-    },
-    "zedo.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1537925998104,
       "userAction": ""
     },
     "zemanta.com": {
@@ -11310,99 +4584,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "zendesk.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zergnet.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zhaopin.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zhiziyun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "zidtech.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ziffdavis-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537793130072,
-      "userAction": ""
-    },
-    "ziffdavis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zn23mecwvtuhqn9gz-careerbuilder.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537360405071,
-      "userAction": ""
-    },
-    "zn5aocakgjj2uagxj-nintendoofamerica.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537772219683,
-      "userAction": ""
-    },
-    "zn9yauo1hia5mptaj-sni.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537680786191,
-      "userAction": ""
-    },
-    "zn_5u81q8n4jdu5ls9-cbs.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537550926929,
-      "userAction": ""
-    },
-    "zn_a9290jo7eb4diuz-mayoclinicsurveys.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537460499021,
-      "userAction": ""
-    },
-    "zna3ibgvbbhforp7n-web.siteintercept.qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537346781528,
-      "userAction": ""
-    },
-    "zoho.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zohopublic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zoomph.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -11415,45 +4599,27 @@
   },
   "snitch_map": {
     "126.net": [
-      "163.com",
-      "fotki.com"
-    ],
-    "127.net": [
       "163.com"
     ],
     "15gifts.com": [
       "thetimes.co.uk"
     ],
     "1dmp.io": [
-      "tomsk.ru",
-      "diary.ru"
-    ],
-    "1rx.io": [
-      "tinyurl.com",
-      "lycos.com",
-      "photobucket.com"
-    ],
-    "23video.com": [
-      "bandcamp.com"
-    ],
-    "247-inc.net": [
-      "marriott.com"
+      "radikal.ru"
     ],
     "247realmedia.com": [
       "bmj.com",
-      "aappublications.org",
       "americanbar.org"
     ],
-    "2hanwriten.com": [
-      "tinypic.com"
-    ],
-    "2mdnsys.com": [
-      "liveuamap.com"
-    ],
     "2o7.net": [
-      "mysql.com",
       "cdc.gov",
-      "theatlantic.com"
+      "prnewswire.com",
+      "fastcompany.com",
+      "earthlink.net",
+      "qz.com",
+      "philips.com",
+      "cancer.gov",
+      "oclc.org"
     ],
     "33across.com": [
       "accuweather.com"
@@ -11461,26 +4627,20 @@
     "360.cn": [
       "so.com"
     ],
-    "360buyimg.com": [
-      "jd.com"
-    ],
     "360yield.com": [
       "springer.com",
-      "home.pl",
-      "allafrica.com"
+      "economist.com",
+      "home.pl"
     ],
     "3gl.net": [
-      "istockphoto.com",
-      "gettyimages.com",
       "economist.com"
     ],
     "3lift.com": [
-      "nature.com",
-      "springer.com",
-      "theverge.com"
-    ],
-    "4dsply.com": [
-      "wnd.com"
+      "msn.com",
+      "usatoday.com",
+      "nginx.org",
+      "space.com",
+      "polygon.com"
     ],
     "50bang.org": [
       "2345.com"
@@ -11492,50 +4652,27 @@
       "ganji.com"
     ],
     "5p4rk13.com": [
-      "sfu.ca",
-      "cdbaby.com"
+      "sfu.ca"
     ],
     "6sc.co": [
-      "zendesk.com",
-      "gotomeeting.com",
-      "rsa.com"
-    ],
-    "7eer.net": [
-      "lenovo.com",
-      "adidas.com"
-    ],
-    "7grid.com": [
-      "mihanblog.com"
+      "brightcove.com"
     ],
     "aamsitecertifier.com": [
-      "smh.com.au",
       "theglobeandmail.com",
-      "bostonglobe.com"
-    ],
-    "aaxads.com": [
-      "forbes.com"
+      "bostonglobe.com",
+      "post-gazette.com"
     ],
     "abmr.net": [
-      "paypal.com",
-      "nike.com"
+      "nike.com",
+      "freetype.org"
     ],
     "accessatlanta.com": [
       "ajc.com"
     ],
-    "accuweather.com": [
-      "miamiherald.com",
-      "sacbee.com",
-      "kansascity.com"
-    ],
-    "acint.net": [
-      "tomsk.ru",
-      "radikal.ru",
-      "diary.ru"
-    ],
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr"
+      "leparisien.fr"
     ],
     "acquia.com": [
       "panasonic.com",
@@ -11549,185 +4686,150 @@
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "bartleby.com"
+      "dropbox.com",
+      "businessinsider.com"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
+    "ad-plus.cn": [
+      "sohu.com"
+    ],
     "ad-stir.com": [
       "sakura.ne.jp",
-      "biglobe.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com",
-      "yesky.com"
+      "huanqiu.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
     ],
-    "adaraanalytics.com": [
-      "hyatt.com"
-    ],
     "adc-srv.net": [
       "autodesk.com"
     ],
-    "adclear.net": [
-      "t-online.de"
-    ],
     "addroplet.com": [
-      "wallinside.com",
-      "wnd.com",
-      "washingtonexaminer.com"
+      "washingtonexaminer.com",
+      "wnd.com"
     ],
     "addthis.com": [
-      "nasa.gov",
-      "jimdo.com",
-      "yahoo.com"
-    ],
-    "addtoany.com": [
-      "irs.gov"
+      "who.int",
+      "columbia.edu",
+      "giphy.com",
+      "heart.org",
+      "gulfnews.com"
     ],
     "adentifi.com": [
-      "metmuseum.org",
-      "infoplease.com"
+      "metmuseum.org"
     ],
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com"
+      "springer.com",
+      "si.com",
+      "goal.com"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "rambler.ru"
-    ],
-    "adfront.org": [
-      "joomla.org"
+      "sputniknews.com"
     ],
     "adhigh.net": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru"
-    ],
-    "adidas.fi": [
-      "adidas.com"
+      "rambler.ru"
     ],
     "adingo.jp": [
-      "biglobe.ne.jp"
+      "seesaa.jp"
     ],
     "adition.com": [
-      "bloomberg.com",
-      "dailymotion.com",
-      "spiegel.de"
+      "variety.com",
+      "lemonde.fr",
+      "sueddeutsche.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
     "adkernel.com": [
-      "venturebeat.com",
       "livescience.com",
-      "space.com"
-    ],
-    "adlmerge.com": [
-      "tomsk.ru"
-    ],
-    "admaster.com.cn": [
-      "autohome.com.cn",
-      "bshare.cn",
-      "yesky.com"
+      "space.com",
+      "howtogeek.com",
+      "dailydot.com"
     ],
     "admission.net": [
       "edmunds.com"
     ],
-    "admixer.net": [
-      "space.com"
-    ],
     "adnxs.com": [
-      "yahoo.com",
-      "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "dropbox.com",
+      "seattletimes.com",
+      "rfi.fr"
     ],
     "adobe.com": [
-      "wikipedia.org",
-      "apache.org",
       "behance.net",
       "history.com",
       "nbc.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
-      "bbb.org",
-      "bizjournals.com"
+      "worldbank.org",
+      "nbcnews.com",
+      "aarp.org",
+      "networksolutions.com"
     ],
     "adotmob.com": [
-      "standard.co.uk",
-      "upwork.com"
+      "variety.com"
     ],
     "adriver.ru": [
       "ria.ru",
-      "rambler.ru",
-      "tomsk.ru"
+      "home.pl"
     ],
     "adroll.com": [
-      "stumbleupon.com",
-      "nature.com",
-      "nginx.org"
+      "nginx.org",
+      "cloudflare.com",
+      "ning.com",
+      "salesforce.com",
+      "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
-      "bloomberg.com",
-      "springer.com"
+      "springer.com",
+      "home.pl"
     ],
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "informationweek.com"
-    ],
-    "adsniper.ru": [
-      "rambler.ru"
+      "squareup.com",
+      "bostonherald.com"
     ],
     "adsrvr.org": [
       "adobe.com",
-      "yahoo.com",
-      "googletagmanager.com"
+      "sourceforge.net",
+      "nytimes.com",
+      "seattletimes.com",
+      "colourlovers.com"
     ],
     "adswizz.com": [
+      "variety.com",
       "iheart.com",
-      "tunein.com",
-      "variety.com"
+      "tunein.com"
     ],
     "adsymptotic.com": [
-      "tinyurl.com",
       "etsy.com",
-      "tripadvisor.com"
-    ],
-    "adtags.pro": [
-      "tomsk.ru"
-    ],
-    "adtdp.com": [
-      "biglobe.ne.jp"
+      "tripadvisor.com",
+      "economist.com",
+      "space.com",
+      "colourlovers.com"
     ],
     "advertising.com": [
-      "amazon.com",
-      "sourceforge.net",
-      "dropbox.com"
-    ],
-    "advertur.ru": [
-      "radikal.ru"
-    ],
-    "adwstats.com": [
-      "cisco.com"
+      "dropbox.com",
+      "msn.com",
+      "wsj.com",
+      "norton.com",
+      "walgreens.com"
     ],
     "adx.com.ru": [
-      "rambler.ru",
-      "tomsk.ru"
-    ],
-    "adx1.com": [
-      "venturebeat.com",
-      "livescience.com",
-      "space.com"
+      "rambler.ru"
     ],
     "adzerk.net": [
       "asp.net"
@@ -11735,61 +4837,56 @@
     "aetnd.com": [
       "history.com"
     ],
-    "afilio.com.br": [
-      "mcafee.com"
-    ],
     "afkp.net": [
       "autodesk.com"
     ],
     "agkn.com": [
-      "amazon.com",
-      "t-online.de",
-      "bloomberg.com"
-    ],
-    "aid-ad.jp": [
-      "shinobi.jp"
+      "dropbox.com",
+      "cnet.com",
+      "businessinsider.com",
+      "cbs.com",
+      "gizmodo.com"
     ],
     "aidata.io": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru"
-    ],
-    "aili.com": [
-      "sina.com.cn"
-    ],
-    "ajx130.online": [
       "radikal.ru"
     ],
     "akamaihd.net": [
+      "forbes.com",
       "voanews.com",
-      "repubblica.it",
-      "iyfubh.com"
+      "cracked.com"
     ],
     "akamaized.net": [
       "tamu.edu",
       "microsoft.com",
-      "nbc.com",
-      "purevolume.com"
+      "xbox.com",
+      "rice.edu",
+      "blizzard.com",
+      "office.com",
+      "jugem.jp"
     ],
     "albacross.com": [
       "rebelmouse.com"
     ],
     "alibaba.com": [
-      "youku.com",
-      "taobao.com",
+      "tmall.com",
       "aliexpress.com",
-      "tmall.com"
+      "alibabacloud.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
-      "alibaba.com",
       "youku.com",
-      "aliexpress.com",
-      "1688.com"
+      "sohu.com",
+      "taobao.com",
+      "alibaba.com",
+      "1688.com",
+      "toutiao.com",
+      "2345.com",
+      "tmall.com"
     ],
     "alipay.com": [
-      "alibaba.com",
-      "youku.com"
+      "youku.com",
+      "taobao.com",
+      "tmall.com"
     ],
     "aliyun.com": [
       "alibabacloud.com",
@@ -11797,30 +4894,24 @@
     ],
     "allure.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
-    ],
-    "am15.net": [
-      "radikal.ru"
-    ],
-    "amap.com": [
-      "zhaopin.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "amazon-adsystem.com": [
       "amazon.com",
-      "nytimes.com",
-      "reddit.com"
+      "vimeo.com",
+      "reddit.com",
+      "nifty.com",
+      "pitchfork.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
     ],
     "amazon.com": [
-      "qq.com",
       "imdb.com",
       "amazon.co.uk",
       "amazon.de",
-      "amazon.co.jp",
-      "amazon.ca"
+      "amazon.co.jp"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -11834,142 +4925,89 @@
     "answerscloud.com": [
       "worldbank.org",
       "acs.org",
-      "fbi.gov"
-    ],
-    "antdsp.com": [
-      "hc360.com"
+      "fbi.gov",
+      "aarp.org",
+      "walgreens.com"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
     "aol.com": [
-      "engadget.com",
-      "indiatimes.com",
-      "autoblog.com"
-    ],
-    "ap.org": [
-      "post-gazette.com"
-    ],
-    "apester.com": [
-      "deadline.com",
-      "searchenginewatch.com",
-      "nme.com"
+      "techcrunch.com"
     ],
     "apn.co.nz": [
       "nzherald.co.nz"
     ],
     "app.link": [
+      "medium.com",
       "foursquare.com",
       "history.com",
-      "nbc.com"
-    ],
-    "appdynamics.com": [
-      "nfl.com"
+      "nbc.com",
+      "strava.com"
     ],
     "apple.com": [
-      "digitaltrends.com",
-      "icloud.com",
-      "softpedia.com"
+      "digitaltrends.com"
     ],
-    "aqtracker.com": [
-      "nikkei.com"
-    ],
-    "arcgis.com": [
-      "chron.com"
+    "apvdr.com": [
+      "goo.ne.jp"
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
     ],
-    "areyouahuman.com": [
-      "reuters.com",
-      "merriam-webster.com",
-      "accuweather.com"
-    ],
-    "arrivalist.com": [
-      "philly.com"
-    ],
     "art19.com": [
       "coindesk.com"
     ],
-    "asos-media.com": [
-      "asos.com"
-    ],
     "atdmt.com": [
       "facebook.com",
-      "yahoo.com",
-      "msn.com"
+      "shutterfly.com",
+      "xbox.com",
+      "slack.com"
     ],
     "atemda.com": [
       "springer.com",
       "home.pl"
     ],
-    "atgsvcs.com": [
-      "oracle.com",
-      "xerox.com"
-    ],
     "ati-host.net": [
-      "straitstimes.com",
       "bbc.co.uk",
-      "thestar.com.my"
+      "straitstimes.com"
     ],
     "att.com": [
       "att.net"
     ],
-    "atwola.com": [
-      "huffingtonpost.com",
-      "aol.com",
-      "techcrunch.com"
-    ],
-    "audtd.com": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "autoimg.cn": [
-      "autohome.com.cn"
+    "auone.jp": [
+      "goo.ne.jp"
     ],
     "autopilothq.com": [
       "bitbucket.org",
-      "rfc-editor.org",
-      "typeform.com"
-    ],
-    "b1img.com": [
-      "threadless.com"
+      "typeform.com",
+      "atlassian.com"
     ],
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com"
+      "sohu.com",
+      "ce.cn",
+      "qianlong.com"
     ],
     "bam-x.com": [
       "gq.com"
     ],
+    "barnebys.com": [
+      "lemonde.fr"
+    ],
+    "baur.de": [
+      "t-online.de"
+    ],
     "bazaarvoice.com": [
-      "target.com",
-      "lenovo.com",
       "motorola.com"
-    ],
-    "bbb.org": [
-      "penders.com",
-      "afternic.com",
-      "sedo.com"
-    ],
-    "bbbpromos.org": [
-      "bbb.org"
     ],
     "bbc.co.uk": [
       "bbc.com"
-    ],
-    "bbelements.com": [
-      "idnes.cz"
-    ],
-    "beatport.com": [
-      "tmall.com"
     ],
     "beemray.com": [
       "telegraph.co.uk",
@@ -11977,87 +5015,74 @@
     ],
     "beian.gov.cn": [
       "dzwww.com",
-      "ku6.com",
       "qianlong.com"
     ],
-    "benchtag2.co": [
-      "sbs.com.au"
-    ],
-    "betweendigital.com": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
     "bfmio.com": [
-      "symantec.com",
       "tinypic.com",
-      "venturebeat.com"
-    ],
-    "bfmtv.com": [
-      "liberation.fr",
-      "lexpress.fr"
+      "livescience.com",
+      "space.com",
+      "dailydot.com"
     ],
     "biddingx.com": [
       "sina.com.cn"
     ],
     "bidr.io": [
       "adobe.com",
-      "dailymotion.com",
-      "hootsuite.com"
+      "hp.com",
+      "symantec.com",
+      "sap.com",
+      "box.com"
     ],
     "bidswitch.net": [
-      "yahoo.com",
-      "google.com",
-      "amazon.com"
+      "dropbox.com",
+      "tinyurl.com",
+      "usatoday.com",
+      "seattletimes.com",
+      "colourlovers.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
-    ],
-    "bigmir.net": [
-      "kharkov.ua",
-      "kh.ua"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "office.com"
-    ],
-    "bitbucket.org": [
-      "atlassian.com"
+      "sap.com",
+      "office.com",
+      "pingdom.com"
     ],
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com"
+      "ibm.com",
+      "eventbrite.co.uk",
+      "gitlab.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
     ],
     "bizographics.com": [
-      "zend.com",
-      "nginx.com",
-      "oreilly.com"
+      "jimdo.com",
+      "surveymonkey.com",
+      "techcrunch.com"
     ],
     "bizrate.com": [
+      "time.com",
       "fortune.com",
-      "people.com",
-      "ew.com"
-    ],
-    "blogos.com": [
-      "livedoor.com"
-    ],
-    "bloomberg.com": [
-      "macrumors.com"
+      "ew.com",
+      "sourceforge.net",
+      "travelandleisure.com"
     ],
     "bluecava.com": [
-      "history.com",
-      "biography.com"
+      "giphy.com",
+      "walmart.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
-      "theatlantic.com",
-      "sfgate.com"
+      "sfgate.com",
+      "chron.com",
+      "startribune.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -12066,75 +5091,66 @@
       "variety.com"
     ],
     "bnidx.com": [
-      "jigsy.com",
-      "bravenet.com"
-    ],
-    "bobo.com": [
-      "163.com"
+      "bravenet.com",
+      "jigsy.com"
     ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org"
+      "cancer.org",
+      "groupon.com",
+      "networksolutions.com"
     ],
     "bonappetit.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "boston.com": [
       "bostonglobe.com"
     ],
-    "botradar.tech": [
-      "radikal.ru"
-    ],
-    "boudja.com": [
-      "4shared.com"
+    "bostonglobemedia.com": [
+      "boston.com"
     ],
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com"
+      "usatoday.com",
+      "dictionary.com",
+      "pitchfork.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
     ],
     "brides.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "brightcove.com": [
-      "scholastic.com",
-      "si.com",
-      "federalreserve.gov",
       "aarp.org",
-      "informationweek.com"
+      "theaustralian.com.au",
+      "informationweek.com",
+      "scholastic.com"
     ],
     "brightcove.net": [
-      "lefigaro.fr",
-      "politico.com",
-      "bostonglobe.com"
-    ],
-    "bshare.cn": [
-      "qianlong.com"
+      "aljazeera.com",
+      "lonelyplanet.com",
+      "techtarget.com",
+      "thenational.ae"
     ],
     "bttrack.com": [
-      "yahoo.com",
-      "independent.co.uk",
-      "zendesk.com"
+      "mirror.co.uk",
+      "nypost.com",
+      "livescience.com",
+      "salesforce.com",
+      "dailydot.com"
     ],
     "btttag.com": [
-      "samsung.com",
-      "marriott.com",
-      "ihg.com"
-    ],
-    "bumlam.com": [
-      "rambler.ru"
+      "marriott.com"
     ],
     "c-ctrip.com": [
-      "ctrip.com",
-      "qunar.com"
+      "ctrip.com"
     ],
     "c212.net": [
       "prnewswire.com"
@@ -12145,29 +5161,24 @@
     "cadreon.com": [
       "economist.com"
     ],
-    "caltat.com": [
-      "live4fun.ru"
-    ],
-    "candlewoodsuites.com": [
-      "ihg.com"
-    ],
-    "capturehighered.net": [
-      "ku.edu",
-      "unm.edu"
-    ],
     "carambo.la": [
-      "accuweather.com",
-      "salon.com"
+      "salon.com",
+      "accuweather.com"
     ],
     "casalemedia.com": [
-      "amazon.com",
       "dropbox.com",
-      "myspace.com"
+      "myspace.com",
+      "washingtonpost.com",
+      "techradar.com",
+      "colourlovers.com"
     ],
     "cbsi.com": [
-      "zdnet.com",
+      "cnet.com",
+      "cbsnews.com",
       "last.fm",
-      "gamespot.com"
+      "gamespot.com",
+      "cbs.com",
+      "techrepublic.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -12176,15 +5187,8 @@
       "softonic.com",
       "biography.com"
     ],
-    "cdn-apple.com": [
-      "icloud.com"
-    ],
-    "cdn-hotels.com": [
-      "hotels.com"
-    ],
     "cdn-net.com": [
-      "hotels.com",
-      "americanexpress.com"
+      "hotels.com"
     ],
     "cdnwidget.com": [
       "photoshelter.com"
@@ -12195,78 +5199,49 @@
     "changeagain.me": [
       "iconosquare.com"
     ],
-    "charitynavigator.org": [
-      "heart.org"
-    ],
     "chei.com.cn": [
       "chsi.com.cn"
     ],
-    "chicagotribune.com": [
-      "wikipedia.org"
-    ],
-    "chinajob.com": [
-      "china.org.cn"
-    ],
     "chinaso.com": [
-      "weather.com.cn",
-      "chinanews.com"
-    ],
-    "chinavivaki.com": [
-      "bshare.cn"
+      "weather.com.cn"
     ],
     "choozle.com": [
-      "denverpost.com",
-      "photobucket.com"
+      "photobucket.com",
+      "denverpost.com"
     ],
     "circularhub.com": [
       "suntimes.com",
+      "stltoday.com",
       "tampabay.com",
       "bostonherald.com"
     ],
     "civicscience.com": [
-      "post-gazette.com",
-      "knowyourmeme.com",
-      "ebaumsworld.com"
+      "post-gazette.com"
     ],
     "ckies.net": [
       "abril.com.br"
     ],
-    "cleveland.com": [
-      "nola.com"
-    ],
     "clickability.com": [
-      "prnewswire.com",
       "philly.com",
       "proquest.com"
-    ],
-    "clicktale.net": [
-      "xbox.com",
-      "office.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
       "mapquest.com"
     ],
-    "clmbtech.com": [
-      "indiatimes.com"
-    ],
     "cloudflare.com": [
-      "uci.edu",
-      "nbcnews.com",
       "sciencemag.org",
+      "uci.edu",
       "symantec.com",
       "allaboutcookies.org"
     ],
     "cnet.com": [
       "zdnet.com"
     ],
-    "cnn.net": [
-      "cnn.com"
-    ],
     "cntraveler.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "cnzz.com": [
       "zol.com.cn"
@@ -12274,20 +5249,11 @@
     "cobaltgroup.com": [
       "edmunds.com"
     ],
-    "coherentpath.com": [
-      "staples.com"
-    ],
     "cohesionapps.com": [
-      "americanexpress.com",
-      "admin.ch",
       "bankrate.com"
     ],
     "collegenet.com": [
-      "gmu.edu",
-      "ku.edu"
-    ],
-    "comm100.com": [
-      "hobbyking.com"
+      "gmu.edu"
     ],
     "commander1.com": [
       "ovh.com",
@@ -12297,125 +5263,91 @@
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com"
-    ],
-    "complex.com": [
-      "knowyourmeme.com",
-      "dailydot.com",
-      "ebaumsworld.com"
-    ],
-    "conative.de": [
-      "focus.de"
+      "hp.com",
+      "sap.com",
+      "box.com"
     ],
     "condenastdigital.com": [
       "wired.com",
+      "newyorker.com",
       "arstechnica.com",
-      "nj.com"
-    ],
-    "conductrics.com": [
-      "nginx.com"
+      "nj.com",
+      "pitchfork.com"
     ],
     "connatix.com": [
+      "jpost.com",
       "alternet.org",
-      "dailydot.com",
-      "jpost.com"
+      "dailydot.com"
     ],
     "connexity.net": [
       "sourceforge.net"
     ],
     "consensu.org": [
+      "buzzfeed.com",
       "rollingstone.com",
       "variety.com",
-      "adweek.com"
-    ],
-    "consumable.com": [
-      "xfinity.com"
+      "upi.com",
+      "washingtonexaminer.com"
     ],
     "content.ad": [
       "tinypic.com"
     ],
-    "contentabc.com": [
-      "pornhub.com"
-    ],
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "bloomberg.com"
-    ],
-    "convertful.com": [
-      "lifehack.org"
+      "usatoday.com",
+      "space.com",
+      "colourlovers.com"
     ],
     "convertro.com": [
-      "ibm.com",
-      "logitech.com",
       "slack.com"
-    ],
-    "convio.net": [
-      "diabetes.org"
     ],
     "cornell.edu": [
       "arxiv.org"
     ],
-    "cox.net": [
-      "cox.com"
-    ],
-    "coxbusiness.com": [
-      "cox.com"
-    ],
-    "cpex.cz": [
-      "idnes.cz"
+    "coxmediagroup.com": [
+      "ajc.com"
     ],
     "cpx.to": [
+      "independent.co.uk",
+      "mirror.co.uk",
       "express.co.uk",
-      "digitaltrends.com",
-      "techradar.com"
+      "techradar.com",
+      "rfi.fr"
     ],
     "cquotient.com": [
       "gopro.com"
     ],
-    "cr-nielsen.com": [
-      "youku.com"
+    "creative-serving.com": [
+      "tinyurl.com"
     ],
     "creativecdn.com": [
-      "ria.ru",
-      "udn.com"
-    ],
-    "creativecommons.org": [
-      "perl.com"
+      "ria.ru"
     ],
     "criteo.com": [
-      "tinyurl.com",
+      "dropbox.com",
+      "forbes.com",
       "washingtonpost.com",
-      "dailymail.co.uk"
-    ],
-    "croissed.info": [
-      "4shared.com"
-    ],
-    "crowneplaza.com": [
-      "ihg.com"
+      "fool.com",
+      "sedo.com"
     ],
     "crsspxl.com": [
       "sourceforge.net",
-      "slashdot.org",
-      "bartleby.com"
+      "slashdot.org"
     ],
     "cssrvsync.com": [
       "springer.com",
       "home.pl"
     ],
-    "ctv.ca": [
-      "ctvnews.ca"
-    ],
-    "curse.com": [
-      "wowdb.com"
-    ],
-    "custhelp.com": [
-      "oracle.com"
+    "ctrmi.com": [
+      "sina.com.cn"
     ],
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
-      "gizmodo.com"
+      "gizmodo.com",
+      "kotaku.com",
+      "coindesk.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -12424,13 +5356,14 @@
       "webnode.com"
     ],
     "d2-apps.net": [
-      "rakuten.co.jp",
-      "yahoo.co.jp"
+      "goo.ne.jp",
+      "asahi.com"
     ],
     "d41.co": [
+      "hp.com",
       "intel.com",
       "hpe.com",
-      "hp.com"
+      "sap.com"
     ],
     "da-ads.com": [
       "deviantart.com"
@@ -12438,117 +5371,73 @@
     "dailymail.co.uk": [
       "metro.co.uk"
     ],
-    "dailymotion.com": [
-      "google.com"
-    ],
     "datamind.ru": [
-      "novostimira.com",
       "rambler.ru",
-      "kharkov.ua"
-    ],
-    "datasteam.io": [
-      "ama-assn.org"
+      "novostimira.com"
     ],
     "daum.net": [
       "shutterstock.com",
       "tistory.com"
     ],
-    "daumcdn.net": [
-      "daum.net"
-    ],
-    "daumdn.com": [
-      "shutterstock.com"
-    ],
     "dc-storm.com": [
       "nike.com",
-      "shutterstock.com",
+      "alibabacloud.com",
       "bostonglobe.com"
-    ],
-    "deep.bi": [
-      "hrw.org"
-    ],
-    "dell.com": [
-      "rsa.com"
     ],
     "demdex.net": [
       "adobe.com",
-      "yahoo.com",
-      "amazon.com"
-    ],
-    "departapp.com": [
-      "liveuamap.com"
+      "amazon.com",
+      "soundcloud.com",
+      "bluehost.com",
+      "syfy.com"
     ],
     "deployads.com": [
       "tinyurl.com",
-      "lycos.com",
-      "sciencedaily.com"
-    ],
-    "deqwas.net": [
-      "rakuten.co.jp"
-    ],
-    "developermedia.com": [
-      "codeproject.com"
+      "sciencedaily.com",
+      "zerohedge.com"
     ],
     "dezeenjobs.com": [
       "dezeen.com"
     ],
-    "dhs.gov": [
-      "fema.gov"
+    "df-srv.de": [
+      "sueddeutsche.de"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
-      "starwars.com",
-      "go.com"
+      "starwars.com"
     ],
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com"
-    ],
-    "dictionary.com": [
-      "thesaurus.com"
-    ],
-    "digitaladsystems.com": [
-      "tomsk.ru"
+      "zerohedge.com"
     ],
     "digitaltarget.ru": [
-      "liveinternet.ru",
-      "rambler.ru",
-      "tomsk.ru"
+      "radikal.ru"
     ],
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk"
-    ],
-    "disney.com": [
-      "starwars.com"
+      "express.co.uk",
+      "theonion.com",
+      "bostonherald.com"
     ],
     "disqus.com": [
-      "pnas.org",
-      "dyn.com",
-      "mercurynews.com",
       "rollingstone.com",
-      "tmz.com",
-      "patch.com"
+      "dyn.com",
+      "mercurynews.com"
     ],
     "distiltag.com": [
-      "reuters.com"
+      "reuters.com",
+      "merriam-webster.com"
     ],
     "districtm.io": [
       "barnesandnoble.com",
-      "urbandictionary.com",
-      "axs.com"
-    ],
-    "djv99sxoqpv11.cloudfront.net": [
-      "4shared.com"
+      "seattletimes.com",
+      "miamiherald.com",
+      "colourlovers.com"
     ],
     "dmxleo.com": [
-      "dailymotion.com"
-    ],
-    "dnnapi.com": [
-      "zenfolio.com",
-      "gob.es"
+      "pastebin.com"
     ],
     "dol.gov": [
       "osha.gov"
@@ -12556,12 +5445,15 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com"
+      "tinypic.com",
+      "atlasobscura.com"
     ],
     "dotomi.com": [
-      "tinyurl.com",
       "samsung.com",
-      "webmd.com"
+      "economist.com",
+      "barnesandnoble.com",
+      "seattletimes.com",
+      "colourlovers.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -12569,47 +5461,39 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com"
-    ],
-    "doublemax.net": [
-      "udn.com"
+      "linkedin.com",
+      "billboard.com",
+      "syfy.com"
     ],
     "doublepimpssl.com": [
       "pornhub.com"
     ],
-    "doubleverify.com": [
-      "military.com",
-      "allafrica.com"
+    "dowjones.io": [
+      "marketwatch.com"
     ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com"
+      "adweek.com"
     ],
-    "dsp-rambler.ru": [
-      "rambler.ru"
+    "dsp.com": [
+      "qq.com"
+    ],
+    "dudintrec.ru": [
+      "radikal.ru"
     ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
-      "t-online.de",
       "cnbc.com",
-      "nbcnews.com"
-    ],
-    "dynatrace-managed.com": [
-      "delta.com"
-    ],
-    "dyntrk.com": [
-      "dailymotion.com",
-      "infoplease.com"
+      "nbcnews.com",
+      "norton.com",
+      "washingtonexaminer.com"
     ],
     "ebay-us.com": [
-      "ebay.com.au",
-      "ebay.com"
-    ],
-    "ebay.co.uk": [
-      "synacor.com"
+      "ebay.com",
+      "ebay.com.au"
     ],
     "ebay.com": [
       "ebay.co.uk",
@@ -12619,27 +5503,13 @@
     "ebayrtm.com": [
       "ebay.co.uk",
       "ebay.de",
-      "ebay.com",
       "ebay.com.au"
     ],
-    "ebdr3.com": [
-      "springer.com"
-    ],
     "ebis.ne.jp": [
-      "exblog.jp",
-      "xrea.com"
-    ],
-    "econda-monitor.de": [
-      "expedia.com"
-    ],
-    "ecustomeropinions.com": [
-      "skysports.com"
+      "exblog.jp"
     ],
     "edge-cdn.net": [
       "biomedcentral.com"
-    ],
-    "edmunds.com": [
-      "unenvironment.org"
     ],
     "effectivemeasure.net": [
       "bbc.com",
@@ -12648,11 +5518,12 @@
     ],
     "eloqua.com": [
       "intel.com",
-      "cisco.com",
-      "prnewswire.com"
+      "redhat.com",
+      "wisc.edu",
+      "thawte.com",
+      "eset.com"
     ],
     "elsevier.com": [
-      "sciencedirect.com",
       "thelancet.com",
       "cell.com"
     ],
@@ -12660,14 +5531,7 @@
       "thelancet.com",
       "cell.com"
     ],
-    "emc.com": [
-      "rsa.com"
-    ],
     "emlgrid.com": [
-      "home.pl"
-    ],
-    "emxdgt.com": [
-      "springer.com",
       "home.pl"
     ],
     "envato.com": [
@@ -12675,56 +5539,30 @@
     ],
     "epicurious.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
     ],
-    "espn.com": [
-      "fivethirtyeight.com"
-    ],
-    "estara.com": [
-      "xerox.com"
-    ],
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "lefigaro.fr"
-    ],
-    "etracker.de": [
-      "sedo.com"
-    ],
-    "etsystudio.com": [
-      "etsy.com"
-    ],
-    "evenhotels.com": [
-      "ihg.com"
-    ],
-    "eventsabout.com": [
-      "sacbee.com"
+      "tomshardware.com"
     ],
     "everesttech.net": [
       "adobe.com",
-      "yahoo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "seattletimes.com",
+      "colourlovers.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
     ],
     "evise.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
-    ],
-    "evolok.net": [
-      "scotsman.com"
-    ],
-    "evyy.net": [
-      "office.com"
-    ],
-    "ew3.io": [
-      "liberation.fr"
+      "thelancet.com",
+      "cell.com"
     ],
     "exactag.com": [
       "t-online.de"
@@ -12732,31 +5570,26 @@
     "excite.co.jp": [
       "exblog.jp"
     ],
-    "exe.bid": [
-      "rambler.ru"
-    ],
     "exelator.com": [
-      "soundcloud.com",
       "forbes.com",
-      "bloomberg.com"
-    ],
-    "exosrv.com": [
-      "pornhub.com"
-    ],
-    "expedia.com": [
-      "excite.com"
+      "businessinsider.com",
+      "talktalk.co.uk",
+      "bluehost.com",
+      "gizmodo.com"
     ],
     "eyeota.net": [
       "sourceforge.net",
-      "forbes.com",
-      "bloomberg.com"
+      "dropbox.com",
+      "wsj.com",
+      "space.com",
+      "zerohedge.com"
     ],
     "eyereturn.com": [
-      "thestar.com",
-      "queensu.ca"
+      "thestar.com"
     ],
     "eyeviewads.com": [
-      "staples.com"
+      "nypost.com",
+      "walgreens.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -12764,34 +5597,16 @@
     ],
     "facebook.com": [
       "instagram.com",
-      "wordpress.org",
-      "adobe.com"
-    ],
-    "facetz.net": [
-      "novostimira.com",
-      "rambler.ru",
-      "kharkov.ua"
-    ],
-    "fairfax.com.au": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "fastcompany.com": [
-      "fastcodesign.com"
+      "adobe.com",
+      "apple.com",
+      "bluehost.com",
+      "syfy.com"
     ],
     "fdlstatic.com": [
       "cnet.com"
     ],
     "feathr.co": [
-      "informationweek.com",
-      "eurogamer.net"
-    ],
-    "ffx.io": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "fidelity-media.com": [
-      "home.pl"
+      "informationweek.com"
     ],
     "filepicker.io": [
       "enlightenment.org",
@@ -12799,82 +5614,58 @@
     ],
     "firstimpression.io": [
       "jpost.com",
-      "serverwatch.com",
       "haaretz.com"
     ],
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu"
+      "aarp.org"
     ],
     "flickr.com": [
-      "state.gov",
       "oecd.org",
       "enable-javascript.com",
       "cia.gov",
       "ncsu.edu",
-      "gatech.edu"
+      "gatech.edu",
+      "colostate.edu"
     ],
     "flipboard.com": [
       "venturebeat.com",
-      "autoblog.com",
-      "popsugar.com"
-    ],
-    "flyercity.ca": [
-      "canada.com"
+      "popsugar.com",
+      "autoblog.com"
     ],
     "flyertown.ca": [
-      "canada.com",
+      "nationalpost.com",
       "globalnews.ca",
-      "nationalpost.com"
+      "vancouversun.com"
     ],
     "fontawesome.com": [
-      "socarrao.com.br",
-      "clinicaltrials.gov",
-      "moonfruit.com",
       "webex.com",
+      "ucsc.edu",
+      "jugem.jp",
       "sitepoint.com"
     ],
     "force.com": [
       "constantcontact.com",
+      "teamviewer.com",
       "salesforce.com"
     ],
     "foresee.com": [
       "epa.gov",
-      "si.edu",
-      "theglobeandmail.com"
+      "sec.gov",
+      "bls.gov",
+      "smithsonianmag.com"
     ],
     "formstack.com": [
       "in.gov"
     ],
-    "forretres.ru": [
-      "radikal.ru"
-    ],
     "fout.jp": [
       "economist.com",
-      "hatena.ne.jp"
-    ],
-    "fox.com": [
-      "nationalgeographic.com",
-      "foxnews.com",
-      "foxbusiness.com"
-    ],
-    "foxbusiness.com": [
-      "fox.com"
-    ],
-    "foxnews.com": [
-      "foxbusiness.com",
-      "fox.com"
-    ],
-    "foxsports.com": [
-      "fox.com"
+      "exblog.jp",
+      "goo.ne.jp"
     ],
     "foxycart.com": [
       "brookings.edu"
-    ],
-    "freeskreen.com": [
-      "nationalpost.com",
-      "wattpad.com"
     ],
     "freshdesk.com": [
       "podbean.com"
@@ -12882,166 +5673,122 @@
     "friendbuy.com": [
       "lulu.com"
     ],
-    "funcaptcha.com": [
-      "axs.com"
-    ],
-    "funnyordie.com": [
-      "deadline.com",
-      "videojs.com"
-    ],
     "fwmrm.net": [
-      "yahoo.com",
-      "mlb.com",
-      "xfinity.com"
+      "discovery.com",
+      "foodnetwork.com",
+      "channel4.com",
+      "hgtv.com"
     ],
-    "g2crowd.com": [
-      "prezi.com",
-      "teamviewer.us",
-      "wpengine.com"
-    ],
-    "gamer-network.net": [
-      "eurogamer.net"
+    "geetest.com": [
+      "axs.com"
     ],
     "gemius.pl": [
       "sapo.pt",
-      "interia.pl",
       "ria.ru"
-    ],
-    "gentags.net": [
-      "sina.com.cn"
     ],
     "getclicky.com": [
       "icio.us",
       "newatlas.com",
       "cyberchimps.com"
     ],
-    "getdrip.com": [
-      "dreamhost.com"
-    ],
-    "getpocket.com": [
-      "cronolog.org"
-    ],
     "getsmartcontent.com": [
-      "pcworld.com",
-      "computerworld.com",
-      "hpe.com"
-    ],
-    "gfycat.com": [
-      "reddit.com"
+      "pcworld.com"
     ],
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au"
+      "abc.net.au",
+      "redcross.org",
+      "syfy.com"
     ],
     "giphy.com": [
-      "urbandictionary.com",
-      "liberation.fr",
-      "webshots.com"
-    ],
-    "github.com": [
-      "wsj.com"
+      "urbandictionary.com"
     ],
     "glamour.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com"
-    ],
-    "gmossp-sp.jp": [
-      "shinobi.jp",
-      "shop-pro.jp"
+      "fortune.com",
+      "ew.com",
+      "travelandleisure.com"
     ],
     "go.com": [
       "disney.com",
-      "espn.com",
       "starwars.com",
       "fivethirtyeight.com"
     ],
     "golfdigest.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
-    "google.co.jp": [
-      "forumotion.com"
-    ],
     "google.com": [
       "youtube.com",
       "linkedin.com",
-      "google.de",
-      "scmp.com",
-      "chromium.org"
+      "pinterest.com",
+      "chromium.org",
+      "designboom.com"
     ],
     "gq.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "gridsumdissector.com": [
-      "qq.com",
-      "www.gov.cn",
-      "autohome.com.cn"
+      "www.gov.cn"
     ],
     "groupondata.com": [
       "groupon.com"
     ],
-    "gsimedia.net": [
-      "acehardware.com"
-    ],
-    "gssprt.jp": [
-      "dropbox.com",
-      "biglobe.ne.jp"
+    "gstatic.com": [
+      "google.ch",
+      "propublica.org",
+      "facebook.com",
+      "google.com.tw",
+      "goal.com",
+      "google.ca"
     ],
     "gtags.net": [
-      "sina.com.cn",
       "ctrip.com"
     ],
     "gumgum.com": [
-      "liveuamap.com",
-      "colourlovers.com",
-      "infoplease.com"
-    ],
-    "guoshipartners.com": [
-      "udn.com"
+      "snopes.com",
+      "thehindu.com",
+      "home.pl",
+      "colourlovers.com"
     ],
     "gwallet.com": [
       "adobe.com",
+      "economist.com",
       "ox.ac.uk",
-      "ihg.com"
+      "alternet.org",
+      "nme.com"
     ],
     "hatena.com": [
       "hatena.ne.jp"
     ],
     "hatena.ne.jp": [
-      "hatenablog.com",
-      "cronolog.org"
+      "hatenablog.com"
+    ],
+    "hdslb.com": [
+      "bilibili.com"
     ],
     "healte.de": [
-      "spiegel.de",
       "reuters.com"
     ],
     "hearstnp.com": [
       "sfgate.com",
-      "chron.com",
-      "seattlepi.com"
+      "chron.com"
     ],
     "help.com": [
-      "comodo.com",
-      "couchsurfing.com"
-    ],
-    "hiexpress.com": [
-      "ihg.com"
-    ],
-    "highwire.org": [
-      "pnas.org"
+      "comodo.com"
     ],
     "hitslink.com": [
       "webstarts.com"
@@ -13049,42 +5796,19 @@
     "hive.co": [
       "complex.com"
     ],
-    "hlserve.com": [
-      "bestbuy.com",
-      "macys.com",
-      "kohls.com"
-    ],
-    "holidayinn.com": [
-      "ihg.com"
-    ],
-    "holidayinnresorts.com": [
-      "ihg.com"
-    ],
     "horyzon-media.com": [
       "skyrock.com"
     ],
-    "hotelindigo.com": [
-      "ihg.com"
-    ],
-    "hotelsapi.io": [
-      "ovh.net"
-    ],
-    "htmedia.in": [
-      "hindustantimes.com"
-    ],
-    "hubpd.com": [
-      "huanqiu.com"
+    "huanqiu.com": [
+      "sina.com.cn"
     ],
     "hubspot.com": [
-      "wpengine.com",
-      "shopify.com",
-      "technologyreview.com"
+      "scoop.it",
+      "500px.com",
+      "thelancet.com"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
-    ],
-    "huffingtonpost.com": [
-      "huffingtonpost.co.uk"
     ],
     "hugedata.com.cn": [
       "miit.gov.cn"
@@ -13092,157 +5816,106 @@
     "huihui.cn": [
       "youdao.com"
     ],
-    "hwcdn.net": [
-      "boingboing.net"
-    ],
     "hybrid.ai": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru"
-    ],
-    "hypemarks.com": [
-      "uchicago.edu",
-      "purdue.edu",
-      "brown.edu"
-    ],
-    "i.ua": [
-      "kharkov.ua",
-      "kh.ua"
-    ],
-    "i1img.com": [
-      "excite.com"
-    ],
-    "ib-ibi.com": [
-      "globo.com"
+      "rambler.ru"
     ],
     "ibclick.stream": [
-      "webmd.com",
-      "wikitravel.org",
-      "inhabitat.com"
+      "webmd.com"
     ],
     "ibillboard.com": [
       "springer.com",
-      "home.pl",
-      "idnes.cz"
+      "home.pl"
     ],
     "ibt.com": [
       "newsweek.com",
       "ibtimes.com"
     ],
     "id5-sync.com": [
-      "bloomberg.com",
-      "venturebeat.com",
-      "dailymotion.com"
-    ],
-    "idealmedia.com": [
-      "alternet.org",
-      "thehill.com"
+      "livescience.com",
+      "skyrock.com",
+      "space.com"
     ],
     "ign.com": [
       "videojs.com"
     ],
     "igodigital.com": [
-      "apa.org",
-      "adidas.com",
-      "motorola.com"
+      "motorola.com",
+      "nintendo.com"
     ],
     "iheart.com": [
       "variety.com"
     ],
     "im-apps.net": [
+      "economist.com",
       "exblog.jp",
-      "rakuten.co.jp",
-      "biglobe.ne.jp"
-    ],
-    "imagetopng.club": [
-      "4shared.com"
-    ],
-    "imedia.cz": [
-      "idnes.cz"
-    ],
-    "imgfarm.com": [
-      "excite.com"
+      "biglobe.ne.jp",
+      "nifty.com"
     ],
     "imgur.com": [
       "stackoverflow.com",
-      "stackexchange.com",
-      "unm.edu"
+      "stackexchange.com"
     ],
     "impact-ad.jp": [
-      "rakuten.co.jp",
+      "economist.com",
       "yahoo.co.jp",
-      "goo.ne.jp"
+      "hatena.ne.jp",
+      "nifty.com"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com"
+      "wsj.com",
+      "speedtest.net",
+      "syfy.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
       "gartner.com"
     ],
-    "infolinks.com": [
-      "infoplease.com"
-    ],
-    "innovid.com": [
-      "nationalreview.com"
+    "innity.com": [
+      "thestar.com.my"
     ],
     "inq.com": [
-      "att.com",
-      "shutterstock.com",
       "ups.com"
     ],
-    "inquisitr.com": [
-      "www.poznan.pl"
-    ],
-    "inside-graph.com": [
-      "staples.com"
-    ],
     "insightexpressai.com": [
+      "giphy.com",
       "unsplash.com",
-      "standard.co.uk",
-      "motorola.com"
+      "gopro.com"
     ],
     "instagram.com": [
-      "cam.ac.uk",
       "illinois.edu",
+      "cam.ac.uk",
       "cbslocal.com",
       "arizona.edu",
-      "people.com",
-      "scmp.com"
+      "tmz.com",
+      "patch.com"
     ],
     "instinctiveads.com": [
+      "rollingstone.com",
       "variety.com",
-      "dp.ua",
-      "blackberry.com"
+      "indiewire.com"
     ],
     "intentiq.com": [
-      "sourceforge.net",
-      "symantec.com"
+      "thinkgeek.com"
     ],
     "intentmedia.net": [
-      "hotels.com",
       "tripadvisor.com",
-      "expedia.com"
+      "hotels.com"
     ],
     "intercom.io": [
-      "themeforest.net",
-      "ft.com",
-      "elegantthemes.com"
+      "visual.ly",
+      "yumpu.com",
+      "iconfinder.com"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
-      "wikitravel.org",
-      "inhabitat.com"
+      "wikitravel.org"
     ],
     "investingchannel.com": [
       "zerohedge.com"
-    ],
-    "investis.com": [
-      "ge.com"
     ],
     "invoc.us": [
       "prweb.com"
@@ -13250,70 +5923,53 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com"
+      "xing.com",
+      "welt.de"
     ],
     "iolam.it": [
       "virgilio.it"
     ],
     "iperceptions.com": [
-      "ford.com",
-      "seagate.com",
-      "honeywell.com"
+      "boeing.com"
     ],
     "ipinyou.com": [
-      "autohome.com.cn",
       "suning.com"
     ],
     "ipredictive.com": [
       "myspace.com",
-      "dailymotion.com"
+      "usatoday.com"
     ],
     "irs01.com": [
       "youku.com"
     ],
-    "izooto.com": [
-      "indianexpress.com"
-    ],
-    "janrainsso.com": [
-      "vancouversun.com"
+    "ixiaa.com": [
+      "businessinsider.com"
     ],
     "jd.com": [
       "163.com",
-      "ifeng.com",
       "sohu.com"
     ],
     "jquery.com": [
-      "dyn.com",
-      "fujitsu.com",
-      "liveleak.com",
-      "opensource.org"
+      "opensource.org",
+      "lemonde.fr",
+      "businessinsider.com"
     ],
     "jrs5.com": [
       "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "coursera.org"
     ],
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com"
-    ],
-    "justpremium.com": [
-      "tvtropes.org"
+      "dallasnews.com",
+      "vancouversun.com"
     ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com",
-      "zenfolio.com"
-    ],
-    "jword.jp": [
-      "excite.co.jp"
-    ],
-    "jyxo.com": [
-      "blog.cz"
+      "searchengineland.com"
     ],
     "kakao.com": [
-      "tistory.com",
       "daum.net"
     ],
     "kameleoon.eu": [
@@ -13321,9 +5977,11 @@
       "orange.fr"
     ],
     "keywee.co": [
+      "nytimes.com",
       "latimes.com",
       "nationalgeographic.com",
-      "chicagotribune.com"
+      "smithsonianmag.com",
+      "apartmenttherapy.com"
     ],
     "kinja.com": [
       "gizmodo.com",
@@ -13333,92 +5991,73 @@
     "kiwiirc.com": [
       "enlightenment.org"
     ],
-    "knet.cn": [
-      "dzwww.com"
-    ],
     "krxd.net": [
-      "inhabitat.com",
-      "bgr.com",
-      "jalopnik.com"
-    ],
-    "ladsp.com": [
-      "exblog.jp",
-      "biglobe.ne.jp",
-      "shop-pro.jp"
+      "businessinsider.com",
+      "usatoday.com",
+      "nature.com",
+      "billboard.com",
+      "gizmodo.com"
     ],
     "leadintel.io": [
       "nme.com"
     ],
-    "leaf.io": [
-      "ehow.com",
-      "livestrong.com"
-    ],
     "legocdn.com": [
       "lego.com"
     ],
-    "lejwaengv.com": [
-      "rd.com"
-    ],
-    "lentainform.com": [
-      "rambler.ru"
-    ],
     "liadm.com": [
-      "webmd.com",
-      "nj.com",
-      "patch.com"
-    ],
-    "libero.it": [
-      "virgilio.it"
+      "bloomberg.com",
+      "time.com",
+      "economist.com",
+      "ew.com",
+      "travelandleisure.com"
     ],
     "licasd.com": [
-      "nj.com"
-    ],
-    "licdn.com": [
-      "linkedin.com"
+      "ew.com",
+      "travelandleisure.com"
     ],
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
+      "lefigaro.fr",
       "home.pl"
     ],
     "lightboxcdn.com": [
-      "zdnet.com",
+      "gizmodo.com",
       "fastcompany.com",
-      "adweek.com"
+      "lifehacker.com",
+      "theonion.com",
+      "dailycaller.com"
     ],
     "lijit.com": [
       "sourceforge.net",
-      "bloomberg.com",
-      "deviantart.com"
-    ],
-    "lincoln.com": [
-      "ford.com"
+      "deviantart.com",
+      "mirror.co.uk",
+      "upi.com",
+      "infoplease.com"
     ],
     "link-page.info": [
-      "netvibes.com",
-      "icq.com"
+      "netvibes.com"
     ],
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "sap.com",
+      "lexisnexis.com"
     ],
     "linksynergy.com": [
-      "rakuten.co.jp",
       "pcworld.com",
-      "nike.com"
-    ],
-    "list-manage.com": [
-      "boingboing.net"
+      "nike.com",
+      "alibabacloud.com",
+      "infoworld.com"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "paypal.com",
-      "skype.com",
-      "msn.com",
       "microsoft.com",
+      "msn.com",
+      "bing.com",
       "office.com"
     ],
     "livechatinc.com": [
@@ -13427,28 +6066,22 @@
       "sophos.com",
       "nazwa.pl"
     ],
-    "livedoor.jp": [
-      "livedoor.com"
-    ],
     "livejournal.net": [
       "livejournal.com"
     ],
     "liveperson.net": [
-      "apache.org",
-      "prnewswire.com",
-      "ibm.com"
-    ],
-    "lkqd.net": [
-      "allafrica.com"
+      "talktalk.co.uk",
+      "earthlink.net",
+      "thetimes.co.uk",
+      "trendmicro.com",
+      "lexisnexis.com"
     ],
     "loc.gov": [
-      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
-      "infoplease.com",
-      "coindesk.com",
-      "edmunds.com"
+      "jpost.com",
+      "infoplease.com"
     ],
     "logly.co.jp": [
       "goo.ne.jp",
@@ -13457,55 +6090,41 @@
     "lp1block.com": [
       "radikal.ru"
     ],
-    "lqm.io": [
-      "lefigaro.fr"
-    ],
     "lrcontent.com": [
       "cbc.ca",
       "arte.tv"
     ],
-    "lucklayed.info": [
-      "4shared.com"
-    ],
-    "lwcal.com": [
-      "sfu.ca"
-    ],
     "lytics.io": [
-      "adweek.com",
+      "economist.com",
       "digitaltrends.com",
+      "adweek.com",
       "fool.com"
     ],
     "m6r.eu": [
       "t-online.de",
       "statista.com"
     ],
-    "madeleine.de": [
-      "t-online.de"
+    "macromill.com": [
+      "asahi.com"
     ],
     "mail.ru": [
       "vk.com",
-      "novostimira.com",
-      "google.com",
+      "yandex.ru",
+      "thehill.com",
       "icq.com",
-      "ok.ru"
-    ],
-    "mailchimp.com": [
-      "colorlib.com",
-      "fas.org",
-      "tias.com",
-      "boingboing.net"
-    ],
-    "mantisadnetwork.com": [
-      "tvtropes.org"
+      "ok.ru",
+      "liveinternet.ru",
+      "novostimira.com"
     ],
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "hootsuite.com"
+      "smugmug.com",
+      "eventbrite.co.uk",
+      "godaddy.com"
     ],
     "marketlinc.com": [
-      "kaspersky.com",
-      "norton.com",
+      "teamviewer.com",
       "eset.com"
     ],
     "marketo.com": [
@@ -13518,153 +6137,130 @@
       "domaintools.com"
     ],
     "matheranalytics.com": [
-      "theglobeandmail.com",
       "thestar.com",
+      "mercurynews.com",
       "seattletimes.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "ew.com",
+      "colourlovers.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
-      "forbes.com"
+      "forbes.com",
+      "thestreet.com",
+      "cracked.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
+      "columbia.edu",
       "uci.edu",
-      "autodesk.com"
+      "colourlovers.com"
     ],
     "mediaforge.com": [
-      "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com"
-    ],
-    "medialand.ru": [
-      "rbc.ru"
+      "bostonglobe.com",
+      "coursera.org"
     ],
     "mediaplex.com": [
+      "economist.com",
       "dell.com",
-      "shutterfly.com",
-      "military.com"
+      "shutterfly.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
-      "lynda.com",
-      "liberation.fr"
+      "leparisien.fr"
     ],
     "mediav.com": [
+      "so.com",
       "ctrip.com",
-      "2345.com",
-      "so.com"
+      "toutiao.com"
     ],
     "mediawallahscript.com": [
       "sourceforge.net",
-      "photobucket.com",
-      "shopko.com"
+      "gopro.com"
     ],
     "mediawiki.org": [
       "wikimedia.org"
-    ],
-    "medscape.com": [
-      "medicinenet.com"
     ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
     "metadsp.co.uk": [
-      "nypost.com",
-      "standard.co.uk"
+      "usatoday.com",
+      "mirror.co.uk",
+      "nypost.com"
+    ],
+    "mfadsrvr.com": [
+      "nbcsports.com"
     ],
     "mg2connext.com": [
-      "mercurynews.com",
       "philly.com",
-      "denverpost.com"
+      "newsday.com",
+      "ajc.com"
     ],
     "mgid.com": [
-      "liveleak.com",
-      "radikal.ru"
-    ],
-    "miamiherald.com": [
-      "sacbee.com",
-      "kansascity.com"
+      "liveleak.com"
     ],
     "miaozhen.com": [
+      "qq.com",
       "sina.com.cn",
-      "163.com",
-      "dzwww.com"
+      "pconline.com.cn"
     ],
     "microad.jp": [
-      "rakuten.co.jp",
       "sakura.ne.jp",
-      "biglobe.ne.jp"
+      "hatena.ne.jp"
     ],
     "microsoft.com": [
+      "msn.com",
       "live.com",
       "skype.com",
-      "or.kr",
       "office.com",
       "xbox.com",
-      "complex.com",
-      "encyclopedia.com"
+      "complex.com"
     ],
     "microsoftonline.com": [
       "microsoft.com",
-      "office.com",
-      "xbox.com"
-    ],
-    "mirtesen.ru": [
-      "rbc.ru"
+      "office.com"
     ],
     "mktoresp.com": [
       "parallels.com",
-      "prnewswire.com",
-      "zend.com"
+      "zend.com",
+      "prweb.com",
+      "proofpoint.com",
+      "pingdom.com"
     ],
     "ml314.com": [
       "sourceforge.net",
-      "forbes.com",
-      "bloomberg.com"
-    ],
-    "mlb.com": [
-      "nhl.com"
-    ],
-    "mlive.com": [
-      "nola.com"
+      "wsj.com",
+      "bloomberg.com",
+      "space.com",
+      "zerohedge.com"
     ],
     "mmstat.com": [
-      "alibaba.com",
       "youku.com",
-      "taobao.com"
-    ],
-    "mmtro.com": [
-      "upwork.com"
-    ],
-    "molefefiseranis.ru": [
-      "radikal.ru"
+      "sohu.com",
+      "taobao.com",
+      "tmall.com"
     ],
     "monetate.net": [
       "nationalgeographic.com",
-      "marriott.com",
-      "ticketmaster.com"
-    ],
-    "monster.com": [
-      "military.com"
+      "marriott.com"
     ],
     "mookie1.com": [
-      "t-online.de",
-      "nbcnews.com",
-      "theglobeandmail.com"
+      "businessinsider.com",
+      "photobucket.com",
+      "theglobeandmail.com",
+      "eonline.com"
     ],
     "mouseflow.com": [
-      "bbb.org",
       "nintendo.com"
     ],
     "mpnrs.com": [
@@ -13673,7 +6269,6 @@
     ],
     "mrpfd.com": [
       "symantec.com",
-      "gouv.fr",
       "hpe.com"
     ],
     "msgapp.com": [
@@ -13681,101 +6276,63 @@
       "odin.com"
     ],
     "msn.com": [
-      "w3.org",
-      "marketwatch.com",
-      "google.com"
-    ],
-    "mthsense.com": [
-      "alternet.org"
-    ],
-    "mtty.com": [
-      "163.com"
+      "marketwatch.com"
     ],
     "mtvnservices.com": [
       "mtv.com",
       "cc.com"
     ],
-    "multiview.com": [
-      "symantec.com"
-    ],
     "musthird.com": [
       "airbnb.com"
-    ],
-    "muumuu-domain.com": [
-      "shop-pro.jp"
-    ],
-    "mybuys.com": [
-      "shopko.com"
-    ],
-    "myhard.com": [
-      "yesky.com"
     ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
-    ],
-    "myregistry.com": [
-      "shopko.com"
     ],
     "myspacecdn.com": [
       "myspace.com"
     ],
     "myvisualiq.net": [
       "soundcloud.com",
+      "paypal.com",
       "surveymonkey.com",
-      "spotify.com"
+      "bluehost.com"
     ],
     "nanigans.com": [
+      "squareup.com",
       "thinkgeek.com",
-      "overstock.com",
-      "squareup.com"
+      "yellowpages.com"
     ],
     "narrative.io": [
-      "sourceforge.net"
+      "sourceforge.net",
+      "businessinsider.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
     ],
     "nationalgeographic.com": [
-      "foxnews.com",
-      "foxbusiness.com",
-      "fox.com"
-    ],
-    "native.ai": [
-      "rollingstone.com"
+      "foxnews.com"
     ],
     "nativendo.de": [
-      "t-online.de",
-      "gnu.org",
-      "focus.de"
+      "t-online.de"
     ],
     "naver.com": [
-      "unity3d.com",
-      "cafe24.com"
+      "unity3d.com"
     ],
     "naver.jp": [
-      "line.me",
-      "livedoor.com"
-    ],
-    "nbcnews.com": [
-      "today.com",
-      "msnbc.com"
+      "line.me"
     ],
     "nbcuni.com": [
       "cnbc.com",
-      "msnbc.com",
-      "nbc.com"
-    ],
-    "netdna-ssl.com": [
-      "alternet.org"
+      "nbcnews.com",
+      "today.com",
+      "nbc.com",
+      "syfy.com"
     ],
     "netmng.com": [
-      "lenovo.com",
-      "theknot.com",
-      "shopko.com"
-    ],
-    "newatlas.com": [
-      "flipboard.com"
+      "businessinsider.com",
+      "lemonde.fr",
+      "colourlovers.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -13799,15 +6356,15 @@
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
-      "thesun.co.uk"
+      "thesun.co.uk",
+      "biblegateway.com",
+      "heraldsun.com.au"
     ],
     "newsinc.com": [
       "latimes.com",
-      "nydailynews.com",
-      "hollywoodreporter.com"
-    ],
-    "newsmemory.com": [
-      "cleveland.com"
+      "hollywoodreporter.com",
+      "thehill.com",
+      "ajc.com"
     ],
     "newsvine.com": [
       "nbcnews.com",
@@ -13819,8 +6376,8 @@
     ],
     "newyorker.com": [
       "wired.com",
-      "vanityfair.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -13828,81 +6385,33 @@
     "ngpvan.com": [
       "greenpeace.org"
     ],
-    "nih.gov": [
-      "medlineplus.gov",
-      "clinicaltrials.gov"
-    ],
-    "nokia.com": [
-      "bell-labs.com"
-    ],
-    "norton.com": [
-      "namejet.com"
-    ],
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com"
-    ],
-    "nsaudience.pl": [
-      "interia.pl"
-    ],
-    "nscontext.eu": [
-      "interia.pl",
-      "home.pl"
+      "huffingtonpost.com",
+      "redcross.org",
+      "nbcsports.com"
     ],
     "nuggad.net": [
-      "t-online.de",
-      "liberation.fr",
-      "lexpress.fr"
+      "t-online.de"
     ],
     "nxtck.com": [
       "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com"
-    ],
-    "nymag.com": [
-      "vulture.com"
-    ],
-    "nzaza.com": [
-      "upwork.com"
+      "bostonglobe.com",
+      "coursera.org",
+      "orange.fr"
     ],
     "o0bg.com": [
       "bostonglobe.com"
     ],
-    "oath.com": [
-      "tumblr.com",
-      "huffingtonpost.co.uk",
-      "techradar.com"
-    ],
-    "ocdn.eu": [
-      "onet.pl",
-      "brightcove.net"
-    ],
-    "oclc.org": [
-      "worldcat.org"
-    ],
-    "ofapes.com": [
-      "radikal.ru"
-    ],
     "offaces-butional.com": [
       "pornhub.com"
     ],
-    "office.com": [
-      "microsoftonline.com"
-    ],
-    "office365.com": [
-      "microsoftonline.com"
-    ],
     "ojrq.net": [
-      "office.com",
       "autodesk.com"
     ],
     "ok.ru": [
-      "ria.ru",
-      "mail.ru"
-    ],
-    "olark.com": [
-      "webstarts.com"
+      "ria.ru"
     ],
     "olympicchannel.com": [
       "olympic.org"
@@ -13914,17 +6423,17 @@
       "rambler.ru"
     ],
     "omnitagjs.com": [
-      "springer.com",
-      "standard.co.uk",
-      "home.pl"
+      "mirror.co.uk",
+      "variety.com",
+      "skyrock.com",
+      "standard.co.uk"
     ],
     "omtrdc.net": [
       "adobe.com",
+      "telegraph.co.uk",
       "amazon.com",
-      "telegraph.co.uk"
-    ],
-    "onclickmega.com": [
-      "brothersoft.com"
+      "sap.com",
+      "rtve.es"
     ],
     "onecount.net": [
       "foreignpolicy.com"
@@ -13932,16 +6441,12 @@
     "oneroof.co.nz": [
       "nzherald.co.nz"
     ],
-    "onet.tv": [
-      "onet.pl"
-    ],
     "onetrust.com": [
+      "cnn.com",
+      "thesun.co.uk",
       "themeisle.com",
-      "bitbucket.org",
-      "namecheap.com"
-    ],
-    "onevision.com.tw": [
-      "udn.com"
+      "atlassian.com",
+      "active.com"
     ],
     "online-metrix.net": [
       "gotomeeting.com"
@@ -13951,25 +6456,26 @@
     ],
     "onthe.io": [
       "indiatimes.com",
-      "wn.com",
-      "express.co.uk"
+      "express.co.uk",
+      "rbc.ru"
     ],
     "ooyala.com": [
+      "bizjournals.com",
       "accuweather.com",
-      "technologyreview.com",
-      "bizjournals.com"
+      "fedex.com"
     ],
     "openhub.net": [
       "mariadb.org"
     ],
     "openstat.net": [
-      "novostimira.com",
-      "kharkov.ua"
+      "novostimira.com"
     ],
     "openx.net": [
-      "yahoo.com",
-      "amazon.com",
-      "nytimes.com"
+      "nytimes.com",
+      "dropbox.com",
+      "telegraph.co.uk",
+      "liveinternet.ru",
+      "colourlovers.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -13977,23 +6483,18 @@
     "optaim.com": [
       "sohu.com"
     ],
-    "optimix.asia": [
-      "bshare.cn",
-      "qianlong.com"
-    ],
     "optimizely.com": [
-      "cnn.com",
-      "creativecommons.org",
-      "webs.com",
       "nytimes.com",
-      "live.com",
-      "ibm.com",
+      "cnn.com",
+      "microsoft.com",
       "bbc.com",
       "hp.com",
+      "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
       "foxnews.com",
+      "change.org",
       "wikihow.com",
       "imageshack.us",
       "newyorker.com",
@@ -14005,9 +6506,10 @@
       "gotomeeting.com",
       "accorhotels.com",
       "history.com",
-      "jamanetwork.com",
       "bestbuy.com",
+      "salesforce.com",
       "www.nhs.uk",
+      "office.com",
       "imageshack.com",
       "dallasnews.com",
       "metmuseum.org",
@@ -14015,108 +6517,77 @@
       "blizzard.com",
       "foxbusiness.com",
       "ama-assn.org",
-      "office.com",
       "squareup.com",
       "starbucks.com",
       "care2.com",
       "ajc.com",
       "justgiving.com",
+      "bankrate.com",
       "dreamhost.com",
       "edx.org",
       "bartleby.com",
-      "zenfolio.com",
-      "fourseasons.com",
-      "theknot.com",
-      "legacy.com",
       "couchsurfing.com",
       "gitlab.com",
       "peta.org",
       "fox.com"
-    ],
-    "optimove.events": [
-      "bhphotovideo.com"
     ],
     "ora.tv": [
       "cheezburger.com",
       "alternet.org",
       "wnd.com"
     ],
-    "oracleimg.com": [
-      "dyn.com"
-    ],
     "orangeads.fr": [
       "orange.fr"
-    ],
-    "oreilly.com": [
-      "onlamp.com",
-      "ora.com"
-    ],
-    "otm-r.com": [
-      "tomsk.ru",
-      "radikal.ru",
-      "diary.ru"
     ],
     "otto.de": [
       "t-online.de"
     ],
     "outbrain.com": [
-      "nature.com",
-      "scribd.com",
-      "foxnews.com"
-    ],
-    "ovh.com": [
-      "ovh.co.uk"
+      "cnn.com",
+      "msn.com",
+      "wsj.com",
+      "ew.com",
+      "rfi.fr"
     ],
     "owneriq.net": [
-      "lycos.com",
       "lg.com",
-      "washingtontimes.com"
-    ],
-    "owox.com": [
-      "simplesite.com"
-    ],
-    "paddle.com": [
-      "snapwidget.com"
+      "acer.com",
+      "walgreens.com"
     ],
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org"
+      "ap.org",
+      "heroku.com",
+      "propublica.org"
     ],
     "parsely.com": [
+      "huffingtonpost.com",
+      "bloomberg.com",
       "time.com",
-      "wired.com",
-      "wikia.com"
+      "huffingtonpost.co.uk",
+      "syfy.com"
     ],
     "paypal.com": [
-      "paypal.me",
-      "greenpeace.org"
+      "greenpeace.org",
+      "paypal.me"
     ],
     "paypalobjects.com": [
       "paypal.com",
-      "freetype.org",
-      "paypal.me"
+      "paypal.me",
+      "freetype.org"
     ],
     "payroll.com": [
       "intuit.com"
-    ],
-    "pbskids.org": [
-      "pbs.org"
-    ],
-    "pcmag.com": [
-      "macrumors.com",
-      "extremetech.com"
-    ],
-    "pdmp.jp": [
-      "shop-pro.jp"
     ],
     "performgroup.com": [
       "goal.com"
     ],
     "perimeterx.net": [
-      "bloomberg.com",
-      "pixnet.net",
-      "macrumors.com"
+      "udemy.com",
+      "zillow.com",
+      "seekingalpha.com",
+      "couchsurfing.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
@@ -14128,48 +6599,29 @@
       "autohome.com.cn"
     ],
     "pinterest.com": [
+      "nytimes.com",
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "nytimes.com"
+      "huffingtonpost.co.uk"
     ],
     "pitchfork.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
-    ],
-    "pixanalytics.com": [
-      "pixnet.net"
+      "vogue.com"
     ],
     "piximedia.com": [
       "orange.fr"
     ],
-    "pixnet.cc": [
-      "pixnet.net"
-    ],
-    "placed.com": [
-      "imdb.com"
-    ],
     "placelocal.com": [
       "gopro.com"
     ],
-    "playwire.com": [
-      "infoplease.com",
-      "zotero.org"
-    ],
     "plista.com": [
-      "express.co.uk",
-      "dailystar.co.uk"
+      "express.co.uk"
     ],
     "po.st": [
-      "smithsonianmag.com",
-      "wnd.com",
-      "business2community.com"
-    ],
-    "polymorphicads.jp": [
-      "shinobi.jp"
+      "nme.com",
+      "wnd.com"
     ],
     "popin.cc": [
-      "infoseek.co.jp",
       "nifty.com"
     ],
     "popsugar-assets.com": [
@@ -14178,32 +6630,30 @@
     "postrelease.com": [
       "reuters.com",
       "independent.co.uk",
-      "chicagotribune.com"
+      "chicagotribune.com",
+      "seattletimes.com",
+      "bostonherald.com"
     ],
     "powerlinks.com": [
+      "variety.com",
       "lemonde.fr",
-      "livescience.com",
-      "standard.co.uk"
-    ],
-    "pressboard.ca": [
-      "observer.com"
+      "howtogeek.com"
     ],
     "prfct.co": [
-      "smugmug.com",
-      "marthastewart.com"
+      "smugmug.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
-      "symantec.com",
-      "slashdot.org"
+      "slashdot.org",
+      "thinkgeek.com"
+    ],
+    "prod-cmg-proxy-connext.azurewebsites.net": [
+      "ajc.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
       "denverpost.com",
       "ocregister.com"
-    ],
-    "proparm.jp": [
-      "biglobe.ne.jp"
     ],
     "provenpixel.com": [
       "shopify.com"
@@ -14214,29 +6664,21 @@
     "proximus.be": [
       "skynet.be"
     ],
-    "proximustv.be": [
-      "skynet.be"
-    ],
     "pscp.tv": [
-      "ey.com",
-      "ria.ru",
       "nasa.gov"
     ],
     "pub.network": [
-      "metacafe.com",
       "coindesk.com"
-    ],
-    "publishme.se": [
-      "blogg.se"
     ],
     "pubmatic.com": [
       "dropbox.com",
-      "tinyurl.com",
-      "bloomberg.com"
+      "businessinsider.com",
+      "usatoday.com",
+      "space.com",
+      "colourlovers.com"
     ],
     "pubmine.com": [
-      "foreignpolicy.com",
-      "onecount.net"
+      "foreignpolicy.com"
     ],
     "pulpix.com": [
       "variety.com"
@@ -14244,7 +6686,8 @@
     "purch.com": [
       "livescience.com",
       "space.com",
-      "tomshardware.com"
+      "tomshardware.com",
+      "anandtech.com"
     ],
     "purechat.com": [
       "byu.edu"
@@ -14252,62 +6695,25 @@
     "pushanert.com": [
       "4shared.com"
     ],
-    "pxf.io": [
-      "namecheap.com",
-      "udemy.com"
-    ],
     "pxi.pub": [
       "mentalfloss.com"
     ],
-    "pxtres.com": [
-      "howstuffworks.com"
-    ],
-    "pxuno.com": [
-      "howstuffworks.com"
-    ],
-    "pxzwei.com": [
-      "howstuffworks.com"
-    ],
     "pymx5.com": [
+      "sfgate.com",
       "seattletimes.com",
-      "seattlepi.com",
-      "sfgate.com"
-    ],
-    "qnsr.com": [
-      "serverwatch.com"
-    ],
-    "qq.com": [
-      "sina.com.cn",
-      "ctrip.com",
-      "weather.com.cn",
-      "tencent.com"
-    ],
-    "qsstats.com": [
-      "serverwatch.com",
-      "eweek.com"
-    ],
-    "qtmojo.com": [
-      "dzwww.com"
+      "cracked.com"
     ],
     "qualtrics.com": [
-      "adidas.com",
-      "cnet.com",
-      "babycenter.com",
       "techrepublic.com",
-      "hulu.com",
       "nintendo.com",
-      "mayoclinic.org",
-      "hgtv.com",
-      "networksolutions.com",
-      "careerbuilder.com"
+      "cnet.com"
     ],
     "quantserve.com": [
-      "wordpress.org",
       "vimeo.com",
-      "reddit.com"
-    ],
-    "quantummetric.com": [
-      "macys.com"
+      "wordpress.org",
+      "reddit.com",
+      "fool.com",
+      "rfi.fr"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -14318,7 +6724,9 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com"
+      "ning.com",
+      "billboard.com",
+      "eset.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -14326,46 +6734,25 @@
     "radiotime.com": [
       "tunein.com"
     ],
-    "rakuten.co.jp": [
-      "infoseek.co.jp"
-    ],
     "rambler.ru": [
       "livejournal.com",
-      "washingtonpost.com",
       "novostimira.com",
       "ria.ru"
     ],
-    "rbnt.org": [
-      "radikal.ru"
-    ],
-    "rcsmetrics.it": [
-      "corriere.it"
-    ],
-    "reachmax.cn": [
-      "sina.com.cn",
-      "autohome.com.cn",
-      "bshare.cn"
+    "reactful.com": [
+      "thawte.com"
     ],
     "reddit.com": [
       "acm.org",
       "perl.com"
     ],
     "redlink.com": [
-      "jamanetwork.com",
-      "ccc.de"
-    ],
-    "reference.com": [
-      "thesaurus.com"
+      "jamanetwork.com"
     ],
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
-    "relap.io": [
-      "diary.ru"
-    ],
     "republer.com": [
-      "tomsk.ru",
-      "radikal.ru",
       "rambler.ru"
     ],
     "researchintel.com": [
@@ -14382,22 +6769,24 @@
       "reuters.com"
     ],
     "revcontent.com": [
-      "liveuamap.com",
-      "wnd.com",
-      "jpost.com"
+      "jpost.com",
+      "breitbart.com",
+      "bostonherald.com"
     ],
     "revjet.com": [
-      "homedepot.com",
-      "expedia.com",
       "bankrate.com"
     ],
     "rezync.com": [
-      "economist.com"
+      "economist.com",
+      "accuweather.com",
+      "investopedia.com"
     ],
     "rfihub.com": [
       "dropbox.com",
-      "tinyurl.com",
-      "npr.org"
+      "npr.org",
+      "economist.com",
+      "kaspersky.com",
+      "gopro.com"
     ],
     "rhombusads.com": [
       "adweek.com"
@@ -14411,99 +6800,77 @@
       "mlive.com"
     ],
     "richrelevance.com": [
-      "hbr.org",
-      "kohls.com"
-    ],
-    "rightnowtech.com": [
-      "oracle.com"
+      "hbr.org"
     ],
     "rkdms.com": [
-      "time.com",
+      "dropbox.com",
+      "usatoday.com",
       "wired.com",
-      "cbsnews.com"
+      "kotaku.com",
+      "gizmodo.com"
     ],
     "rlcdn.com": [
       "adobe.com",
-      "yahoo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "reddit.com",
+      "sap.com",
+      "colourlovers.com"
     ],
     "rnengage.com": [
-      "oracle.com",
       "thinkgeek.com"
     ],
     "rockyou.net": [
       "springer.com"
     ],
-    "roomkey.com": [
-      "hilton.com",
-      "ihg.com"
-    ],
-    "roymorgan.com": [
-      "smh.com.au"
-    ],
-    "rtb.com.ru": [
-      "radikal.ru",
-      "diary.ru"
+    "rqtrk.eu": [
+      "dropbox.com"
     ],
     "rtk.io": [
-      "post-gazette.com",
       "seattletimes.com",
-      "startribune.com",
-      "azcentral.com"
+      "miamiherald.com",
+      "startribune.com"
     ],
     "ru4.com": [
-      "dropbox.com",
-      "bloomberg.com"
+      "dropbox.com"
     ],
     "rubiconproject.com": [
-      "yahoo.com",
-      "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "cnn.com",
+      "techradar.com",
+      "colourlovers.com"
     ],
     "rundsp.com": [
-      "hpe.com",
-      "alternet.org"
-    ],
-    "rutarget.ru": [
-      "rambler.ru",
-      "ria.ru"
+      "hpe.com"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "codepen.io",
-      "tvtropes.org"
+      "bell-labs.com",
+      "hwg.org"
     ],
     "s3xified.com": [
-      "venturebeat.com",
-      "livescience.com",
-      "lycos.com"
-    ],
-    "sabavision.com": [
-      "mihanblog.com"
+      "thehindu.com"
     ],
     "salesforceliveagent.com": [
-      "constantcontact.com",
       "marriott.com",
+      "teamviewer.com",
       "prweb.com",
-      "salesforce.com"
+      "salesforce.com",
+      "eset.com"
     ],
     "salesloft.com": [
+      "wpengine.com",
       "techtarget.com",
-      "upwork.com",
-      "wpengine.com"
+      "upwork.com"
     ],
     "salesmanago.pl": [
       "home.pl"
     ],
     "samba.tv": [
-      "imdb.com",
       "gizmodo.com",
-      "lifehacker.com"
-    ],
-    "sbal4kp.com": [
-      "dropbox.com"
-    ],
-    "scarabresearch.com": [
-      "tate.org.uk"
+      "lifehacker.com",
+      "history.com",
+      "tmz.com",
+      "syfy.com"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -14512,219 +6879,174 @@
       "thelancet.com",
       "cell.com"
     ],
-    "sciencedirectassets.com": [
-      "sciencedirect.com"
-    ],
     "sciverse.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
-    ],
-    "scoop.it": [
-      "investorseurope.technology"
+      "thelancet.com",
+      "cell.com"
     ],
     "scopus.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
-      "tumblr.com"
+      "tumblr.com",
+      "billboard.com",
+      "syfy.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
-      "startribune.com",
-      "ctvnews.ca"
+      "startribune.com"
     ],
-    "sddan.com": [
-      "upwork.com"
-    ],
-    "seadform.net": [
-      "bloomberg.com"
-    ],
-    "searchmarketing.com": [
-      "macys.com"
+    "sdp-campaign.de": [
+      "t-online.de"
     ],
     "securedvisit.com": [
-      "cafepress.com",
-      "staples.com"
-    ],
-    "seekingalpha.com": [
-      "ytimg.com"
+      "cafepress.com"
     ],
     "sekindo.com": [
       "allafrica.com"
     ],
     "selectablemedia.com": [
+      "time.com",
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "travelandleisure.com"
     ],
     "self.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "semasio.net": [
-      "bloomberg.com"
+      "space.com"
     ],
     "sendtonews.com": [
-      "canada.com",
       "bostonherald.com"
     ],
     "servebom.com": [
-      "venturebeat.com",
       "livescience.com",
-      "space.com"
-    ],
-    "servedby-buysellads.com": [
-      "dribbble.com"
+      "space.com",
+      "howtogeek.com",
+      "dailydot.com"
     ],
     "serverbid.com": [
-      "coindesk.com"
+      "sciencedaily.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
-      "t-online.de",
-      "nbcnews.com"
+      "businessinsider.com",
+      "news.com.au",
+      "redbull.com",
+      "syfy.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
       "fitbit.com"
     ],
-    "shareaholic.com": [
-      "washingtontimes.com",
-      "turnerpublishing.com"
-    ],
     "sharethis.com": [
-      "www.uk.com",
-      "whatsapp.com",
-      "lycos.com"
+      "uk.com",
+      "www.vic.gov.au",
+      "mcafee.com",
+      "findlaw.com",
+      "dailycaller.com"
     ],
     "sharethrough.com": [
-      "yahoo.com",
-      "cnn.com",
-      "time.com"
-    ],
-    "sheego.de": [
-      "t-online.de"
+      "springer.com",
+      "samsung.com",
+      "cnbc.com",
+      "squareup.com"
     ],
     "shop.pe": [
-      "dyn.com",
-      "bluehost.com",
-      "fourseasons.com"
-    ],
-    "shopify.com": [
-      "codepen.io",
-      "raspberrypi.org"
+      "dyn.com"
     ],
     "siftscience.com": [
-      "scribd.com",
       "kickstarter.com",
       "flickr.com",
-      "upwork.com"
-    ],
-    "simplereach.com": [
-      "theatlantic.com"
+      "shutterstock.com",
+      "patreon.com",
+      "couchsurfing.com"
     ],
     "simpli.fi": [
-      "symantec.com",
-      "washingtontimes.com",
-      "thinkgeek.com"
+      "thinkgeek.com",
+      "tampabay.com"
     ],
     "sina.cn": [
       "sina.com.cn"
     ],
     "sina.com.cn": [
       "weibo.com",
-      "dzwww.com",
-      "sina.com"
-    ],
-    "sinoptik.ua": [
-      "kharkov.ua",
-      "kh.ua"
-    ],
-    "sitehelix.com": [
-      "overstock.com"
+      "suning.com"
     ],
     "siteimprove.com": [
-      "usda.gov",
+      "berkeley.edu",
       "verisign.com",
-      "udel.edu"
+      "udel.edu",
+      "ethz.ch",
+      "ucsb.edu",
+      "fsu.edu",
+      "buffalo.edu",
+      "unsw.edu.au",
+      "ucsf.edu",
+      "case.edu",
+      "oclc.org"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
     ],
-    "sitelabweb.com": [
-      "lenovo.com",
-      "upwork.com"
-    ],
     "sitelock.com": [
-      "joomla.org",
-      "netfirms.com"
+      "joomla.org"
     ],
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "seattletimes.com"
+      "accuweather.com",
+      "seattletimes.com",
+      "travelandleisure.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com"
+      "gizmodo.com",
+      "digital.com",
+      "atlasobscura.com"
     ],
     "sky.com": [
-      "skygroup.sky",
-      "skysports.com"
+      "skygroup.sky"
     ],
     "slashdotmedia.com": [
       "slashdot.org"
     ],
     "smartadserver.com": [
       "springer.com",
+      "elpais.com",
       "skyrock.com",
-      "sapo.pt"
-    ],
-    "smartclip.net": [
-      "infoplease.com"
+      "home.pl"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
-    ],
-    "smi2.net": [
-      "rbc.ru"
     ],
     "smi2.ru": [
       "rbc.ru"
     ],
     "smithsonian.museum": [
-      "si.edu",
       "smithsonianmag.com"
     ],
-    "smyte.com": [
-      "indiegogo.com",
-      "zendesk.com"
-    ],
     "snapchat.com": [
-      "jimdo.com",
-      "overstock.com",
-      "complex.com"
-    ],
-    "snapwidget.com": [
-      "udel.edu"
-    ],
-    "snplow.net": [
-      "wetransfer.com"
+      "giphy.com",
+      "walmart.com",
+      "wpengine.com",
+      "motorola.com",
+      "syfy.com"
     ],
     "so.com": [
       "360.cn"
     ],
     "socdm.com": [
-      "rakuten.co.jp",
-      "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "hatena.ne.jp",
+      "ocn.ne.jp"
     ],
     "sociomantic.com": [
       "springer.com",
@@ -14733,66 +7055,34 @@
     "soflopxl.com": [
       "howstuffworks.com"
     ],
-    "softonic-analytics.net": [
-      "softonic.com"
-    ],
-    "sogou.com": [
-      "soso.com",
-      "ifeng.com"
-    ],
-    "sohu.com": [
-      "ifeng.com",
-      "ctrip.com",
-      "focus.cn"
-    ],
     "sojern.com": [
-      "ihg.com",
-      "hyatt.com",
       "gopro.com"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
-    "soliditet.se": [
-      "jalbum.net"
-    ],
-    "solocpm.com": [
-      "edx.org"
-    ],
     "sonobi.com": [
-      "photobucket.com",
+      "usatoday.com",
+      "springer.com",
       "deviantart.com",
-      "springer.com"
-    ],
-    "sonyentertainmentnetwork.com": [
-      "playstation.com"
+      "space.com",
+      "goal.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "ea.com",
-      "independent.ie"
-    ],
-    "sourceforge.net": [
-      "libpng.org"
-    ],
-    "sp.global.ssl.fastly.net": [
-      "theglobeandmail.com"
-    ],
-    "spectate.com": [
-      "emory.edu"
+      "tmz.com",
+      "irishtimes.com",
+      "mo.gov"
     ],
     "sphereup.com": [
       "jpost.com"
     ],
     "spiceworks.com": [
-      "cloudflare.com",
-      "symantec.com",
-      "sophos.com"
-    ],
-    "spineuniverse.com": [
-      "psychcentral.com"
+      "hp.com",
+      "salesforce.com",
+      "slack.com"
     ],
     "spingo.com": [
       "detroitnews.com"
@@ -14804,16 +7094,15 @@
       "engadget.com",
       "denverpost.com"
     ],
-    "spotify.com": [
-      "oregonstate.edu"
-    ],
     "spots.im": [
       "denverpost.com"
     ],
     "spotxchange.com": [
-      "amazon.com",
       "dropbox.com",
-      "dailymotion.com"
+      "npr.org",
+      "express.co.uk",
+      "jpost.com",
+      "bostonherald.com"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -14821,13 +7110,11 @@
     ],
     "springernature.com": [
       "nature.com",
-      "biomedcentral.com",
-      "springer.com"
+      "springer.com",
+      "biomedcentral.com"
     ],
     "springserve.com": [
-      "tinypic.com",
-      "liveuamap.com",
-      "magento.com"
+      "tinypic.com"
     ],
     "sprinklr.com": [
       "autodesk.com"
@@ -14836,130 +7123,92 @@
       "straitstimes.com"
     ],
     "stackadapt.com": [
-      "thehill.com",
-      "farfetch.com",
-      "threadless.com"
-    ],
-    "staples-sparx.com": [
-      "staples.com"
-    ],
-    "staples-static.com": [
-      "staples.com"
-    ],
-    "starfieldtech.com": [
-      "scamnumbers.info"
+      "shopify.com",
+      "farfetch.com"
     ],
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org"
-    ],
-    "staticimgfarm.com": [
-      "excite.com"
-    ],
-    "staybridge.com": [
-      "ihg.com"
+      "freepik.com",
+      "zerohedge.com"
     ],
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "istockphoto.com"
-    ],
-    "steepto.com": [
-      "liveleak.com"
+      "gettyimages.com",
+      "newegg.com",
+      "careerbuilder.com"
     ],
     "stg-sp.global.ssl.fastly.net": [
       "theglobeandmail.com"
     ],
-    "stg8.com": [
-      "sina.com.cn"
-    ],
     "stickyadstv.com": [
-      "bloomberg.com",
-      "dailymotion.com",
-      "feedburner.com"
+      "pastebin.com",
+      "thinkgeek.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
     ],
     "storygize.net": [
       "autodesk.com",
-      "squareup.com",
-      "dn.ua"
-    ],
-    "streem.com.au": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "streetscout.com": [
-      "azcentral.com"
+      "squareup.com"
     ],
     "stripe.com": [
-      "iconfinder.com",
+      "smashballoon.com",
       "presscustomizr.com",
       "themezee.com",
-      "smashballoon.com",
       "documentcloud.org"
     ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com"
+      "studiopress.com",
+      "makezine.com"
     ],
     "sundaysky.com": [
-      "overstock.com",
-      "alternet.org",
-      "infoplease.com"
+      "fiverr.com",
+      "jpost.com",
+      "dailydot.com"
     ],
     "suning.cn": [
       "suning.com"
     ],
     "suning.com": [
       "qq.com",
-      "ifeng.com",
       "sohu.com"
     ],
-    "sunrtb.com": [
-      "yesky.com"
-    ],
     "supplyframe.com": [
-      "ti.com",
-      "arduino.cc"
+      "arduino.cc",
+      "ti.com"
     ],
     "survata.com": [
       "tripadvisor.com"
     ],
+    "surveygizmo.com": [
+      "berkeley.edu"
+    ],
     "surveymonkey.com": [
+      "techcrunch.com",
       "cambridge.org",
-      "investopedia.com",
-      "foreignpolicy.com",
-      "iop.org"
+      "iop.org",
+      "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
-      "metacafe.com",
-      "indianexpress.com"
+      "thehindu.com"
     ],
     "symantec.com": [
-      "norton.com",
-      "opinionlab.com"
-    ],
-    "synacor.com": [
-      "att.net"
+      "norton.com"
     ],
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
-      "t-online.de"
+      "msn.com",
+      "fool.com",
+      "nbcsports.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
-    ],
-    "tag4arm.com": [
-      "norton.com"
-    ],
-    "tagdelivery.com": [
-      "overstock.com"
     ],
     "tailtarget.com": [
       "uol.com.br"
@@ -14969,73 +7218,57 @@
       "hotels.com"
     ],
     "tanx.com": [
-      "sina.com.cn",
-      "alibaba.com",
-      "ifeng.com"
+      "sohu.com",
+      "ifeng.com",
+      "tmall.com",
+      "2345.com"
     ],
     "taobao.com": [
       "sina.com.cn",
-      "1688.com",
+      "alibaba.com",
       "tmall.com",
-      "alibaba.com"
+      "1688.com"
     ],
     "tapad.com": [
       "adobe.com",
-      "yahoo.com",
-      "soundcloud.com"
-    ],
-    "targetimg1.com": [
-      "target.com"
+      "soundcloud.com",
+      "dropbox.com",
+      "rottentomatoes.com"
     ],
     "tawk.to": [
       "cba.pl",
       "affordable-papers.net"
     ],
-    "tcell.io": [
-      "sophos.com"
+    "taylorandfrancis.com": [
+      "tandfonline.com"
     ],
     "teads.tv": [
-      "alternet.org"
+      "walgreens.com"
     ],
     "tealiumiq.com": [
       "ibm.com",
-      "cbsnews.com",
-      "evernote.com"
-    ],
-    "technolutions.net": [
-      "illinois.edu",
-      "upenn.edu",
-      "uci.edu"
+      "cnet.com",
+      "samsung.com",
+      "welt.de",
+      "usmagazine.com"
     ],
     "techweb.com": [
       "informationweek.com"
     ],
     "teenvogue.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
-    ],
-    "telegraph.co.uk": [
-      "wordpress.com"
-    ],
-    "telekom.de": [
-      "t-online.de"
-    ],
-    "tenmax.io": [
-      "biglobe.ne.jp"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "theadex.com": [
       "t-online.de",
-      "gnu.org",
-      "spiegel.de"
-    ],
-    "theatlas.com": [
-      "qz.com"
+      "spiegel.de",
+      "sueddeutsche.de"
     ],
     "thebrighttag.com": [
-      "netflix.com",
-      "wufoo.com",
-      "playstation.com"
+      "playstation.com",
+      "mercurynews.com",
+      "ubisoft.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -15043,44 +7276,36 @@
     "theguardian.com": [
       "videojs.com"
     ],
-    "thesaurus.com": [
-      "dictionary.com"
-    ],
-    "thomsonreuters.com": [
-      "reuters.com"
-    ],
-    "tianqi.com": [
-      "qianlong.com"
+    "thrtle.com": [
+      "sourceforge.net"
     ],
     "tianqijun.com": [
       "qianlong.com"
-    ],
-    "tidaltv.com": [
-      "dailymotion.com",
-      "nationalgeographic.com",
-      "xfinity.com"
     ],
     "tidelinedata.io": [
       "deviantart.com"
     ],
     "timecommerce.net": [
+      "time.com",
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "travelandleisure.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
     ],
     "tinypass.com": [
+      "bloomberg.com",
       "businessinsider.com",
       "techcrunch.com",
-      "kickstarter.com"
+      "adage.com",
+      "gizmodo.com"
     ],
     "tiqcdn.com": [
-      "cisco.com",
-      "nbcnews.com",
-      "ibm.com",
       "wsj.com",
+      "cisco.com",
+      "marketwatch.com",
       "here.com"
     ],
     "tl813.com": [
@@ -15090,49 +7315,27 @@
     "tm-awx.com": [
       "mirror.co.uk"
     ],
-    "tmall.com": [
-      "taobao.com"
-    ],
     "tns-counter.ru": [
-      "livejournal.com",
       "vk.com",
-      "yandex.ru"
+      "livejournal.com",
+      "yandex.ru",
+      "ok.ru",
+      "radikal.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
     ],
-    "tracc.it": [
-      "france24.com",
-      "rfi.fr"
-    ],
-    "trackad.cz": [
-      "idnes.cz"
-    ],
     "trackalyzer.com": [
       "squareup.com"
     ],
-    "tradedoubler.com": [
-      "lemonde.fr",
-      "interia.pl"
-    ],
     "tradelab.fr": [
-      "eklablog.com",
-      "leparisien.fr"
+      "eklablog.com"
     ],
     "traffic-media.co": [
       "radikal.ru"
     ],
-    "trafficgate.net": [
-      "rakuten.co.jp"
-    ],
-    "trafficjam.cn": [
-      "youku.com"
-    ],
     "trafficjunky.net": [
       "pornhub.com"
-    ],
-    "travelsmarter.net": [
-      "tripadvisor.com"
     ],
     "travelzoo.com": [
       "philly.com"
@@ -15140,27 +7343,27 @@
     "trb.com": [
       "latimes.com",
       "chicagotribune.com",
-      "nydailynews.com"
+      "baltimoresun.com"
     ],
     "treasuredata.com": [
-      "biglobe.ne.jp",
-      "nintendo.com",
-      "exblog.jp"
+      "exblog.jp",
+      "hatena.ne.jp",
+      "asahi.com"
     ],
     "tremorhub.com": [
       "usatoday.com",
-      "azcentral.com",
-      "freep.com"
+      "freep.com",
+      "detroitnews.com"
     ],
     "tribalfusion.com": [
-      "dailymotion.com",
       "pastebin.com",
-      "liveleak.com"
+      "liveleak.com",
+      "xe.com",
+      "colourlovers.com"
     ],
     "tribl.io": [
-      "prezi.com",
-      "zimbra.com",
-      "prnewswire.com"
+      "prnewswire.com",
+      "zimbra.com"
     ],
     "tripadvisor.com": [
       "accorhotels.com"
@@ -15168,98 +7371,70 @@
     "tronc.com": [
       "latimes.com",
       "chicagotribune.com",
-      "nydailynews.com"
+      "baltimoresun.com"
     ],
     "trumba.com": [
-      "ucdavis.edu",
-      "utah.edu",
-      "emory.edu"
-    ],
-    "truoptik.com": [
-      "slashdot.org",
-      "infoplease.com"
+      "ucdavis.edu"
     ],
     "trustarc.com": [
       "skynet.be"
     ],
-    "trustev.com": [
-      "lenovo.com"
-    ],
     "trustpilot.com": [
       "jalbum.net",
-      "avira.com",
       "moonfruit.com"
     ],
     "trvl-px.com": [
-      "hotels.com",
-      "expedia.com"
-    ],
-    "tumblr.com": [
-      "dailydot.com",
-      "theweek.com"
+      "hotels.com"
     ],
     "turn.com": [
-      "bloomberg.com",
+      "hp.com",
       "wired.com",
-      "webmd.com"
+      "economist.com",
+      "miamiherald.com",
+      "pitchfork.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
     ],
     "tvsquared.com": [
-      "telegraph.co.uk",
+      "wsj.com",
       "jimdo.com",
-      "squarespace.com"
-    ],
-    "twimg.com": [
-      "coe.int",
-      "ey.com",
-      "dol.gov"
+      "squarespace.com",
+      "aarp.org"
     ],
     "twitter.com": [
+      "amazon.com",
       "wordpress.org",
-      "yahoo.com",
-      "chicagotribune.com",
+      "nytimes.com",
       "cnn.com",
-      "cnet.com"
+      "msn.com",
+      "perl.com",
+      "syfy.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com"
-    ],
-    "ubi.com": [
-      "ubisoft.com"
+      "digital.com",
+      "dailycaller.com"
     ],
     "uc.se": [
       "jalbum.net"
     ],
     "uciservice.com": [
-      "hotels.com",
-      "expedia.com"
+      "hotels.com"
     ],
     "ucoz.net": [
       "narod.ru"
     ],
     "udmserve.net": [
-      "colourlovers.com",
-      "dailydot.com",
       "washingtonexaminer.com"
-    ],
-    "udnfunlife.com": [
-      "udn.com"
-    ],
-    "uefa.com": [
-      "bleacherreport.com"
-    ],
-    "ufpcdn.com": [
-      "brothersoft.com"
     ],
     "ugdturner.com": [
       "cnn.com",
       "nba.com"
     ],
     "undertone.com": [
+      "hpe.com",
       "dallasnews.com",
       "alternet.org"
     ],
@@ -15271,28 +7446,21 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "earthlink.net",
+      "businessweek.com",
       "boingboing.net"
     ],
     "upravel.com": [
-      "rambler.ru",
-      "tomsk.ru"
+      "rambler.ru"
     ],
     "upsellit.com": [
       "samsung.com",
-      "garmin.com",
       "motorola.com"
-    ],
-    "uptolike.com": [
-      "live4fun.ru"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
     ],
     "usa.gov": [
-      "transportation.gov",
-      "dhs.gov",
-      "usembassy.gov"
+      "transportation.gov"
     ],
     "useproof.com": [
       "iconosquare.com"
@@ -15300,12 +7468,8 @@
     "usergram.info": [
       "ocn.ne.jp"
     ],
-    "userreport.com": [
-      "scotsman.com"
-    ],
     "uservoice.com": [
-      "scoop.it",
-      "theknot.com"
+      "scoop.it"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -15314,143 +7478,112 @@
       "radikal.ru"
     ],
     "utarget.ru": [
-      "radikal.ru",
-      "diary.ru"
+      "radikal.ru"
     ],
     "uuidksinc.net": [
-      "radikal.ru",
-      "diary.ru"
+      "radikal.ru"
     ],
     "v-biz.com.ua": [
       "novostimira.com"
     ],
-    "v12group.com": [
-      "tinyurl.com",
-      "shopko.com"
-    ],
     "vanityfair.com": [
       "wired.com",
-      "newyorker.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "veinteractive.com": [
       "prweb.com",
-      "logitech.com",
       "wnd.com"
     ],
     "velaro.com": [
-      "lg.com",
-      "eff.org"
-    ],
-    "velemh.com": [
-      "liveuamap.com"
-    ],
-    "verticalhealth.net": [
-      "psychcentral.com"
-    ],
-    "veruta.com": [
-      "shopko.com"
+      "lg.com"
     ],
     "viafoura.co": [
       "cbc.ca",
-      "columbia.edu",
-      "nj.com"
+      "nj.com",
+      "irishtimes.com"
+    ],
+    "viafoura.com": [
+      "irishtimes.com"
     ],
     "viafoura.net": [
       "cbc.ca"
     ],
     "videoamp.com": [
-      "hpe.com"
-    ],
-    "videohub.tv": [
-      "liveuamap.com"
+      "alternet.org"
     ],
     "vidible.tv": [
       "aol.com",
-      "nydailynews.com",
       "autoblog.com"
     ],
     "viglink.com": [
-      "zdnet.com",
+      "cnet.com",
+      "thedailybeast.com",
       "softonic.com",
-      "techrepublic.com"
+      "dailycaller.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
       "olympic.org",
-      "tmz.com"
+      "today.com",
+      "cbs.com"
     ],
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "livestream.com",
-      "princeton.edu",
-      "cargocollective.com"
+      "wufoo.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
+      "time.com",
       "fortune.com",
-      "people.com"
+      "ew.com",
+      "travelandleisure.com"
     ],
     "virgilio.it": [
       "libero.it"
     ],
-    "visualstudio.com": [
-      "microsoft.com"
-    ],
-    "vizury.com": [
-      "dreamstime.com"
+    "visitor-track.com": [
+      "redcross.org"
     ],
     "vk.com": [
+      "yandex.ru",
       "rt.com",
-      "templatemonster.com",
       "ria.ru"
+    ],
+    "vmmpxl.com": [
+      "networksolutions.com"
     ],
     "vogue.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "pitchfork.com"
     ],
     "volvelle.tech": [
-      "prweb.com",
-      "logitech.com"
+      "colourlovers.com"
     ],
     "voxmedia.com": [
       "theverge.com",
       "vox.com",
       "recode.net",
-      "sbnation.com"
-    ],
-    "vtracy.de": [
-      "bloomberg.com"
+      "sbnation.com",
+      "polygon.com"
     ],
     "w55c.net": [
-      "hpe.com",
-      "ebay.com",
-      "sourceforge.net"
-    ],
-    "wal.co": [
-      "walmart.com"
+      "hp.com",
+      "businessinsider.com",
+      "pbs.org"
     ],
     "wallst.com": [
       "reuters.com"
     ],
-    "walmartimages.com": [
-      "walmart.com"
-    ],
-    "waptime.cn": [
-      "tianqi.com"
-    ],
-    "warnerbros.com": [
-      "tmz.com"
-    ],
     "wbtrk.net": [
-      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
     "wcfbc.net": [
-      "bild.de"
+      "repubblica.it",
+      "bild.de",
+      "goethe.de"
     ],
     "weather.com": [
       "wunderground.com"
@@ -15461,8 +7594,8 @@
     ],
     "weborama.fr": [
       "lemonde.fr",
-      "rbc.ru",
-      "lexpress.fr"
+      "lefigaro.fr",
+      "rbc.ru"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -15475,26 +7608,21 @@
       "freewebs.com"
     ],
     "webspectator.com": [
-      "goal.com",
-      "guinnessworldrecords.com"
+      "goal.com"
     ],
     "webtrekk.net": [
       "springer.com",
-      "localiser-ip.com",
-      "welt.de"
+      "repubblica.it",
+      "goethe.de"
     ],
     "webtrendslive.com": [
-      "nature.com",
       "abc.net.au",
-      "oup.com"
-    ],
-    "webvisor.org": [
-      "ucoz.ru"
+      "oup.com",
+      "ethz.ch",
+      "www.nhs.uk",
+      "dhl.com"
     ],
     "weibo.com": [
-      "sina.com.cn"
-    ],
-    "weicaixun.com": [
       "sina.com.cn"
     ],
     "welt.de": [
@@ -15509,33 +7637,24 @@
     "wikimedia.org": [
       "wikipedia.org",
       "wiktionary.org",
-      "mediawiki.org",
       "wikisource.org",
-      "wikibooks.org",
-      "wikiquote.org"
+      "mediawiki.org",
+      "wikibooks.org"
     ],
     "wired.com": [
-      "newyorker.com",
-      "vanityfair.com",
-      "vogue.com"
-    ],
-    "wise.space": [
-      "purevolume.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
-      "canada.com",
-      "globalnews.ca"
+      "globalnews.ca",
+      "bostonherald.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
     ],
-    "wishpond.net": [
-      "discovermagazine.com"
-    ],
     "wistia.com": [
-      "zendesk.com",
       "typeform.com",
       "photoshelter.com"
     ],
@@ -15546,18 +7665,15 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "upwork.com",
-      "zappos.com",
-      "redbubble.com"
+      "upwork.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "wnyc.org": [
-      "newyorker.com",
-      "qq.com"
+      "newyorker.com"
     ],
     "wolfram.com": [
       "wolframalpha.com"
@@ -15566,55 +7682,38 @@
       "tinypic.com"
     ],
     "woopic.com": [
-      "orange.fr",
-      "2345.com"
+      "orange.fr"
     ],
     "wordpress.com": [
       "time.com",
-      "prnewswire.com",
-      "cbslocal.com",
       "fortune.com",
       "akismet.com",
+      "cbslocal.com",
       "nypost.com",
       "news.com.au",
       "variety.com",
       "metro.co.uk",
       "people.com",
-      "woocommerce.com",
-      "ew.com",
-      "jetpack.com"
+      "woocommerce.com"
+    ],
+    "workandmoney.com": [
+      "nbcsports.com"
     ],
     "wrating.com": [
-      "163.com",
       "jrj.com.cn",
       "weather.com.cn"
     ],
-    "wsj.com": [
+    "wsj.net": [
+      "wsj.com",
       "marketwatch.com"
     ],
-    "wsj.net": [
-      "marketwatch.com",
-      "sfgate.com",
-      "wsj.com"
-    ],
     "wsod.com": [
-      "seekingalpha.com",
-      "zerohedge.com",
-      "yahoo.com"
+      "yahoo.com",
+      "zerohedge.com"
     ],
     "wt-eu02.net": [
-      "virgilio.it",
-      "libero.it"
-    ],
-    "wurfl.io": [
-      "dw.com",
-      "bartleby.com"
-    ],
-    "wywyuserservice.com": [
-      "vmware.com"
-    ],
-    "xad.com": [
-      "vt.edu"
+      "libero.it",
+      "virgilio.it"
     ],
     "xe19io.com": [
       "nme.com"
@@ -15628,18 +7727,18 @@
     ],
     "xiti.com": [
       "lemonde.fr",
-      "unblog.fr",
-      "uefa.com"
+      "skyrock.com",
+      "faz.net",
+      "leparisien.fr"
     ],
     "xlisting.jp": [
-      "rakuten.co.jp",
-      "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "xplosion.de": [
-      "t-online.de",
       "spiegel.de",
-      "faz.net"
+      "sueddeutsche.de",
+      "zeit.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
@@ -15647,94 +7746,81 @@
     "xtgreat.com": [
       "qq.com"
     ],
-    "xxxlutz.de": [
-      "t-online.de"
-    ],
     "yadro.ru": [
       "vk.com",
-      "novostimira.com",
-      "mail.ru"
+      "mail.ru",
+      "rt.com",
+      "ok.ru",
+      "radikal.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
+      "economist.com",
       "exblog.jp",
-      "rakuten.co.jp"
+      "ocn.ne.jp"
     ],
     "yahoo.com": [
       "vimeo.com",
-      "flickr.com"
+      "tumblr.com",
+      "flickr.com",
+      "fool.com",
+      "eset.com"
     ],
     "yandex.ru": [
-      "livejournal.com",
       "opera.com",
-      "stanford.edu",
+      "livejournal.com",
       "ning.com",
-      "qip.ru",
-      "tass.ru",
+      "rt.com",
+      "liveinternet.ru",
+      "sputniknews.com",
       "radikal.ru"
-    ],
-    "yandex.ua": [
-      "kharkov.ua",
-      "kh.ua"
     ],
     "yastatic.net": [
-      "qip.ru",
-      "tass.ru",
-      "radikal.ru"
-    ],
-    "yieldify.com": [
-      "logitech.com"
+      "sputniknews.com",
+      "ria.ru",
+      "yandex.ru"
     ],
     "yieldlab.net": [
+      "t-online.de",
+      "springer.com",
       "spiegel.de",
-      "heise.de",
-      "faz.net"
+      "heise.de"
     ],
     "yieldoptimizer.com": [
-      "ihg.com",
-      "hyatt.com",
-      "philly.com"
+      "groupon.com"
     ],
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
-      "dropbox.com",
-      "sbs.com.au"
+      "qualtrics.com"
     ],
     "yldbt.com": [
-      "wired.com",
-      "arstechnica.com",
-      "newyorker.com"
-    ],
-    "ymetrica1.com": [
-      "kharkov.ua",
-      "kh.ua",
-      "ucoz.ru"
-    ],
-    "yoox.it": [
-      "net-a-porter.com"
+      "usatoday.com",
+      "pcworld.com",
+      "computerworld.com",
+      "biography.com"
     ],
     "yotpo.com": [
       "gopro.com"
     ],
     "youtube-nocookie.com": [
-      "epa.gov",
       "moodle.org",
       "popsci.com",
       "uscourts.gov"
     ],
     "youtube.com": [
-      "vimeo.com",
       "google.com",
-      "godaddy.com",
       "mozilla.org",
+      "nih.gov",
       "telegraph.co.uk",
-      "brown.edu"
+      "boutell.com",
+      "uh.edu",
+      "dezeen.com",
+      "honeywell.com"
     ],
     "youvisit.com": [
       "osu.edu",
-      "oregonstate.edu",
       "fsu.edu"
     ],
     "ypcdn.com": [
@@ -15749,50 +7835,34 @@
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com"
+      "ign.com",
+      "speedtest.net",
+      "everydayhealth.com"
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com",
-      "infoplease.com"
+      "thehindu.com"
     ],
     "zemanta.com": [
-      "independent.co.uk",
-      "thehill.com",
-      "farfetch.com"
-    ],
-    "zendesk.com": [
-      "jugem.jp",
-      "in.gov",
-      "hobbyking.com"
+      "paypal.com",
+      "usatoday.com",
+      "mirror.co.uk",
+      "farfetch.com",
+      "colourlovers.com"
     ],
     "zergnet.com": [
       "imdb.com",
-      "pcmag.com",
-      "rollingstone.com"
-    ],
-    "zhaopin.cn": [
-      "zhaopin.com"
-    ],
-    "zhiziyun.com": [
-      "ctrip.com"
+      "marketwatch.com",
+      "weather.com",
+      "tmz.com"
     ],
     "zidtech.com": [
       "coindesk.com"
     ],
     "ziffdavis.com": [
-      "ign.com",
       "extremetech.com"
     ],
-    "zoho.com": [
-      "zoho.in"
-    ],
-    "zohopublic.com": [
-      "zoho.com"
-    ],
     "zoomph.com": [
-      "udel.edu",
-      "biglobe.ne.jp",
       "uga.edu"
     ],
     "zprk.io": [
@@ -15804,5 +7874,5 @@
       "parallels.com"
     ]
   },
-  "version": "2018.9.18"
+  "version": "2018.9.19"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,7 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535286656578,
+      "nextUpdateTime": 1535598197544,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -18,99 +18,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "126.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "127.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "15gifts.com": {
+    "194-vvc-221.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535671078852,
       "userAction": ""
     },
-    "1dmp.io": {
+    "20798148p.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535760970927,
       "userAction": ""
     },
-    "1rx.io": {
+    "2771890.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535477982326,
+      "userAction": ""
+    },
+    "2912a.v.fwmrm.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535520902504,
+      "userAction": ""
+    },
+    "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "23video.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "247-inc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "2mdnsys.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535508988871,
       "userAction": ""
     },
     "2o7.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "33across.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360buyimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360yield.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "3gl.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -123,145 +69,157 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535622422355,
+      "nextUpdateTime": 1535388856176,
+      "userAction": ""
+    },
+    "4292932.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535492182388,
+      "userAction": ""
+    },
+    "4303900.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535709815906,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535775348784,
+      "nextUpdateTime": 1535690936934,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535742976621,
+      "nextUpdateTime": 1535282712221,
+      "userAction": ""
+    },
+    "4645712.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535642991767,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535601822060,
+      "nextUpdateTime": 1535526803320,
       "userAction": ""
     },
-    "4dsply.com": {
+    "516-dgm-318.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "50bang.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535662787551,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421406745,
+      "nextUpdateTime": 1535488582093,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535678362084,
+      "nextUpdateTime": 1535328095043,
       "userAction": ""
     },
-    "58.com": {
+    "5779616.fls.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "58cdn.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "5p4rk13.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535323766046,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535474821572,
+      "nextUpdateTime": 1535614886406,
       "userAction": ""
     },
-    "6sc.co": {
+    "6954342.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535360379630,
+      "userAction": ""
+    },
+    "8117415.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535440566618,
+      "userAction": ""
+    },
+    "8242400.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535299551431,
+      "userAction": ""
+    },
+    "8758559.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535315581112,
+      "userAction": ""
+    },
+    "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "7eer.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "7grid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535376693594,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535542110562,
+      "nextUpdateTime": 1535719315712,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535742693411,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535589740320,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535463154990,
+      "nextUpdateTime": 1535470877593,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535540108802,
+      "nextUpdateTime": 1535702667567,
       "userAction": ""
     },
-    "aamsitecertifier.com": {
+    "a6250770393.cdn.optimizely.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535724954686,
+      "userAction": ""
+    },
+    "a7718922374.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535483154043,
+      "userAction": ""
+    },
+    "aa.agkn.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535780115828,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535404732620,
+      "nextUpdateTime": 1535779559578,
       "userAction": ""
     },
-    "aaxads.com": {
+    "aax.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "abmr.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "accessatlanta.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535412607145,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -270,28 +228,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.pinterest.com": {
+    "accounts.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535476844661,
-      "userAction": ""
-    },
-    "accuweather.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535434218229,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535648447717,
-      "userAction": ""
-    },
-    "acint.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535660982750,
       "userAction": ""
     },
     "acpm.fr": {
@@ -300,43 +246,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "acquia.com": {
+    "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535490888501,
       "userAction": ""
     },
-    "actionnetwork.org": {
+    "activenetwork-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535404713512,
       "userAction": ""
     },
-    "acuityplatform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "acxiomapac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-hatena.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-stir.com": {
+    "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535641831031,
       "userAction": ""
     },
-    "ad-survey.com": {
+    "ad-score.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -344,55 +272,19 @@
     },
     "ad.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535775636862,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535379331728,
       "userAction": ""
     },
-    "adapf.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adaraanalytics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adc-srv.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adclear.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "addroplet.com": {
+    "ad.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535307543537,
       "userAction": ""
     },
     "addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "addtoany.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adentifi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -402,57 +294,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adfox.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adfront.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adidas.fi": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adingo.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adition.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adjust-net.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adlmerge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -462,58 +306,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admaster.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "admiral.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535772075044,
-      "userAction": ""
-    },
-    "admission.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "admixer.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adobe.com": {
+    "ado.pro-market.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adotmob.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535527859438,
       "userAction": ""
     },
     "adroll.com": {
@@ -525,37 +327,43 @@
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370835027,
+      "nextUpdateTime": 1535445477120,
+      "userAction": ""
+    },
+    "ads.rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535585934820,
+      "userAction": ""
+    },
+    "ads.scorecardresearch.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535744320295,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535550355567,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535694008167,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535565086150,
-      "userAction": ""
-    },
-    "adscale.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535577473176,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535326224607,
+      "nextUpdateTime": 1535711402958,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535736403220,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535726386777,
       "userAction": ""
     },
     "adsnative.com": {
@@ -564,19 +372,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsniper.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -588,63 +384,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtags.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adtdp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "advertur.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adwstats.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx.com.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adzerk.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aetnd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "afilio.com.br": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -654,87 +396,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aid-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aidata.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aili.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aimfr.solution.weborama.fr": {
+    "aimfar.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535542761690,
-      "userAction": ""
-    },
-    "ajx130.online": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "akamaihd.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "akamaized.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "albacross.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alibaba.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alicdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alipay.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aliyun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535609624527,
       "userAction": ""
     },
     "allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "am15.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -744,58 +414,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "amazon.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "amazon.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "amazoncustomerservice.d2.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ameba.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535498841630,
+      "nextUpdateTime": 1535691963120,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535555345379,
+      "nextUpdateTime": 1535516989467,
+      "userAction": ""
+    },
+    "amplifypixel.outbrain.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535284316576,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535483731128,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535285639223,
       "userAction": ""
     },
-    "and.co.uk": {
+    "analytics.twitter.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "answcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535540660259,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -804,58 +456,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "antdsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aol.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aol.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ap.lijit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535489107203,
-      "userAction": ""
-    },
-    "ap.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "apester.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535751809759,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535490100109,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535472792249,
       "userAction": ""
     },
-    "api.company-target.com": {
+    "api-iam.intercom.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535501927149,
+      "userAction": ""
+    },
+    "api-public.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535301364451,
+      "nextUpdateTime": 1535762945972,
       "userAction": ""
     },
-    "api.ooyala.com": {
+    "api-v3.tinypass.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535704572492,
+      "userAction": ""
+    },
+    "api.adsnative.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535558537040,
+      "userAction": ""
+    },
+    "api.bounceexchange.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535711849116,
+      "userAction": ""
+    },
+    "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535630848647,
+      "userAction": ""
+    },
+    "api.nanigans.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535780608617,
+      "userAction": ""
+    },
+    "api.pymx5.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535442958777,
+      "userAction": ""
+    },
+    "api.viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535461454234,
       "userAction": ""
     },
     "apis.google.com": {
@@ -864,40 +528,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "apn.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535306650672,
-      "userAction": ""
-    },
-    "appdynamics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "apple.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aqtracker.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "arcgis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535346277488,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -906,76 +540,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "areyouahuman.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "arrivalist.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535594727054,
-      "userAction": ""
-    },
-    "asos-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "assets.adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535394076248,
-      "userAction": ""
-    },
-    "assets.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535510850486,
-      "userAction": ""
-    },
-    "atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atemda.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atgsvcs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ati-host.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "att.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535661299224,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -984,142 +552,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "audtd.com": {
+    "au.audience.newscgp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535726850586,
+      "userAction": ""
+    },
+    "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "auth.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "autoimg.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "autopilothq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535553365774,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535386434475,
+      "nextUpdateTime": 1535469524850,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535723388880,
-      "userAction": ""
-    },
-    "b1img.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535654763789,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535744100522,
-      "userAction": ""
-    },
-    "baidu.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bam-x.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535637344742,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535569138358,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535524792139,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535438816329,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535726960200,
       "userAction": ""
     },
-    "bazaarvoice.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbb.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbbpromos.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbc.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbelements.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "beacon.sojern.com": {
+    "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535622307627,
-      "userAction": ""
-    },
-    "beatport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "beemray.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "benchtag2.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "betweendigital.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535432389781,
       "userAction": ""
     },
     "bfmio.com": {
@@ -1128,57 +606,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bfmtv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535711505346,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535784224054,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535650884138,
+      "nextUpdateTime": 1535573293865,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535739989901,
-      "userAction": ""
-    },
-    "biddingx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bidr.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535551251160,
       "userAction": ""
     },
     "bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bigmining.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bigmir.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1188,75 +636,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bitbucket.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizibly.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizographics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizrate.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "blogos.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bloomberg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluecava.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluemix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluetoad.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bnidx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1278,34 +660,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boston.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "botradar.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "boudja.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "brandcdn.com": {
+    "boxinc.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535478347303,
       "userAction": ""
     },
     "brides.com": {
@@ -1314,88 +678,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "brightcove.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "brightcove.net": {
+    "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535315840766,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535317580022,
+      "nextUpdateTime": 1535306900694,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535402427322,
+      "nextUpdateTime": 1535302383139,
       "userAction": ""
     },
-    "btttag.com": {
+    "c.adsymptotic.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bumlam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "c-ctrip.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535392133905,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421865228,
+      "nextUpdateTime": 1535503302723,
       "userAction": ""
     },
-    "c.jsrdn.com": {
+    "c.deployads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535330316862,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535412362928,
       "userAction": ""
     },
-    "c.ooyala.com": {
+    "c.liadm.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535584173633,
+      "userAction": ""
+    },
+    "c.statcounter.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535597776860,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535588673925,
+      "nextUpdateTime": 1535690141366,
       "userAction": ""
     },
-    "c212.net": {
+    "cache.vindicosuite.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "c3tag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cadreon.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535279594967,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -1404,34 +744,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "candlewoodsuites.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535350870640,
+      "nextUpdateTime": 1535327513388,
       "userAction": ""
     },
-    "capturehighered.net": {
+    "capture.condenastdigital.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "carambo.la": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535568142694,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -1440,70 +762,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cbsi.com": {
+    "cdn-gl.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535517244578,
       "userAction": ""
     },
-    "cbsistatic.com": {
+    "cdn.bizible.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535517807139,
+      "userAction": ""
+    },
+    "cdn.digitru.st": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535755634406,
+      "userAction": ""
+    },
+    "cdn.inquisitr.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ccgateway.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-apple.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-hotels.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-net.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535368181224,
-      "userAction": ""
-    },
-    "cdn.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535681885582,
-      "userAction": ""
-    },
-    "cdn.engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535319832215,
+      "nextUpdateTime": 1535779331445,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535361058019,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535713763814,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535470292945,
+      "nextUpdateTime": 1535528231483,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -1512,64 +804,34 @@
       "nextUpdateTime": 1529084908284,
       "userAction": ""
     },
-    "cdn.onthe.io": {
+    "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535744920970,
-      "userAction": ""
-    },
-    "cdn.static.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535611322176,
+      "nextUpdateTime": 1535560444094,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535276039817,
+      "nextUpdateTime": 1535368051541,
       "userAction": ""
     },
-    "cdn.viglink.com": {
+    "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535336572694,
-      "userAction": ""
-    },
-    "cdn.yldbt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535578016864,
+      "nextUpdateTime": 1535608113749,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535277004223,
+      "nextUpdateTime": 1535644505799,
       "userAction": ""
     },
-    "cdnwidget.com": {
+    "cdns.gigya.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cern.ch": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "changeagain.me": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "charitynavigator.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535455708662,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -1581,79 +843,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535335339975,
-      "userAction": ""
-    },
-    "chei.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chicagotribune.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinajob.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinaso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinavivaki.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "choozle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "civicscience.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ckies.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clickability.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clicktale.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clicktripz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535567467824,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -1668,40 +858,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "clmbtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cloudflare.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535507563124,
-      "userAction": ""
-    },
-    "cnet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535483839903,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535746884132,
-      "userAction": ""
-    },
-    "cnn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535365976800,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -1710,52 +876,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cnzz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "coherentpath.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cohesionapps.com": {
+    "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collector-963.tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535591536333,
-      "userAction": ""
-    },
-    "collegenet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "comm100.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535444044156,
       "userAction": ""
     },
     "company-target.com": {
@@ -1764,16 +888,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "complex.com": {
+    "condenast.demdex.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "conative.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535682892731,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -1782,34 +900,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "conductrics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "configusa.veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535312396043,
-      "userAction": ""
-    },
-    "connatix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535327816790,
-      "userAction": ""
-    },
-    "connexity.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535296279568,
       "userAction": ""
     },
     "consensu.org": {
@@ -1824,22 +918,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumable.com": {
+    "consumer.krxd.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "contentabc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535506369860,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535551827176,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535701071745,
       "userAction": ""
     },
     "contextweb.com": {
@@ -1848,52 +936,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "convertful.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "convertro.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "convio.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cornell.edu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535282313499,
-      "userAction": ""
-    },
-    "cox.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "coxbusiness.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cpex.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535424975290,
       "userAction": ""
     },
     "cpx.to": {
@@ -1902,49 +948,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cquotient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cr-nielsen.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creativecdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creativecommons.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "criteo.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "croissed.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "crowneplaza.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "crsspxl.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1956,40 +960,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cssrvsync.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535785680382,
-      "userAction": ""
-    },
-    "ct.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535721841563,
-      "userAction": ""
-    },
-    "ctv.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "curse.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "custhelp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535762279418,
       "userAction": ""
     },
     "cxense.com": {
@@ -1998,121 +972,79 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "d.adroll.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535342840522,
+      "userAction": ""
+    },
+    "d.agkn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535565611927,
+      "userAction": ""
+    },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535632869291,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535713060726,
+      "userAction": ""
+    },
+    "d.df-srv.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535364087304,
+      "userAction": ""
+    },
+    "d.la1-c2-dfw.salesforceliveagent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535674921575,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535589504356,
-      "userAction": ""
-    },
-    "d1af033869koo7.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d1rv23qj5kas56.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d2-apps.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535487468755,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535550694881,
-      "userAction": ""
-    },
-    "d41.co": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535606881689,
       "userAction": ""
     },
-    "da-ads.com": {
+    "data.ad-score.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535303631043,
       "userAction": ""
     },
-    "dailymail.co.uk": {
+    "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dailymotion.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535379877739,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535731314406,
-      "userAction": ""
-    },
-    "datamind.ru": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535357000518,
       "userAction": ""
     },
-    "datasteam.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daum.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daumcdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daumdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dc-storm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deep.bi": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "delivery.h.switchadhub.com": {
+    "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535332408469,
+      "nextUpdateTime": 1535668414319,
       "userAction": ""
     },
-    "dell.com": {
+    "de.ioam.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535731438109,
+      "userAction": ""
+    },
+    "deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2124,27 +1056,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "departapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deqwas.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "developermedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2154,45 +1068,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dezeenjobs.com": {
+    "df-srv.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dhs.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "di-dtaectolog-us-prod-1.appspot.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dianomi.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dictionary.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "digitaladsystems.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2202,28 +1080,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "disney.com": {
+    "dis.us.criteo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535432116374,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535351853085,
+      "nextUpdateTime": 1535319875858,
       "userAction": ""
     },
-    "disqus.com": {
+    "districtm-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "distiltag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535721504755,
       "userAction": ""
     },
     "districtm.io": {
@@ -2232,39 +1104,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "djv99sxoqpv11.cloudfront.net": {
+    "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dmxleo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dnnapi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535293970894,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dol.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "domdex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2274,46 +1122,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dotsub.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "doublemax.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "doublepimpssl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "doubleverify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535660981833,
-      "userAction": ""
-    },
-    "dpmsrv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535778123280,
       "userAction": ""
     },
     "drive.google.com": {
@@ -2322,13 +1140,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dx.steelhousemedia.com": {
+    "dsum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535375666559,
+      "nextUpdateTime": 1535544929225,
       "userAction": ""
     },
-    "dynad.net": {
+    "dsum.casalemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535728636063,
+      "userAction": ""
+    },
+    "dxpmedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2340,34 +1164,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dynatrace-managed.com": {
+    "eb2.3lift.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dyntrk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535569655087,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -2376,46 +1176,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ebdr3.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebis.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "econda-monitor.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ecustomeropinions.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "edge-cdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535709156246,
-      "userAction": ""
-    },
-    "edmunds.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535525806664,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -2430,106 +1194,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "elsevier.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "elsevierhealth.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emlgrid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emxdgt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "engage.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535467267128,
-      "userAction": ""
-    },
-    "envato.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "equalstyle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "espn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "estara.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "estat.com": {
+    "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "etracker.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "etsystudio.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535726564765,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535668613149,
+      "nextUpdateTime": 1535399555453,
       "userAction": ""
     },
-    "evenhotels.com": {
+    "events.mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eventsabout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535428968914,
       "userAction": ""
     },
     "everesttech.net": {
@@ -2538,58 +1224,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "everyaction.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535627703429,
-      "userAction": ""
-    },
-    "evise.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "evolok.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "evyy.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ew3.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "exactag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "excite.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "exe.bid": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535403017484,
       "userAction": ""
     },
     "exelator.com": {
@@ -2598,22 +1236,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "exosrv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "expedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535776477755,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535646811319,
       "userAction": ""
     },
     "eyeota.net": {
@@ -2622,19 +1248,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eyereturn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "eyeviewads.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ezoic.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2646,46 +1260,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "facetz.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fairfax.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fastcompany.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535767229628,
+      "nextUpdateTime": 1535725073044,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535384258292,
-      "userAction": ""
-    },
-    "fdlstatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "feathr.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535696802415,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -2700,154 +1284,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ffx.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fidelity-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "filepicker.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "firstimpression.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flashtalking.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flickr.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flipboard.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flyercity.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fontawesome.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foresee.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "forms.hubspot.com": {
+    "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535314602665,
-      "userAction": ""
-    },
-    "formstack.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fout.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fox.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxbusiness.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxnews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxsports.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxycart.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "freeskreen.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535786271610,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535545678626,
-      "userAction": ""
-    },
-    "freshdesk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "friendbuy.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "funcaptcha.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "funnyordie.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535281885570,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -2864,92 +1316,56 @@
     },
     "g2.gumgum.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535321909354,
-      "userAction": ""
-    },
-    "g2crowd.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535692750885,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535664024752,
+      "nextUpdateTime": 1535691303682,
       "userAction": ""
     },
-    "gamer-network.net": {
+    "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535691097103,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535688623621,
+      "nextUpdateTime": 1535545531677,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535283408614,
+      "nextUpdateTime": 1535587812182,
+      "userAction": ""
+    },
+    "gannett.hb.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535649331173,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535451768544,
-      "userAction": ""
-    },
-    "gemius.pl": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gentags.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535491753062,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535307250586,
+      "userAction": ""
+    },
+    "geosync.solution.weborama.fr": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535374294843,
-      "userAction": ""
-    },
-    "getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getdrip.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getpocket.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getsmartcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gfycat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535284522122,
       "userAction": ""
     },
     "gigya.com": {
@@ -2958,33 +1374,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "giphy.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "github.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "globalwebindex.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gmossp-sp.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3000,18 +1392,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "goo.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "google.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "google.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3021,7 +1401,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535422625541,
+      "nextUpdateTime": 1535317462506,
       "userAction": ""
     },
     "gq.com": {
@@ -3033,19 +1413,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535323245373,
-      "userAction": ""
-    },
-    "gridsumdissector.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "groupondata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535648552872,
       "userAction": ""
     },
     "groups.google.com": {
@@ -3054,33 +1422,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gsimedia.net": {
+    "gscounters.us1.gigya.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535453629901,
       "userAction": ""
     },
-    "gssprt.jp": {
+    "gslbeacon.lijit.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535367472545,
       "userAction": ""
     },
-    "gtags.net": {
+    "gum.criteo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535629285942,
       "userAction": ""
     },
     "gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "guoshipartners.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3090,286 +1452,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hatena.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hatena.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hbevents.1rx.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535462113539,
-      "userAction": ""
-    },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535354947278,
+      "nextUpdateTime": 1535465563548,
       "userAction": ""
     },
-    "healte.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hearstnp.com": {
+    "hpr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535418833610,
       "userAction": ""
     },
-    "help.com": {
+    "i.liadm.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hiexpress.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "highwire.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hitslink.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hive.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hlserve.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "holidayinn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "holidayinnresorts.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "horyzon-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hotelindigo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hotelsapi.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "htmedia.in": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huffingtonpost.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huffingtonpost.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huihui.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hwcdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hypemarks.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535364247788,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535360193879,
-      "userAction": ""
-    },
-    "i.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "i1img.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ib-ibi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535423720799,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535769237395,
+      "nextUpdateTime": 1535418433351,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535784604446,
+      "nextUpdateTime": 1535791087893,
       "userAction": ""
     },
-    "ibclick.stream": {
+    "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ibillboard.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ibt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535533568374,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535504362106,
-      "userAction": ""
-    },
-    "id5-sync.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "idealmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ign.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "igodigital.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iheart.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "im-apps.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imagetopng.club": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imedia.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "img.purch.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imgfarm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imgur.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "impact-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535505218565,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -3378,34 +1506,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "infinity-tracking.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "infinityid.condenastdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535705265312,
-      "userAction": ""
-    },
-    "infolinks.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "innovid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "inq.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535334042860,
       "userAction": ""
     },
     "inquisitr.com": {
@@ -3414,16 +1518,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "inside-graph.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535293278709,
+      "nextUpdateTime": 1535515823670,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -3432,34 +1530,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "instagram.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535314940322,
-      "userAction": ""
-    },
-    "instinctiveads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "intentiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "intentmedia.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535619321717,
       "userAction": ""
     },
     "intercom.io": {
@@ -3468,45 +1542,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "intergient.com": {
+    "investing-channel-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "internetbrands.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "investis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "invoc.us": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535538084696,
       "userAction": ""
     },
     "ioam.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3516,58 +1560,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ipinyou.com": {
+    "ips-invite.iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ipredictive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "irs01.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "izooto.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535461878087,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535488196626,
-      "userAction": ""
-    },
-    "janrainsso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jd.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jquery.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jrs5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535692870860,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -3582,39 +1584,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "justpremium.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jword.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jyxo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kakao.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kameleoon.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3660,27 +1632,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "kinja.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kiwiirc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "l.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3690,61 +1644,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ladsp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "leadintel.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "leaf.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "legocdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lejwaengv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "liadm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "libero.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licasd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ligadx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3762,39 +1662,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lincoln.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "link-page.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "linksynergy.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "list-manage.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "listrakbi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3810,130 +1680,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "livedoor.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "livejournal.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "liveperson.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lkqd.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "load.sumo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535536085224,
-      "userAction": ""
-    },
-    "loc.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lockerdome.com": {
+    "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535455362196,
+      "nextUpdateTime": 1535681411551,
       "userAction": ""
     },
-    "log.mmstat.com": {
+    "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535759748439,
+      "nextUpdateTime": 1535321905319,
+      "userAction": ""
+    },
+    "loadus.exelator.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535566793461,
+      "userAction": ""
+    },
+    "log.outbrain.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535418449649,
+      "userAction": ""
+    },
+    "login-ds.dotomi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535561002865,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535540033786,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535755600759,
       "userAction": ""
     },
-    "logly.co.jp": {
+    "login.live.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535388260240,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535391723972,
-      "userAction": ""
-    },
-    "lqm.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lucklayed.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lwcal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lytics.io": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535584230515,
       "userAction": ""
     },
-    "m6r.eu": {
+    "m.addthis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535708708425,
+      "userAction": ""
+    },
+    "map.dxpmedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "madeleine.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mail.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mailchimp.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mantisadnetwork.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535628695462,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -3954,34 +1764,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "match.adsrvr.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535384308840,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535652945157,
       "userAction": ""
     },
-    "matheranalytics.com": {
+    "match.deepintent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535460992471,
+      "userAction": ""
+    },
+    "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535663791310,
       "userAction": ""
     },
     "mathtag.com": {
@@ -3993,7 +1791,13 @@
     "mc.webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535379216286,
+      "nextUpdateTime": 1535286232291,
+      "userAction": ""
+    },
+    "mc.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535536846686,
       "userAction": ""
     },
     "media.net": {
@@ -4011,58 +1815,10 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535641072175,
-      "userAction": ""
-    },
-    "mediaforge.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medialand.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediaplex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535302299674,
       "userAction": ""
     },
     "mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediav.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediawallahscript.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medscape.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medtargetsystem.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mendeley.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -4074,64 +1830,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "metadsp.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mg2connext.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mgid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "miamiherald.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microad.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microsoft.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microsoftonline.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "mid.rkdms.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535498798816,
-      "userAction": ""
-    },
-    "mirtesen.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535606263682,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -4143,85 +1845,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535599816345,
-      "userAction": ""
-    },
-    "mlb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mlive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mmtro.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "molefefiseranis.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monetate.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monster.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mookie1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mouseflow.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mpnrs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mrpfd.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "msgapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "msn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535387249359,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -4233,12 +1857,6 @@
     "mt1.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mthsense.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4254,31 +1872,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mtty.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtvnservices.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "multiview.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "musthird.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "muumuu-domain.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4296,160 +1890,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mx.technolutions.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535385268290,
-      "userAction": ""
-    },
-    "mybuys.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myhard.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mynativeplatform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myregistry.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myspacecdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myvisualiq.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nasdaq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nationalgeographic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "native.ai": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535536609168,
-      "userAction": ""
-    },
-    "nativendo.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "naver.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "naver.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nbcnews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nbcuni.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "netdna-ssl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "netmng.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newatlas.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "neweggimages.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535381874834,
       "userAction": ""
     },
     "newscgp.com": {
@@ -4458,28 +1908,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "newsinc.com": {
+    "newscorpau.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsmemory.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsvine.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsweekgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535311629687,
       "userAction": ""
     },
     "newyorker.com": {
@@ -4488,34 +1920,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexac.com": {
+    "nexus-websocket-a.intercom.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535376489955,
       "userAction": ""
     },
-    "ngpvan.com": {
+    "nexus-websocket-b.intercom.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nih.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nokia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "norton.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535418451285,
       "userAction": ""
     },
     "nr-data.net": {
@@ -4524,153 +1938,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nsaudience.pl": {
+    "oclc.112.2o7.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nscontext.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nuggad.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nxtck.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nymag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nzaza.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "o0bg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oasc10.247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535771010830,
-      "userAction": ""
-    },
-    "oath.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ocdn.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oclc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ofapes.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "office.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "office365.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ojrq.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ok.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "olark.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "olympicchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omkt.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omnidsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535785645386,
       "userAction": ""
     },
     "omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onclickmega.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onecount.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onet.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4680,45 +1956,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "onevision.com.tw": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "online-metrix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onsugar.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "openhub.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "openstat.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4728,75 +1968,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "opf.ooyala.com": {
+    "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "opinionstage.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optaim.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimix.asia": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535785571775,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimove.events": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ora.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oracleimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "orangeads.fr": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oreilly.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "otm-r.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "otto.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4806,28 +1986,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ovh.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "owox.com": {
+    "p.adsymptotic.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535329796782,
       "userAction": ""
     },
-    "paddle.com": {
+    "p.cpx.to": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535520890292,
+      "userAction": ""
+    },
+    "p.dlx.addthis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535389036499,
+      "userAction": ""
+    },
+    "p.rfihub.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535511748310,
+      "userAction": ""
+    },
+    "p.skimresources.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535711083150,
+      "userAction": ""
+    },
+    "p.yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535505388228,
+      "userAction": ""
+    },
+    "p2.keywee.co": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535641328780,
       "userAction": ""
     },
     "pardot.com": {
@@ -4842,81 +2046,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "paypal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "paypalobjects.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "payroll.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pbskids.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pcmag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pdmp.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "performgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "perimeterx.net": {
+    "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535336231323,
       "userAction": ""
     },
-    "pewresearch.org": {
+    "pd.sharethis.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535496198612,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535701822972,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535546381760,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4929,73 +2079,79 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535775677065,
       "userAction": ""
     },
-    "pixanalytics.com": {
+    "pixel-geo.prfct.co": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535759777976,
+      "userAction": ""
+    },
+    "pixel.advertising.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535462179315,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535283808671,
+      "nextUpdateTime": 1535427198698,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535373297517,
+      "userAction": ""
+    },
+    "pixel.mathtag.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535599324347,
+      "nextUpdateTime": 1535355242307,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535293467498,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535647714316,
       "userAction": ""
     },
-    "pixel.s3xified.com": {
+    "pixel.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535351756763,
+      "nextUpdateTime": 1535525085673,
       "userAction": ""
     },
-    "piximedia.com": {
+    "pixel.sitescout.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535665286918,
       "userAction": ""
     },
-    "pixnet.cc": {
+    "pixel.tapad.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535312220420,
       "userAction": ""
     },
-    "placed.com": {
+    "pixeltrack.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535543028633,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535707414696,
+      "nextUpdateTime": 1535298519588,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535508990081,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "play.google.com": {
@@ -5004,34 +2160,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535784596525,
+      "nextUpdateTime": 1535737640371,
       "userAction": ""
     },
-    "players.brightcove.net": {
+    "playwire-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "playwire.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "plista.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535668829519,
       "userAction": ""
     },
     "plus.google.com": {
@@ -5043,31 +2181,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "polymorphicads.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "popin.cc": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "popsugar-assets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535606931325,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535313424134,
+      "nextUpdateTime": 1535421638602,
       "userAction": ""
     },
     "postrelease.com": {
@@ -5076,21 +2196,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "powerlinks.com": {
+    "pr-bh.ybp.yahoo.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pressboard.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535293929134,
       "userAction": ""
     },
     "prfct.co": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5100,58 +2214,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "prod-mng-proxy-connext.azurewebsites.net": {
+    "profile.justuno.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535623328400,
+      "userAction": ""
+    },
+    "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535551954716,
       "userAction": ""
     },
-    "proparm.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "provenpixel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "providesupport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "proximustv.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pscp.tv": {
+    "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535593545310,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535747649954,
-      "userAction": ""
-    },
-    "publishme.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535583692664,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -5160,129 +2244,57 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubmine.com": {
+    "purch-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pulpix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "purch.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "purechat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535370162061,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535542087750,
+      "userAction": ""
+    },
+    "px.dynamicyield.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535414302086,
+      "nextUpdateTime": 1535646457589,
       "userAction": ""
     },
-    "pxf.io": {
+    "px.owneriq.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535403538242,
       "userAction": ""
     },
-    "pxtres.com": {
+    "px.steelhousemedia.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxuno.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxzwei.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535353388308,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535707658880,
+      "nextUpdateTime": 1535419488708,
+      "userAction": ""
+    },
+    "q.quora.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535369878735,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535322507910,
-      "userAction": ""
-    },
-    "qnsr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qsstats.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qtmojo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantcast.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535303189218,
+      "nextUpdateTime": 1535360796345,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantummetric.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quickbooks.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quickbooksonline.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5292,28 +2304,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.turn.com": {
+    "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469636156,
-      "userAction": ""
-    },
-    "rackcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "radiotime.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rakuten.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535352011476,
       "userAction": ""
     },
     "rambler.ru": {
@@ -5322,135 +2316,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rbnt.org": {
+    "rand.d1.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535286295528,
       "userAction": ""
     },
-    "rcsmetrics.it": {
+    "rcom.dynamicyield.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reachmax.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535306518026,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694127287,
+      "nextUpdateTime": 1535694908698,
       "userAction": ""
     },
-    "reddit.com": {
+    "registercom.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535378845796,
       "userAction": ""
     },
-    "redlink.com": {
+    "registercom.tt.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reference.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "regmedia.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "relap.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "republer.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "researchintel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reson8.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "responsetap.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reutersmedia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "revjet.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rezync.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535430722611,
       "userAction": ""
     },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ria.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "richrelevance.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rightnowtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5466,63 +2364,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rnengage.com": {
+    "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535722022072,
       "userAction": ""
     },
-    "rockyou.net": {
+    "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535789545771,
       "userAction": ""
     },
-    "roomkey.com": {
+    "rtb.districtm.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "roymorgan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtb.com.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtk.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ru4.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535426725737,
       "userAction": ""
     },
     "rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rundsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rutarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5535,61 +2397,79 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535620231354,
+      "nextUpdateTime": 1535544352908,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535361444004,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535604512693,
       "userAction": ""
     },
-    "s.clickability.com": {
+    "s.cpx.to": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535629576922,
+      "userAction": ""
+    },
+    "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535500020630,
+      "nextUpdateTime": 1535598595757,
+      "userAction": ""
+    },
+    "s.jsrdn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535337571271,
+      "userAction": ""
+    },
+    "s.po.st": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535309914794,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535347553762,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535468509231,
+      "userAction": ""
+    },
+    "s.thebrighttag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535566474727,
+      "userAction": ""
+    },
+    "s.yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535661147872,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535497869463,
+      "nextUpdateTime": 1535527772076,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535700678259,
+      "nextUpdateTime": 1535375732663,
       "userAction": ""
     },
-    "s3-us-west-2.amazonaws.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "s3xified.com": {
+    "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535418939591,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535567994221,
-      "userAction": ""
-    },
-    "sabavision.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535312742531,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -5598,88 +2478,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "salesloft.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "salesmanago.pl": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "samba.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535304655636,
+      "nextUpdateTime": 1535671086115,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535415217899,
+      "userAction": ""
+    },
+    "sbnationbidder-d.openx.net": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535380369509,
-      "userAction": ""
-    },
-    "sbal4kp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scarabresearch.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535520014307,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535709010353,
-      "userAction": ""
-    },
-    "scholarlyiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciencedirect.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciencedirectassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciverse.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scoop.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scopus.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535492741324,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -5688,10 +2508,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "scribblelive.com": {
+    "scripps.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535722846588,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -5700,16 +2520,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sddan.com": {
+    "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "seadform.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535778464447,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -5718,93 +2532,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "searchmarketing.com": {
+    "seccdn-gl.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535511738519,
+      "userAction": ""
+    },
+    "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535642980054,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535507877988,
+      "nextUpdateTime": 1535738150884,
       "userAction": ""
     },
-    "secure-cf-c.ooyala.com": {
+    "secure-ds.serving-sys.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535510232378,
+      "userAction": ""
+    },
+    "secure-gl.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535389044916,
+      "userAction": ""
+    },
+    "secure-it.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535444722549,
+      "userAction": ""
+    },
+    "secure-us.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535337220991,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535629104659,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535346501751,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535541191462,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535490196521,
+      "userAction": ""
+    },
+    "secure.livechatinc.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535340041154,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535676669760,
-      "userAction": ""
-    },
-    "securedvisit.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535662738397,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535462521946,
-      "userAction": ""
-    },
-    "seekingalpha.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535494946898,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535611375395,
+      "nextUpdateTime": 1535708162903,
       "userAction": ""
     },
-    "sekindo.com": {
+    "segments.company-target.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436904126,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "semasio.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5814,33 +2628,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servedby-buysellads.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "serverbid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shareaholic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5856,81 +2646,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sheego.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shop.pe": {
+    "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shopify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "simplereach.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "simpli.fi": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sina.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sina.com.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sinoptik.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitehelix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535443540105,
       "userAction": ""
     },
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "siteimproveanalytics.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitelabweb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitelock.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5952,147 +2676,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sky.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "slashdotmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartadserver.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartclip.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535639501499,
-      "userAction": ""
-    },
-    "smashing-delivery.herokuapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smi2.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smithsonian.museum": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smyte.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535591895325,
       "userAction": ""
     },
     "snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "snapwidget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "snplow.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "so.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "socdm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sociomantic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "soflopxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "softonic-analytics.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sogou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sohu.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sojern.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sokrati.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "soliditet.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solocpm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6102,99 +2694,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sonyentertainmentnetwork.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sourceforge.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sp.analytics.yahoo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535735045296,
-      "userAction": ""
-    },
-    "sp.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spectate.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sphereup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spiceworks.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spineuniverse.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spingo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spot.im": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spotify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spots.im": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535500469983,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6204,70 +2718,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "springernature.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "springserve.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sprinklr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "srv-2018-08-25-08.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535294050043,
-      "userAction": ""
-    },
     "srv-2018-08-25-09.config.parsely.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535320516701,
+      "userAction": ""
+    },
+    "srv-2018-08-25-09.pixel.parsely.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389542000,
+      "nextUpdateTime": 1535492273466,
+      "userAction": ""
+    },
+    "srv-2018-08-25-10.config.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535675261339,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535333761299,
+      "nextUpdateTime": 1535327444761,
       "userAction": ""
     },
-    "srx.com.sg": {
+    "ssl.siteimprove.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535590743011,
       "userAction": ""
     },
-    "stackadapt.com": {
+    "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535583569862,
       "userAction": ""
     },
-    "staples-sparx.com": {
+    "ssum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535766135977,
       "userAction": ""
     },
-    "staples-static.com": {
+    "st.dynamicyield.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "starfieldtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535591035984,
       "userAction": ""
     },
     "statcounter.com": {
@@ -6282,111 +2778,45 @@
       "nextUpdateTime": 1529315030088,
       "userAction": ""
     },
-    "static.apester.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535467557092,
-      "userAction": ""
-    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535601577779,
+      "nextUpdateTime": 1535419436462,
       "userAction": ""
     },
-    "static.getclicky.com": {
+    "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535707810492,
+      "nextUpdateTime": 1535526724439,
       "userAction": ""
     },
-    "static.mediarithmics.com": {
+    "static.quantcast.mgr.consensu.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535774749817,
-      "userAction": ""
-    },
-    "staticimgfarm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535354675061,
       "userAction": ""
     },
     "staticxx.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535552916169,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535769350544,
+      "nextUpdateTime": 1535449503047,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535673063982,
-      "userAction": ""
-    },
-    "staybridge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535353496047,
       "userAction": ""
     },
     "steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "steepto.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stg-sp.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stg8.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stickyadstv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "storage.googleapis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "storygize.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "streem.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "streetscout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6399,7 +2829,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535385706713,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -6408,76 +2838,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "suning.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sunrtb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "supplyframe.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "survata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535626849664,
+      "nextUpdateTime": 1535466735514,
       "userAction": ""
     },
-    "surveymonkey.com": {
+    "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535402210709,
       "userAction": ""
     },
-    "switchadhub.com": {
+    "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535601519697,
       "userAction": ""
     },
-    "symantec.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "synacor.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sync.1rx.io": {
+    "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535475220637,
+      "nextUpdateTime": 1535354555122,
+      "userAction": ""
+    },
+    "sync.adkernel.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535721836756,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535707308539,
+      "userAction": ""
+    },
+    "sync.go.sonobi.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535486045547,
+      "nextUpdateTime": 1535279621142,
+      "userAction": ""
+    },
+    "sync.mathtag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535481640591,
+      "userAction": ""
+    },
+    "sync.multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535782023227,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535723607166,
+      "nextUpdateTime": 1535286963228,
+      "userAction": ""
+    },
+    "sync.teads.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535597792238,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -6492,46 +2916,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tacdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tag.1rx.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535430884961,
-      "userAction": ""
-    },
-    "tag.audience.acpm.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535529659019,
-      "userAction": ""
-    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535308652245,
-      "userAction": ""
-    },
-    "tag4arm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tagdelivery.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tailtarget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535325417249,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -6540,45 +2928,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tamgrt.com": {
+    "tap-secure.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tanx.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "taobao.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535448475939,
       "userAction": ""
     },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "targetimg1.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tawk.to": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tcell.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6594,39 +2952,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "technolutions.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "techweb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "telegraph.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "telekom.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tenmax.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6636,76 +2964,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "theatlas.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "theglobeandmail.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "theguardian.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thesaurus.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thomsonreuters.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535635715151,
-      "userAction": ""
-    },
-    "tidaltv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tidelinedata.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535452783142,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535282600241,
-      "userAction": ""
-    },
-    "timewarnercable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535746635108,
       "userAction": ""
     },
     "tinypass.com": {
@@ -6714,34 +2988,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tiqcdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tl813.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535732106207,
-      "userAction": ""
-    },
-    "tm-awx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tmall.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535550935721,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -6750,76 +3000,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "toutapp.com": {
+    "top100.rambler.ru": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535684529979,
       "userAction": ""
     },
-    "tracc.it": {
+    "tr.snapchat.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535544639408,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535492957754,
-      "userAction": ""
-    },
-    "track.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535789537864,
-      "userAction": ""
-    },
-    "trackad.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trackalyzer.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tradedoubler.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tradelab.fr": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficgate.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficjam.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficjunky.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535567234151,
       "userAction": ""
     },
     "translate.google.com": {
@@ -6828,22 +3024,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "travelzoo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trb.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "treasuredata.com": {
+    "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535732628184,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -6858,99 +3042,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trends.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535657111047,
-      "userAction": ""
-    },
-    "tribalfusion.com": {
+    "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tribl.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tripadvisor.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tronc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trumba.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "truoptik.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustev.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustpilot.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trvl-px.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tumblr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535545230967,
       "userAction": ""
     },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tutorialize.me": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "twimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6969,210 +3069,42 @@
     "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535337795053,
+      "nextUpdateTime": 1535784547100,
       "userAction": ""
     },
-    "ubi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uciservice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ucoz.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "udmserve.net": {
+    "ups.xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535623217710,
+      "nextUpdateTime": 1535314703086,
       "userAction": ""
     },
-    "udnfunlife.com": {
+    "us-u.openx.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535688937954,
       "userAction": ""
     },
-    "uefa.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ufpcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ugdturner.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "undertone.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unicc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unity.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unrulymedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "upravel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "upsellit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uptolike.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "urbandictionary.store": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "usa.gov": {
+    "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535597114866,
       "userAction": ""
     },
-    "useproof.com": {
+    "us5.siteimprove.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535432676742,
       "userAction": ""
     },
-    "usergram.info": {
+    "va.v.liveperson.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "userreport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ustream.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "utarget.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "utarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uuidksinc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "v12group.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535729794135,
       "userAction": ""
     },
     "vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "velaro.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "velemh.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vendorlist.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535496547035,
-      "userAction": ""
-    },
-    "verticalhealth.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "veruta.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viafoura.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viafoura.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7182,31 +3114,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "videoamp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "videohub.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vidible.tv": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "viglink.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vilynx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -7224,34 +3132,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "virgilio.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "visitor-service.tealiumiq.com": {
+    "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535328116340,
+      "nextUpdateTime": 1535434926452,
       "userAction": ""
     },
-    "visualstudio.com": {
+    "vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vizury.com": {
+    "vmss.boldchat.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vk.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535472656099,
       "userAction": ""
     },
     "vogue.com": {
@@ -7260,10 +3156,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "volvelle.tech": {
+    "vop.sundaysky.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535338852200,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -7272,103 +3168,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vtracy.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535362215363,
+      "nextUpdateTime": 1535690600138,
       "userAction": ""
     },
-    "w55c.net": {
+    "wam-yahoo.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535775196955,
+      "userAction": ""
+    },
+    "wamfactory.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wallst.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "waptime.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "warnerbros.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wbtrk.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wcfbc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "weather.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535325407427,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535533523401,
-      "userAction": ""
-    },
-    "webmd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535709876484,
       "userAction": ""
     },
     "weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webpush.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "websimages.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webtrekk.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -7386,34 +3210,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "weibo.com": {
+    "widgets.outbrain.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "welt.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "whistleout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wikia-services.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wikimedia.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535679663540,
       "userAction": ""
     },
     "wired.com": {
@@ -7422,49 +3222,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wise.space": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "wishabi.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wishpond.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wishpond.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wistia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wistia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wkxppshj-qx.global.ssl.fastly.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
@@ -7476,88 +3234,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wnyc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "woobi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "woopic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wordpress.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wrating.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421603690,
+      "nextUpdateTime": 1535335492897,
       "userAction": ""
     },
-    "wsj.com": {
+    "ww.steelhousemedia.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wsj.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wurfl.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535556921277,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535462553112,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535475009981,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535628441125,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535491915288,
       "userAction": ""
     },
     "www.bing.com": {
@@ -7568,20 +3266,26 @@
     },
     "www.bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535435837859,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535370836192,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535722692599,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535367117721,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535540695148,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535557439829,
+      "userAction": ""
+    },
+    "www.epicurious.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535356981005,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -7592,14 +3296,14 @@
     },
     "www.glamour.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535352083508,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535304134792,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535442239807,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535654060736,
       "userAction": ""
     },
     "www.google.com": {
@@ -7610,110 +3314,98 @@
     },
     "www.gq.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535557201033,
+      "userAction": ""
+    },
+    "www.justuno.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535415783243,
+      "nextUpdateTime": 1535439526561,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535774798008,
+      "userAction": ""
+    },
+    "www.linkedin.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535584719804,
+      "nextUpdateTime": 1535438867974,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535690782225,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535786649584,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535413588731,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535513903637,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535761756013,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535483680212,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535413948315,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535581539395,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535346939476,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535452630744,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535476281376,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535391747796,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535547170595,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535721812757,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535552612700,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535369389550,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535323278489,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535752078138,
+      "userAction": ""
+    },
+    "www.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535659930279,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535773685713,
-      "userAction": ""
-    },
-    "wwwimages.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wywyuserservice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535279092662,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535595886319,
-      "userAction": ""
-    },
-    "xad.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xg4ken.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xinhuanet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535589911304,
       "userAction": ""
     },
     "xiti.com": {
@@ -7722,33 +3414,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "xlisting.jp": {
+    "xpl.theadex.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535345322663,
       "userAction": ""
     },
     "xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xs4all.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xsdownload.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xxxlutz.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7759,12 +3433,6 @@
       "userAction": ""
     },
     "yadro.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -7782,31 +3450,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yandex.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yastatic.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yieldify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yieldoptimizer.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -7818,145 +3462,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yldbt.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ymetrica1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yoox.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yotpo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "youtube-nocookie.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "youvisit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ypcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yudu.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418328014,
+      "nextUpdateTime": 1535353268865,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535371320121,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535603698010,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zedo.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535719784949,
       "userAction": ""
     },
     "zemanta.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zendesk.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zergnet.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zhaopin.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zhiziyun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ziffdavis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zoho.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zohopublic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zoomph.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -7994,9 +3524,6 @@
       "aappublications.org",
       "americanbar.org"
     ],
-    "254a.com": [
-      "zerohedge.com"
-    ],
     "2mdnsys.com": [
       "liveuamap.com"
     ],
@@ -8005,14 +3532,10 @@
       "cdc.gov",
       "theatlantic.com",
       "prnewswire.com",
-      "earthlink.net",
-      "inc.com",
-      "qz.com",
-      "philips.com",
       "fastcompany.com",
-      "infoseek.co.jp",
-      "ahajournals.org",
-      "sbs.com.au"
+      "earthlink.net",
+      "qz.com",
+      "oclc.org"
     ],
     "33across.com": [
       "accuweather.com"
@@ -8038,8 +3561,7 @@
       "springer.com",
       "theverge.com",
       "wunderground.com",
-      "macworld.com",
-      "polygon.com"
+      "focus.de"
     ],
     "4dsply.com": [
       "wnd.com"
@@ -8097,7 +3619,8 @@
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr"
+      "liberation.fr",
+      "leparisien.fr"
     ],
     "acquia.com": [
       "panasonic.com",
@@ -8111,11 +3634,13 @@
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "bartleby.com",
-      "dropbox.com"
+      "bartleby.com"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
+    ],
+    "ad-score.com": [
+      "wnd.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
@@ -8141,15 +3666,13 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com",
-      "tinypic.com"
+      "washingtonexaminer.com"
     ],
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
       "yahoo.com",
-      "dropbox.com",
-      "business-standard.com",
+      "who.int",
       "gulfnews.com"
     ],
     "addtoany.com": [
@@ -8164,7 +3687,6 @@
       "bloomberg.com",
       "springer.com",
       "shutterstock.com",
-      "si.com",
       "helsinki.fi"
     ],
     "adfox.ru": [
@@ -8190,8 +3712,7 @@
       "bloomberg.com",
       "dailymotion.com",
       "spiegel.de",
-      "t-online.de",
-      "focus.de"
+      "t-online.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -8200,7 +3721,8 @@
     "adkernel.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com"
+      "space.com",
+      "dailydot.com"
     ],
     "adlmerge.com": [
       "tomsk.ru"
@@ -8220,14 +3742,12 @@
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "jsonline.com",
-      "hgtv.com"
+      "rfi.fr"
     ],
     "adobe.com": [
       "wikipedia.org",
       "behance.net",
-      "history.com",
-      "fotolia.com"
+      "history.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
@@ -8249,7 +3769,7 @@
       "nature.com",
       "nginx.org",
       "cloudflare.com",
-      "zenfolio.com"
+      "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
@@ -8259,7 +3779,8 @@
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "informationweek.com"
+      "informationweek.com",
+      "bostonherald.com"
     ],
     "adsniper.ru": [
       "rambler.ru"
@@ -8269,8 +3790,7 @@
       "yahoo.com",
       "googletagmanager.com",
       "sourceforge.net",
-      "jsonline.com",
-      "gizmodo.com"
+      "hgtv.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -8282,7 +3802,6 @@
       "etsy.com",
       "tripadvisor.com",
       "foursquare.com",
-      "jsonline.com",
       "realtor.com"
     ],
     "adtags.pro": [
@@ -8295,9 +3814,8 @@
       "amazon.com",
       "sourceforge.net",
       "dropbox.com",
-      "msn.com",
-      "nordstrom.com",
-      "pitchfork.com"
+      "wsj.com",
+      "walgreens.com"
     ],
     "advertur.ru": [
       "radikal.ru"
@@ -8327,8 +3845,8 @@
       "amazon.com",
       "t-online.de",
       "bloomberg.com",
-      "dropbox.com",
-      "att.net"
+      "cnet.com",
+      "gizmodo.com"
     ],
     "aid-ad.jp": [
       "shinobi.jp"
@@ -8348,7 +3866,8 @@
       "voanews.com",
       "repubblica.it",
       "iyfubh.com",
-      "forbes.com"
+      "forbes.com",
+      "francetvinfo.fr"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -8361,12 +3880,14 @@
     "alibaba.com": [
       "youku.com",
       "taobao.com",
-      "aliexpress.com"
+      "aliexpress.com",
+      "tmall.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
+      "tmall.com",
       "1688.com"
     ],
     "alipay.com": [
@@ -8392,9 +3913,8 @@
       "amazon.com",
       "nytimes.com",
       "reddit.com",
-      "forbes.com",
-      "ocregister.com",
-      "gizmodo.com"
+      "cnn.com",
+      "bostonherald.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -8402,7 +3922,9 @@
     "amazon.com": [
       "qq.com",
       "imdb.com",
-      "amazon.co.uk"
+      "amazon.co.uk",
+      "amazon.de",
+      "amazon.co.jp"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -8416,7 +3938,9 @@
     "answerscloud.com": [
       "worldbank.org",
       "acs.org",
-      "fbi.gov"
+      "fbi.gov",
+      "nasa.gov",
+      "walgreens.com"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -8444,7 +3968,7 @@
       "foursquare.com",
       "history.com",
       "nbc.com",
-      "edx.org"
+      "strava.com"
     ],
     "appdynamics.com": [
       "nfl.com"
@@ -8487,9 +4011,7 @@
     "atdmt.com": [
       "facebook.com",
       "yahoo.com",
-      "msn.com",
-      "t-online.de",
-      "upwork.com"
+      "msn.com"
     ],
     "atemda.com": [
       "springer.com",
@@ -8525,10 +4047,13 @@
       "sina.com.cn",
       "163.com",
       "ifeng.com",
-      "coremail.cn"
+      "51.la"
     ],
     "bam-x.com": [
       "gq.com"
+    ],
+    "baur.de": [
+      "t-online.de"
     ],
     "bazaarvoice.com": [
       "target.com",
@@ -8567,14 +4092,12 @@
       "tomsk.ru",
       "radikal.ru"
     ],
-    "bf-tools.net": [
-      "focus.de"
-    ],
     "bfmio.com": [
       "symantec.com",
       "tinypic.com",
       "venturebeat.com",
-      "livescience.com"
+      "livescience.com",
+      "dailydot.com"
     ],
     "bfmtv.com": [
       "liberation.fr",
@@ -8587,16 +4110,14 @@
       "adobe.com",
       "dailymotion.com",
       "hootsuite.com",
-      "hp.com",
-      "upwork.com"
+      "hp.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
       "amazon.com",
-      "dropbox.com",
-      "jsonline.com",
-      "zerohedge.com"
+      "forbes.com",
+      "bostonherald.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -8610,8 +4131,6 @@
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "microsoft.com",
-      "here.com",
       "pingdom.com"
     ],
     "bitbucket.org": [
@@ -8622,11 +4141,11 @@
       "cloudflare.com",
       "zendesk.com",
       "shutterstock.com",
-      "here.com",
       "gitlab.com"
     ],
     "bizibly.com": [
-      "eventbrite.com"
+      "eventbrite.com",
+      "cloudflare.com"
     ],
     "bizographics.com": [
       "zend.com",
@@ -8638,8 +4157,7 @@
       "fortune.com",
       "people.com",
       "ew.com",
-      "time.com",
-      "si.com"
+      "time.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -8649,14 +4167,13 @@
     ],
     "bluecava.com": [
       "history.com",
-      "biography.com",
-      "complex.com"
+      "biography.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
       "sfgate.com",
-      "discovermagazine.com"
+      "chron.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -8671,7 +4188,8 @@
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org"
+      "cancer.org",
+      "networksolutions.com"
     ],
     "bonappetit.com": [
       "wired.com",
@@ -8680,7 +4198,8 @@
       "pitchfork.com"
     ],
     "boston.com": [
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "bleacherreport.com"
     ],
     "bostonglobemedia.com": [
       "boston.com"
@@ -8695,8 +4214,7 @@
       "cnn.com",
       "time.com",
       "wired.com",
-      "latimes.com",
-      "si.com",
+      "usatoday.com",
       "pitchfork.com"
     ],
     "brandcdn.com": [
@@ -8713,20 +4231,20 @@
       "si.com",
       "federalreserve.gov",
       "theaustralian.com.au",
-      "informationweek.com",
-      "straitstimes.com"
+      "informationweek.com"
     ],
     "brightcove.net": [
       "lefigaro.fr",
       "politico.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "techtarget.com"
     ],
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
       "zendesk.com",
-      "theverge.com",
-      "alternet.org"
+      "uci.edu",
+      "dailydot.com"
     ],
     "btttag.com": [
       "samsung.com",
@@ -8768,16 +4286,13 @@
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
-      "macworld.com",
       "pitchfork.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
       "gamespot.com",
-      "cnet.com",
-      "cbsnews.com",
-      "cbssports.com"
+      "cnet.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -8798,9 +4313,6 @@
     ],
     "cdnwidget.com": [
       "photoshelter.com"
-    ],
-    "cedexis-test.com": [
-      "tumblr.com"
     ],
     "cern.ch": [
       "home.cern"
@@ -8833,8 +4345,7 @@
     "circularhub.com": [
       "suntimes.com",
       "tampabay.com",
-      "bostonherald.com",
-      "stltoday.com"
+      "bostonherald.com"
     ],
     "civicscience.com": [
       "post-gazette.com",
@@ -8866,6 +4377,9 @@
       "sciencemag.org",
       "nginx.com",
       "allaboutcookies.org"
+    ],
+    "cmgdigital.com": [
+      "ajc.com"
     ],
     "cnet.com": [
       "zdnet.com"
@@ -8903,15 +4417,14 @@
     "commander1.com": [
       "ovh.com",
       "ubisoft.com",
-      "arte.tv",
-      "ovh.co.uk"
+      "arte.tv"
     ],
     "company-target.com": [
       "adobe.com",
       "ibm.com",
       "redhat.com",
       "hp.com",
-      "upwork.com"
+      "box.com"
     ],
     "complex.com": [
       "knowyourmeme.com",
@@ -8943,13 +4456,10 @@
       "variety.com",
       "adweek.com",
       "buzzfeed.com",
-      "alternet.org"
+      "nme.com"
     ],
     "consumable.com": [
       "xfinity.com"
-    ],
-    "content.ad": [
-      "tinypic.com"
     ],
     "contentabc.com": [
       "pornhub.com"
@@ -8959,7 +4469,7 @@
       "myspace.com",
       "bloomberg.com",
       "forbes.com",
-      "colourlovers.com"
+      "walgreens.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -8989,7 +4499,6 @@
       "digitaltrends.com",
       "techradar.com",
       "independent.co.uk",
-      "allmusic.com",
       "rfi.fr"
     ],
     "cquotient.com": [
@@ -9010,8 +4519,7 @@
       "washingtonpost.com",
       "dailymail.co.uk",
       "dropbox.com",
-      "alternet.org",
-      "hgtv.com"
+      "sedo.com"
     ],
     "croissed.info": [
       "4shared.com"
@@ -9042,7 +4550,7 @@
       "talktalk.co.uk",
       "gizmodo.com",
       "wsj.com",
-      "jalopnik.com"
+      "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -9105,7 +4613,6 @@
       "yahoo.com",
       "amazon.com",
       "soundcloud.com",
-      "jsonline.com",
       "skynet.be"
     ],
     "departapp.com": [
@@ -9134,8 +4641,7 @@
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
-      "starwars.com",
-      "go.com"
+      "starwars.com"
     ],
     "dianomi.com": [
       "businessinsider.com",
@@ -9157,8 +4663,6 @@
       "britannica.com",
       "lifehacker.com",
       "express.co.uk",
-      "gizmodo.com",
-      "alternet.org",
       "bostonherald.com"
     ],
     "disney.com": [
@@ -9178,8 +4682,8 @@
       "barnesandnoble.com",
       "urbandictionary.com",
       "axs.com",
-      "observer.com",
-      "infoplease.com"
+      "timeanddate.com",
+      "newatlas.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
       "4shared.com"
@@ -9204,7 +4708,7 @@
       "samsung.com",
       "webmd.com",
       "forbes.com",
-      "jsonline.com"
+      "walgreens.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -9214,7 +4718,6 @@
       "twitter.com",
       "linkedin.com",
       "sourceforge.net",
-      "macworld.com",
       "focus.de"
     ],
     "doublemax.net": [
@@ -9227,12 +4730,17 @@
       "military.com",
       "allafrica.com"
     ],
+    "dowjones.io": [
+      "marketwatch.com"
+    ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
       "techtarget.com",
-      "adweek.com",
-      "rd.com"
+      "adweek.com"
+    ],
+    "dxpmedia.com": [
+      "autohome.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -9240,7 +4748,8 @@
     "dynamicyield.com": [
       "t-online.de",
       "cnbc.com",
-      "nbcnews.com"
+      "nbcnews.com",
+      "washingtonexaminer.com"
     ],
     "dynatrace-managed.com": [
       "delta.com"
@@ -9289,14 +4798,14 @@
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com"
+      "gulfnews.com",
+      "goal.com"
     ],
     "eloqua.com": [
       "intel.com",
       "cisco.com",
       "prnewswire.com",
       "redhat.com",
-      "uq.edu.au",
       "eset.com"
     ],
     "elsevier.com": [
@@ -9342,7 +4851,11 @@
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "lefigaro.fr"
+      "lefigaro.fr",
+      "sfgate.com"
+    ],
+    "etahub.com": [
+      "pornhub.com"
     ],
     "etracker.de": [
       "sedo.com"
@@ -9360,8 +4873,8 @@
       "adobe.com",
       "yahoo.com",
       "sourceforge.net",
-      "dropbox.com",
-      "jsonline.com"
+      "tinyurl.com",
+      "newatlas.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
@@ -9406,15 +4919,16 @@
       "sourceforge.net",
       "forbes.com",
       "bloomberg.com",
-      "dropbox.com",
-      "seagate.com"
+      "gizmodo.com",
+      "heraldsun.com.au"
     ],
     "eyereturn.com": [
       "thestar.com",
       "queensu.ca"
     ],
     "eyeviewads.com": [
-      "staples.com"
+      "staples.com",
+      "walgreens.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -9425,8 +4939,7 @@
       "wordpress.org",
       "adobe.com",
       "nytimes.com",
-      "leeds.ac.uk",
-      "designboom.com"
+      "focus.de"
     ],
     "facetz.net": [
       "novostimira.com",
@@ -9484,25 +4997,21 @@
     "flyertown.ca": [
       "canada.com",
       "globalnews.ca",
-      "nationalpost.com"
+      "nationalpost.com",
+      "vancouversun.com"
     ],
     "fontawesome.com": [
       "socarrao.com.br",
       "clinicaltrials.gov",
       "moonfruit.com",
       "webex.com",
-      "sitepoint.com",
-      "emarketer.com"
-    ],
-    "force.com": [
-      "salesforce.com"
+      "sitepoint.com"
     ],
     "foresee.com": [
       "epa.gov",
       "si.edu",
       "theglobeandmail.com",
-      "sec.gov",
-      "kidshealth.org"
+      "sec.gov"
     ],
     "formstack.com": [
       "in.gov"
@@ -9539,6 +5048,9 @@
     "friendbuy.com": [
       "lulu.com"
     ],
+    "fuel451.com": [
+      "prezi.com"
+    ],
     "funcaptcha.com": [
       "axs.com"
     ],
@@ -9550,6 +5062,7 @@
       "yahoo.com",
       "mlb.com",
       "xfinity.com",
+      "discovery.com",
       "hgtv.com"
     ],
     "g2crowd.com": [
@@ -9566,8 +5079,7 @@
     "gemius.pl": [
       "sapo.pt",
       "interia.pl",
-      "ria.ru",
-      "onet.pl"
+      "ria.ru"
     ],
     "gentags.net": [
       "sina.com.cn"
@@ -9595,8 +5107,7 @@
       "cnn.com",
       "independent.co.uk",
       "abc.net.au",
-      "mirror.co.uk",
-      "francetvinfo.fr",
+      "sfgate.com",
       "hgtv.com"
     ],
     "giphy.com": [
@@ -9616,8 +5127,7 @@
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com",
-      "si.com"
+      "fortune.com"
     ],
     "gmossp-sp.jp": [
       "shinobi.jp",
@@ -9647,8 +5157,8 @@
       "google.de",
       "sourceforge.net",
       "google.ca",
+      "scmp.com",
       "chromium.org",
-      "xrea.com",
       "focus.de"
     ],
     "gq.com": [
@@ -9679,7 +5189,8 @@
     "gumgum.com": [
       "liveuamap.com",
       "colourlovers.com",
-      "infoplease.com"
+      "infoplease.com",
+      "coindesk.com"
     ],
     "guoshipartners.com": [
       "udn.com"
@@ -9688,7 +5199,6 @@
       "adobe.com",
       "ox.ac.uk",
       "ihg.com",
-      "economist.com",
       "business2community.com"
     ],
     "gwmtracking.com": [
@@ -9807,7 +5317,8 @@
     "id5-sync.com": [
       "bloomberg.com",
       "venturebeat.com",
-      "dailymotion.com"
+      "dailymotion.com",
+      "livescience.com"
     ],
     "idealmedia.com": [
       "alternet.org",
@@ -9846,19 +5357,14 @@
     "impact-ad.jp": [
       "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp",
-      "ocn.ne.jp"
+      "goo.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
       "bbc.com",
       "wsj.com",
-      "libero.it",
       "gizmodo.com"
-    ],
-    "ineity.pro": [
-      "4shared.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
@@ -9876,7 +5382,8 @@
       "ups.com"
     ],
     "inquisitr.com": [
-      "www.poznan.pl"
+      "www.poznan.pl",
+      "flipboard.com"
     ],
     "inside-graph.com": [
       "staples.com"
@@ -9884,20 +5391,20 @@
     "insightexpressai.com": [
       "unsplash.com",
       "standard.co.uk",
-      "motorola.com"
+      "motorola.com",
+      "gopro.com"
     ],
     "instagram.com": [
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu",
-      "guinnessworldrecords.com"
+      "arizona.edu"
     ],
     "instinctiveads.com": [
       "variety.com",
       "dp.ua",
       "blackberry.com",
-      "bgr.com"
+      "rollingstone.com"
     ],
     "intentiq.com": [
       "sourceforge.net",
@@ -9912,7 +5419,7 @@
       "themeforest.net",
       "ft.com",
       "elegantthemes.com",
-      "visual.ly",
+      "bigcartel.com",
       "iconfinder.com"
     ],
     "intergient.com": [
@@ -9943,15 +5450,15 @@
     "iperceptions.com": [
       "ford.com",
       "seagate.com",
-      "honeywell.com"
+      "honeywell.com",
+      "boeing.com"
     ],
     "ipinyou.com": [
       "autohome.com.cn"
     ],
     "ipredictive.com": [
       "myspace.com",
-      "dailymotion.com",
-      "theverge.com"
+      "dailymotion.com"
     ],
     "irs01.com": [
       "youku.com"
@@ -9971,7 +5478,7 @@
       "dyn.com",
       "fujitsu.com",
       "liveleak.com",
-      "hhs.gov"
+      "lemonde.fr"
     ],
     "jrs5.com": [
       "nike.com",
@@ -9981,7 +5488,8 @@
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com"
+      "dallasnews.com",
+      "vancouversun.com"
     ],
     "justpremium.com": [
       "tvtropes.org"
@@ -9989,7 +5497,8 @@
     "justuno.com": [
       "gartner.com",
       "searchengineland.com",
-      "zenfolio.com"
+      "zenfolio.com",
+      "gopro.com"
     ],
     "jword.jp": [
       "excite.co.jp"
@@ -10010,27 +5519,21 @@
       "nationalgeographic.com",
       "chicagotribune.com",
       "nytimes.com",
-      "complex.com",
-      "apartmenttherapy.com"
+      "zappos.com"
     ],
     "kinja.com": [
       "gizmodo.com",
       "lifehacker.com",
-      "kotaku.com",
-      "jalopnik.com"
+      "kotaku.com"
     ],
     "kiwiirc.com": [
       "enlightenment.org"
-    ],
-    "knet.cn": [
-      "dzwww.com"
     ],
     "krxd.net": [
       "inhabitat.com",
       "bgr.com",
       "jalopnik.com",
       "cnn.com",
-      "fastcompany.com",
       "gizmodo.com"
     ],
     "ladsp.com": [
@@ -10055,7 +5558,8 @@
       "webmd.com",
       "nj.com",
       "patch.com",
-      "cbssports.com"
+      "bloomberg.com",
+      "washingtonexaminer.com"
     ],
     "libero.it": [
       "virgilio.it"
@@ -10069,22 +5573,21 @@
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "home.pl",
-      "orange.fr"
+      "home.pl"
     ],
     "lightboxcdn.com": [
       "zdnet.com",
       "fastcompany.com",
       "adweek.com",
-      "jalopnik.com",
-      "gizmodo.com"
+      "gizmodo.com",
+      "dailycaller.com"
     ],
     "lijit.com": [
       "sourceforge.net",
       "bloomberg.com",
       "deviantart.com",
-      "slashdot.org",
-      "zimbio.com"
+      "uci.edu",
+      "infoplease.com"
     ],
     "lincoln.com": [
       "ford.com"
@@ -10097,15 +5600,13 @@
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "dropbox.com",
-      "here.com",
+      "msn.com",
       "lexisnexis.com"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
       "pcworld.com",
-      "nike.com",
-      "macworld.com"
+      "nike.com"
     ],
     "list-manage.com": [
       "boingboing.net"
@@ -10137,7 +5638,7 @@
       "apache.org",
       "prnewswire.com",
       "ibm.com",
-      "virginmedia.com",
+      "talktalk.co.uk",
       "lexisnexis.com"
     ],
     "lkqd.net": [
@@ -10172,7 +5673,8 @@
     "lytics.io": [
       "adweek.com",
       "digitaltrends.com",
-      "fool.com"
+      "fool.com",
+      "economist.com"
     ],
     "m6r.eu": [
       "t-online.de",
@@ -10184,8 +5686,7 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com",
-      "yandex.ru"
+      "google.com"
     ],
     "mailchimp.com": [
       "colorlib.com",
@@ -10204,37 +5705,41 @@
     "marketlinc.com": [
       "kaspersky.com",
       "norton.com",
-      "eset.com"
+      "eset.com",
+      "teamviewer.us"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
       "dyn.com",
+      "searchengineland.com",
+      "hootsuite.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
       "thestar.com",
-      "seattletimes.com",
-      "kansascity.com"
+      "seattletimes.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
       "forbes.com",
-      "jsonline.com"
+      "pitchfork.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
       "forbes.com",
-      "reuters.com"
+      "reuters.com",
+      "cracked.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
       "uci.edu",
-      "autodesk.com"
+      "autodesk.com",
+      "box.com"
     ],
     "mediaforge.com": [
       "nike.com",
@@ -10252,7 +5757,8 @@
     "mediarithmics.com": [
       "orange.fr",
       "lynda.com",
-      "liberation.fr"
+      "liberation.fr",
+      "leparisien.fr"
     ],
     "mediav.com": [
       "ctrip.com",
@@ -10277,11 +5783,7 @@
     ],
     "metadsp.co.uk": [
       "nypost.com",
-      "standard.co.uk",
-      "theverge.com"
-    ],
-    "mfadsrvr.com": [
-      "att.net"
+      "standard.co.uk"
     ],
     "mg2connext.com": [
       "mercurynews.com",
@@ -10299,8 +5801,7 @@
     "miaozhen.com": [
       "sina.com.cn",
       "163.com",
-      "dzwww.com",
-      "autohome.com.cn"
+      "dzwww.com"
     ],
     "microad.jp": [
       "rakuten.co.jp",
@@ -10314,8 +5815,7 @@
       "msn.com",
       "office.com",
       "xbox.com",
-      "complex.com",
-      "encyclopedia.com"
+      "complex.com"
     ],
     "microsoftonline.com": [
       "microsoft.com",
@@ -10329,7 +5829,6 @@
       "prnewswire.com",
       "zend.com",
       "nginx.com",
-      "here.com",
       "pingdom.com"
     ],
     "ml314.com": [
@@ -10337,7 +5836,6 @@
       "forbes.com",
       "bloomberg.com",
       "wsj.com",
-      "seagate.com",
       "zerohedge.com"
     ],
     "mlb.com": [
@@ -10370,7 +5868,7 @@
       "t-online.de",
       "nbcnews.com",
       "theglobeandmail.com",
-      "dropbox.com"
+      "thetimes.co.uk"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -10405,7 +5903,8 @@
       "cc.com"
     ],
     "multiview.com": [
-      "symantec.com"
+      "symantec.com",
+      "nutrition.org"
     ],
     "musthird.com": [
       "airbnb.com"
@@ -10438,10 +5937,12 @@
     "nanigans.com": [
       "thinkgeek.com",
       "overstock.com",
-      "squareup.com"
+      "squareup.com",
+      "zappos.com"
     ],
     "narrative.io": [
-      "sourceforge.net"
+      "sourceforge.net",
+      "gizmodo.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -10476,7 +5977,7 @@
       "cnbc.com",
       "msnbc.com",
       "nbc.com",
-      "nbcsports.com"
+      "nbcnews.com"
     ],
     "netdna-ssl.com": [
       "alternet.org"
@@ -10484,8 +5985,7 @@
     "netmng.com": [
       "lenovo.com",
       "theknot.com",
-      "shopko.com",
-      "jsonline.com"
+      "shopko.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -10511,7 +6011,8 @@
       "marketwatch.com",
       "nypost.com",
       "thesun.co.uk",
-      "wsj.com"
+      "wsj.com",
+      "heraldsun.com.au"
     ],
     "newsinc.com": [
       "latimes.com",
@@ -10556,7 +6057,6 @@
       "wsj.com",
       "oracle.com",
       "huffingtonpost.com",
-      "codecanyon.net",
       "helsinki.fi"
     ],
     "nsaudience.pl": [
@@ -10629,15 +6129,14 @@
       "springer.com",
       "standard.co.uk",
       "home.pl",
-      "knowyourmeme.com"
+      "skyrock.com"
     ],
     "omtrdc.net": [
       "adobe.com",
       "amazon.com",
       "telegraph.co.uk",
       "marriott.com",
-      "kansascity.com",
-      "pingdom.com"
+      "eset.com"
     ],
     "onclickmega.com": [
       "brothersoft.com"
@@ -10668,8 +6167,7 @@
       "indiatimes.com",
       "wn.com",
       "express.co.uk",
-      "tass.ru",
-      "gulfnews.com"
+      "rbc.ru"
     ],
     "ooyala.com": [
       "accuweather.com",
@@ -10687,8 +6185,7 @@
       "yahoo.com",
       "amazon.com",
       "nytimes.com",
-      "dropbox.com",
-      "libero.it",
+      "forbes.com",
       "active.com"
     ],
     "opinionstage.com": [
@@ -10704,45 +6201,47 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
-      "ibm.com",
-      "microsoft.com",
-      "hp.com",
+      "nytimes.com",
       "bbc.com",
+      "live.com",
+      "ibm.com",
+      "hp.com",
       "wiley.com",
       "npr.org",
       "springer.com",
-      "mashable.com",
       "cbsnews.com",
+      "foxnews.com",
+      "constantcontact.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
       "evernote.com",
       "box.com",
+      "prezi.com",
       "prweb.com",
       "dictionary.com",
+      "bitbucket.org",
+      "gotomeeting.com",
       "accorhotels.com",
       "uber.com",
       "xbox.com",
       "history.com",
       "bestbuy.com",
       "jamanetwork.com",
+      "www.nhs.uk",
       "imageshack.com",
       "atlassian.com",
-      "live.com",
       "dallasnews.com",
       "metmuseum.org",
       "blizzard.com",
       "intuit.com",
-      "ama-assn.org",
       "starbucks.com",
       "squareup.com",
       "ajc.com",
       "justgiving.com",
       "dreamhost.com",
       "edx.org",
-      "cbssports.com",
       "bartleby.com",
-      "gotomeeting.com",
       "theknot.com",
       "zenfolio.com",
       "fourseasons.com",
@@ -10779,8 +6278,7 @@
       "nature.com",
       "scribd.com",
       "foxnews.com",
-      "msn.com",
-      "si.com",
+      "cnn.com",
       "focus.de"
     ],
     "ovh.com": [
@@ -10789,7 +6287,8 @@
     "owneriq.net": [
       "lycos.com",
       "lg.com",
-      "washingtontimes.com"
+      "washingtontimes.com",
+      "pitchfork.com"
     ],
     "owox.com": [
       "simplesite.com"
@@ -10801,14 +6300,13 @@
       "tandfonline.com",
       "prezi.com",
       "ap.org",
-      "guinnessworldrecords.com"
+      "propublica.org"
     ],
     "parsely.com": [
       "time.com",
       "wired.com",
       "wikia.com",
       "wsj.com",
-      "ocregister.com",
       "dezeen.com"
     ],
     "paypal.com": [
@@ -10838,8 +6336,7 @@
     "perimeterx.net": [
       "bloomberg.com",
       "pixnet.net",
-      "macrumors.com",
-      "upwork.com"
+      "macrumors.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
@@ -10859,7 +6356,8 @@
     "pitchfork.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "epicurious.com"
     ],
     "pixanalytics.com": [
       "pixnet.net"
@@ -10886,7 +6384,8 @@
     "po.st": [
       "smithsonianmag.com",
       "wnd.com",
-      "business2community.com"
+      "business2community.com",
+      "nme.com"
     ],
     "polymorphicads.jp": [
       "shinobi.jp"
@@ -10902,7 +6401,6 @@
       "independent.co.uk",
       "chicagotribune.com",
       "wsj.com",
-      "macworld.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
@@ -10958,8 +6456,7 @@
       "tinyurl.com",
       "bloomberg.com",
       "usatoday.com",
-      "jsonline.com",
-      "infoplease.com"
+      "walgreens.com"
     ],
     "pubmine.com": [
       "foreignpolicy.com",
@@ -10993,7 +6490,7 @@
       "seattletimes.com",
       "seattlepi.com",
       "sfgate.com",
-      "rd.com"
+      "cracked.com"
     ],
     "qnsr.com": [
       "serverwatch.com"
@@ -11015,16 +6512,13 @@
       "adidas.com",
       "cnet.com",
       "babycenter.com",
-      "cbssports.com",
-      "mayoclinic.org",
-      "hgtv.com"
+      "mayoclinic.org"
     ],
     "quantserve.com": [
       "wordpress.org",
       "vimeo.com",
       "reddit.com",
       "soundcloud.com",
-      "jsonline.com",
       "gizmodo.com"
     ],
     "quantummetric.com": [
@@ -11040,8 +6534,7 @@
       "weebly.com",
       "bloomberg.com",
       "ning.com",
-      "webnode.com",
-      "upwork.com",
+      "nypost.com",
       "eset.com"
     ],
     "rackcdn.com": [
@@ -11057,7 +6550,8 @@
       "livejournal.com",
       "washingtonpost.com",
       "novostimira.com",
-      "ria.ru"
+      "ria.ru",
+      "kharkov.ua"
     ],
     "rbnt.org": [
       "radikal.ru"
@@ -11069,9 +6563,6 @@
       "sina.com.cn",
       "autohome.com.cn",
       "bshare.cn"
-    ],
-    "readcube.com": [
-      "wiley.com"
     ],
     "reddit.com": [
       "acm.org",
@@ -11119,18 +6610,21 @@
     "revjet.com": [
       "homedepot.com",
       "expedia.com",
-      "bankrate.com",
-      "nordstrom.com"
+      "bankrate.com"
     ],
     "rezync.com": [
-      "economist.com"
+      "economist.com",
+      "salon.com"
     ],
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
       "npr.org",
       "foursquare.com",
-      "yellowpages.com"
+      "gopro.com"
+    ],
+    "rhombusads.com": [
+      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -11151,8 +6645,7 @@
       "time.com",
       "wired.com",
       "cbsnews.com",
-      "dropbox.com",
-      "cbssports.com",
+      "npr.org",
       "gizmodo.com"
     ],
     "rlcdn.com": [
@@ -11160,8 +6653,7 @@
       "yahoo.com",
       "sourceforge.net",
       "reddit.com",
-      "jsonline.com",
-      "bostonherald.com"
+      "box.com"
     ],
     "rnengage.com": [
       "oracle.com",
@@ -11177,36 +6669,34 @@
     "roymorgan.com": [
       "smh.com.au"
     ],
-    "rqtrk.eu": [
-      "dropbox.com"
-    ],
     "rtb.com.ru": [
       "radikal.ru",
       "diary.ru"
     ],
     "rtk.io": [
       "post-gazette.com",
+      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
       "bloomberg.com",
-      "sony.com"
+      "uci.edu"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "libero.it",
-      "gizmodo.com"
+      "pitchfork.com"
     ],
     "rundsp.com": [
       "hpe.com",
       "alternet.org"
     ],
     "rutarget.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "ria.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "codepen.io",
@@ -11220,10 +6710,14 @@
     "sabavision.com": [
       "mihanblog.com"
     ],
+    "salecycle.com": [
+      "talktalk.co.uk"
+    ],
     "salesforceliveagent.com": [
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
+      "salesforce.com",
       "eset.com"
     ],
     "salesloft.com": [
@@ -11237,8 +6731,7 @@
     "samba.tv": [
       "imdb.com",
       "gizmodo.com",
-      "lifehacker.com",
-      "jalopnik.com"
+      "lifehacker.com"
     ],
     "sbal4kp.com": [
       "dropbox.com"
@@ -11274,7 +6767,6 @@
       "yahoo.com",
       "tumblr.com",
       "nytimes.com",
-      "macworld.com",
       "gizmodo.com"
     ],
     "scribblelive.com": [
@@ -11308,8 +6800,7 @@
       "fortune.com",
       "people.com",
       "ew.com",
-      "time.com",
-      "si.com"
+      "time.com"
     ],
     "self.com": [
       "wired.com",
@@ -11327,7 +6818,8 @@
     "servebom.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com"
+      "space.com",
+      "dailydot.com"
     ],
     "servedby-buysellads.com": [
       "dribbble.com"
@@ -11339,8 +6831,7 @@
       "dropbox.com",
       "t-online.de",
       "nbcnews.com",
-      "businessinsider.com",
-      "att.net",
+      "npr.org",
       "hgtv.com"
     ],
     "sessioncam.com": [
@@ -11355,13 +6846,15 @@
       "www.uk.com",
       "whatsapp.com",
       "lycos.com",
-      "us.org"
+      "uci.edu",
+      "dailycaller.com"
     ],
     "sharethrough.com": [
       "yahoo.com",
       "cnn.com",
       "time.com",
-      "cnet.com"
+      "cnet.com",
+      "walgreens.com"
     ],
     "sheego.de": [
       "t-online.de"
@@ -11375,14 +6868,16 @@
       "codepen.io",
       "raspberrypi.org"
     ],
+    "sibautomation.com": [
+      "themeisle.com"
+    ],
     "simplereach.com": [
       "theatlantic.com"
     ],
     "simpli.fi": [
       "symantec.com",
       "washingtontimes.com",
-      "thinkgeek.com",
-      "tampabay.com"
+      "thinkgeek.com"
     ],
     "sina.cn": [
       "sina.com.cn"
@@ -11405,7 +6900,9 @@
       "udel.edu",
       "berkeley.edu",
       "jhu.edu",
-      "helsinki.fi"
+      "helsinki.fi",
+      "case.edu",
+      "oclc.org"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
@@ -11423,15 +6920,14 @@
       "tinypic.com",
       "seattletimes.com",
       "sciencedaily.com",
-      "cbssports.com",
-      "zerohedge.com"
+      "networksolutions.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
       "arstechnica.com",
-      "zimbio.com"
+      "coindesk.com"
     ],
     "sky.com": [
       "skygroup.sky",
@@ -11444,7 +6940,7 @@
       "springer.com",
       "skyrock.com",
       "sapo.pt",
-      "liberation.fr"
+      "elpais.com"
     ],
     "smartclip.net": [
       "infoplease.com"
@@ -11471,7 +6967,7 @@
       "overstock.com",
       "complex.com",
       "wsj.com",
-      "sbs.com.au"
+      "zappos.com"
     ],
     "snapwidget.com": [
       "udel.edu"
@@ -11523,9 +7019,8 @@
       "photobucket.com",
       "deviantart.com",
       "springer.com",
-      "myspace.com",
-      "jsonline.com",
-      "couchsurfing.com"
+      "forbes.com",
+      "detroitnews.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -11534,6 +7029,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
+      "independent.ie",
       "mo.gov"
     ],
     "sourceforge.net": [
@@ -11552,8 +7048,7 @@
       "cloudflare.com",
       "symantec.com",
       "sophos.com",
-      "hp.com",
-      "seagate.com"
+      "hp.com"
     ],
     "spineuniverse.com": [
       "psychcentral.com"
@@ -11579,7 +7074,6 @@
       "dropbox.com",
       "dailymotion.com",
       "thenextweb.com",
-      "alternet.org",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -11620,8 +7114,6 @@
       "hugedomains.com",
       "dropcatch.com",
       "man7.org",
-      "cbslocal.com",
-      "namebright.com",
       "zerohedge.com"
     ],
     "staticimgfarm.com": [
@@ -11633,7 +7125,8 @@
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "istockphoto.com"
+      "istockphoto.com",
+      "careerbuilder.com"
     ],
     "steepto.com": [
       "liveleak.com"
@@ -11647,8 +7140,7 @@
     "stickyadstv.com": [
       "bloomberg.com",
       "dailymotion.com",
-      "feedburner.com",
-      "liberation.fr"
+      "feedburner.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
@@ -11676,12 +7168,13 @@
       "snopes.com",
       "cdbaby.com",
       "studiopress.com",
-      "sitepoint.com"
+      "makezine.com"
     ],
     "sundaysky.com": [
       "overstock.com",
       "alternet.org",
-      "infoplease.com"
+      "infoplease.com",
+      "dailydot.com"
     ],
     "suning.com": [
       "qq.com",
@@ -11701,13 +7194,13 @@
     "surveymonkey.com": [
       "cambridge.org",
       "investopedia.com",
-      "foreignpolicy.com"
+      "foreignpolicy.com",
+      "iop.org"
     ],
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
-      "indianexpress.com",
-      "springer.com"
+      "indianexpress.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -11721,7 +7214,6 @@
       "dropbox.com",
       "t-online.de",
       "msn.com",
-      "att.net",
       "edmunds.com"
     ],
     "tacdn.com": [
@@ -11734,7 +7226,8 @@
       "overstock.com"
     ],
     "tailtarget.com": [
-      "uol.com.br"
+      "uol.com.br",
+      "variety.com"
     ],
     "tamgrt.com": [
       "tripadvisor.com",
@@ -11743,21 +7236,21 @@
     "tanx.com": [
       "sina.com.cn",
       "alibaba.com",
-      "ifeng.com"
+      "ifeng.com",
+      "tmall.com"
     ],
     "taobao.com": [
       "sina.com.cn",
       "1688.com",
       "tmall.com",
-      "coremail.cn"
+      "alibaba.com"
     ],
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
       "soundcloud.com",
-      "dropbox.com",
-      "complex.com",
-      "bostonherald.com"
+      "paypal.com",
+      "networksolutions.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -11769,15 +7262,15 @@
       "sophos.com"
     ],
     "teads.tv": [
-      "alternet.org"
+      "alternet.org",
+      "networksolutions.com"
     ],
     "tealiumiq.com": [
       "ibm.com",
       "cbsnews.com",
       "evernote.com",
       "cnet.com",
-      "cbssports.com",
-      "active.com"
+      "usmagazine.com"
     ],
     "technolutions.net": [
       "illinois.edu",
@@ -11807,7 +7300,6 @@
       "t-online.de",
       "gnu.org",
       "spiegel.de",
-      "liberation.fr",
       "focus.de"
     ],
     "theatlas.com": [
@@ -11817,7 +7309,6 @@
       "netflix.com",
       "wufoo.com",
       "playstation.com",
-      "nordstrom.com",
       "zappos.com"
     ],
     "theglobeandmail.ca": [
@@ -11844,8 +7335,7 @@
       "fortune.com",
       "people.com",
       "ew.com",
-      "time.com",
-      "si.com"
+      "time.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -11855,7 +7345,6 @@
       "techcrunch.com",
       "kickstarter.com",
       "bloomberg.com",
-      "jalopnik.com",
       "gizmodo.com"
     ],
     "tiqcdn.com": [
@@ -11864,8 +7353,7 @@
       "ibm.com",
       "wsj.com",
       "hpe.com",
-      "orange.fr",
-      "here.com"
+      "francetvinfo.fr"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -11882,7 +7370,6 @@
       "vk.com",
       "yandex.ru",
       "mail.ru",
-      "tass.ru",
       "radikal.ru"
     ],
     "toutapp.com": [
@@ -11934,14 +7421,14 @@
     "tremorhub.com": [
       "usatoday.com",
       "azcentral.com",
-      "freep.com"
+      "freep.com",
+      "detroitnews.com"
     ],
     "tribalfusion.com": [
       "dailymotion.com",
       "pastebin.com",
       "liveleak.com",
-      "marriott.com",
-      "jsonline.com"
+      "marriott.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -11974,23 +7461,20 @@
     "trustpilot.com": [
       "jalbum.net",
       "avira.com",
-      "moonfruit.com",
-      "ccleaner.com"
+      "moonfruit.com"
     ],
     "trvl-px.com": [
       "hotels.com",
       "expedia.com"
     ],
     "tumblr.com": [
-      "dailydot.com",
-      "sony.com"
+      "dailydot.com"
     ],
     "turn.com": [
       "bloomberg.com",
       "wired.com",
       "webmd.com",
       "tinyurl.com",
-      "libero.it",
       "pitchfork.com"
     ],
     "tutorialize.me": [
@@ -12012,18 +7496,16 @@
       "yahoo.com",
       "chicagotribune.com",
       "nytimes.com",
-      "dropbox.com",
-      "cnet.com",
-      "macworld.com",
-      "seattlepi.com",
-      "lexisnexis.com",
-      "helsinki.fi",
-      "edmunds.com"
+      "cnn.com",
+      "msn.com",
+      "lexisnexis.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com"
+      "washingtontimes.com",
+      "salon.com",
+      "dailycaller.com"
     ],
     "ubi.com": [
       "ubisoft.com"
@@ -12053,6 +7535,9 @@
       "cnn.com",
       "nba.com"
     ],
+    "ultimedia.com": [
+      "sfgate.com"
+    ],
     "undertone.com": [
       "dallasnews.com",
       "alternet.org"
@@ -12075,8 +7560,7 @@
     "upsellit.com": [
       "samsung.com",
       "garmin.com",
-      "motorola.com",
-      "ccleaner.com"
+      "motorola.com"
     ],
     "uptolike.com": [
       "live4fun.ru"
@@ -12099,7 +7583,6 @@
       "scotsman.com"
     ],
     "uservoice.com": [
-      "scoop.it",
       "theknot.com"
     ],
     "ustream.tv": [
@@ -12153,25 +7636,26 @@
       "cbc.ca"
     ],
     "videoamp.com": [
-      "hpe.com"
+      "hpe.com",
+      "alternet.org"
     ],
     "videohub.tv": [
       "liveuamap.com",
       "wsj.com",
-      "bloomberg.com"
+      "uci.edu"
     ],
     "vidible.tv": [
       "aol.com",
       "nydailynews.com",
       "autoblog.com",
-      "huffingtonpost.com"
+      "techcrunch.com"
     ],
     "viglink.com": [
       "zdnet.com",
       "softonic.com",
       "techrepublic.com",
       "cnet.com",
-      "sheknows.com"
+      "dailycaller.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
@@ -12185,15 +7669,13 @@
       "wufoo.com",
       "heroku.com",
       "emarketer.com",
-      "designboom.com",
-      "oclc.org"
+      "designboom.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
       "fortune.com",
       "people.com",
       "time.com",
-      "si.com",
       "zappos.com"
     ],
     "virgilio.it": [
@@ -12208,8 +7690,10 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru",
-      "yandex.ru"
+      "ria.ru"
+    ],
+    "vmmpxl.com": [
+      "networksolutions.com"
     ],
     "vogue.com": [
       "wired.com",
@@ -12235,7 +7719,10 @@
       "hpe.com",
       "ebay.com",
       "sourceforge.net",
-      "forbes.com"
+      "hp.com"
+    ],
+    "wal.co": [
+      "walmart.com"
     ],
     "wallst.com": [
       "reuters.com"
@@ -12245,9 +7732,6 @@
     ],
     "warnerbros.com": [
       "tmz.com"
-    ],
-    "wayfair.com": [
-      "msn.com"
     ],
     "wbtrk.net": [
       "repubblica.it",
@@ -12267,7 +7751,8 @@
     "weborama.fr": [
       "lemonde.fr",
       "rbc.ru",
-      "lexpress.fr"
+      "lexpress.fr",
+      "leparisien.fr"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -12291,7 +7776,8 @@
     "webtrendslive.com": [
       "nature.com",
       "abc.net.au",
-      "oup.com"
+      "oup.com",
+      "dhl.com"
     ],
     "webvisor.org": [
       "kharkov.ua"
@@ -12329,9 +7815,7 @@
       "suntimes.com",
       "canada.com",
       "globalnews.ca",
-      "tampabay.com",
-      "bostonherald.com",
-      "vancouversun.com"
+      "bostonherald.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
@@ -12342,8 +7826,7 @@
     "wistia.com": [
       "zendesk.com",
       "typeform.com",
-      "photoshelter.com",
-      "buffer.com"
+      "photoshelter.com"
     ],
     "wistia.net": [
       "nielsen.com"
@@ -12429,14 +7912,13 @@
       "lemonde.fr",
       "unblog.fr",
       "uefa.com",
-      "ovh.co.uk",
-      "rfi.fr"
+      "skyrock.com",
+      "leparisien.fr"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
       "biglobe.ne.jp",
-      "goo.ne.jp",
-      "ocn.ne.jp"
+      "goo.ne.jp"
     ],
     "xplosion.de": [
       "t-online.de",
@@ -12455,26 +7937,20 @@
       "novostimira.com",
       "mail.ru",
       "rt.com",
-      "qip.ru",
       "radikal.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
       "rakuten.co.jp",
-      "economist.com",
-      "ocn.ne.jp"
+      "economist.com"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
       "flickr.com",
       "sourceforge.net",
-      "att.net",
       "eset.com"
-    ],
-    "yahoosmallbusiness.com": [
-      "yahoo.com"
     ],
     "yandex.ru": [
       "livejournal.com",
@@ -12482,10 +7958,8 @@
       "stanford.edu",
       "ning.com",
       "rt.com",
-      "qip.ru",
-      "fourseasons.com",
       "radikal.ru",
-      "yandex.com"
+      "kharkov.ua"
     ],
     "yandex.ua": [
       "kharkov.ua",
@@ -12509,23 +7983,22 @@
     "yieldoptimizer.com": [
       "ihg.com",
       "hyatt.com",
-      "philly.com",
-      "fourseasons.com"
+      "philly.com"
     ],
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
       "dropbox.com",
-      "qualtrics.com",
-      "att.net",
+      "iop.org",
+      "sbs.com.au",
       "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
       "newyorker.com",
-      "macworld.com"
+      "pcworld.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -12551,10 +8024,8 @@
       "nih.gov",
       "telegraph.co.uk",
       "caltech.edu",
-      "tmz.com",
       "dailykos.com",
-      "honeywell.com",
-      "vancouversun.com"
+      "honeywell.com"
     ],
     "youvisit.com": [
       "osu.edu",
@@ -12570,7 +8041,8 @@
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com"
+      "ign.com",
+      "everydayhealth.com"
     ],
     "zedo.com": [
       "tinypic.com",
@@ -12582,7 +8054,6 @@
       "thehill.com",
       "farfetch.com",
       "paypal.com",
-      "orange.fr",
       "infoplease.com"
     ],
     "zendesk.com": [
@@ -12594,7 +8065,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "marketwatch.com"
+      "wunderground.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -12626,5 +8097,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.24"
+  "version": "2018.8.25"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,13 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535131518617,
-      "userAction": ""
-    },
-    "112-tzm-766.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535149513388,
+      "nextUpdateTime": 1535286656578,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -48,12 +42,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "194-vvc-221.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535203312039,
-      "userAction": ""
-    },
     "1dmp.io": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -82,12 +70,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "2912a.v.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535391580217,
       "userAction": ""
     },
     "2mdnsys.com": {
@@ -141,43 +123,25 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535288564686,
-      "userAction": ""
-    },
-    "4292932.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535556755499,
+      "nextUpdateTime": 1535622422355,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535616677370,
+      "nextUpdateTime": 1535775348784,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535547398351,
-      "userAction": ""
-    },
-    "4645712.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535592234323,
-      "userAction": ""
-    },
-    "4924464.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535440457062,
+      "nextUpdateTime": 1535742976621,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535276170445,
+      "nextUpdateTime": 1535601822060,
       "userAction": ""
     },
     "4dsply.com": {
@@ -195,19 +159,13 @@
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535593380762,
+      "nextUpdateTime": 1535421406745,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535321145910,
-      "userAction": ""
-    },
-    "5779616.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535482911467,
+      "nextUpdateTime": 1535678362084,
       "userAction": ""
     },
     "58.com": {
@@ -228,16 +186,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "6126321.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535371657297,
-      "userAction": ""
-    },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535167279610,
+      "nextUpdateTime": 1535474821572,
       "userAction": ""
     },
     "6sc.co": {
@@ -258,76 +210,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "8117415.fls.doubleclick.net": {
+    "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535524131585,
-      "userAction": ""
-    },
-    "8242400.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535340362267,
-      "userAction": ""
-    },
-    "8329645.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535353449192,
-      "userAction": ""
-    },
-    "8758559.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535615993684,
-      "userAction": ""
-    },
-    "899-ihp-202.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535133497126,
-      "userAction": ""
-    },
-    "a.quora.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535405357388,
+      "nextUpdateTime": 1535542110562,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535490342215,
+      "nextUpdateTime": 1535742693411,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535378457839,
+      "nextUpdateTime": 1535463154990,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535161779696,
-      "userAction": ""
-    },
-    "a6250770393.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535211637737,
-      "userAction": ""
-    },
-    "a7718922374.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535563194232,
-      "userAction": ""
-    },
-    "aamcftag.aamsitecertifier.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535518074755,
+      "nextUpdateTime": 1535540108802,
       "userAction": ""
     },
     "aamsitecertifier.com": {
@@ -339,7 +243,7 @@
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535119827399,
+      "nextUpdateTime": 1535404732620,
       "userAction": ""
     },
     "aaxads.com": {
@@ -366,6 +270,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "accounts.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535476844661,
+      "userAction": ""
+    },
     "accuweather.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -375,7 +285,7 @@
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535429731669,
+      "nextUpdateTime": 1535648447717,
       "userAction": ""
     },
     "acint.net": {
@@ -399,19 +309,7 @@
     "actionnetwork.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1534640190001,
-      "userAction": ""
-    },
-    "activenetwork-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535338170348,
-      "userAction": ""
-    },
-    "activenetworks-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535559735121,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acuityplatform.com": {
@@ -444,22 +342,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ad.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535280536254,
-      "userAction": ""
-    },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535264413152,
-      "userAction": ""
-    },
-    "ad.yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535443152680,
+      "nextUpdateTime": 1535775636862,
       "userAction": ""
     },
     "adapf.com": {
@@ -585,7 +471,7 @@
     "admiral.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535437438641,
+      "nextUpdateTime": 1535772075044,
       "userAction": ""
     },
     "admission.net": {
@@ -636,40 +522,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.adfox.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535192940943,
-      "userAction": ""
-    },
-    "ads.pro-market.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535166695414,
-      "userAction": ""
-    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535492314435,
-      "userAction": ""
-    },
-    "ads.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535135614621,
+      "nextUpdateTime": 1535370835027,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535549461468,
+      "nextUpdateTime": 1535550355567,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535393595473,
+      "nextUpdateTime": 1535565086150,
       "userAction": ""
     },
     "adscale.de": {
@@ -681,13 +549,13 @@
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585040406,
+      "nextUpdateTime": 1535326224607,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535485571758,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535736403220,
       "userAction": ""
     },
     "adsnative.com": {
@@ -807,7 +675,7 @@
     "aimfr.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535494521452,
+      "nextUpdateTime": 1535542761690,
       "userAction": ""
     },
     "ajx130.online": {
@@ -894,18 +762,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "amazonwebservices.d2.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535475655145,
-      "userAction": ""
-    },
-    "amazonwebservicesinc.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535384144806,
-      "userAction": ""
-    },
     "ameba.jp": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -915,25 +771,19 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535542954455,
+      "nextUpdateTime": 1535498841630,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535381037838,
-      "userAction": ""
-    },
-    "amplifypixel.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535613174595,
+      "nextUpdateTime": 1535555345379,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535108485791,
+      "nextUpdateTime": 1535483731128,
       "userAction": ""
     },
     "and.co.uk": {
@@ -975,7 +825,7 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535275471737,
+      "nextUpdateTime": 1535489107203,
       "userAction": ""
     },
     "ap.org": {
@@ -993,25 +843,13 @@
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535336991540,
-      "userAction": ""
-    },
-    "api-cache.adsnative.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535575652992,
-      "userAction": ""
-    },
-    "api.circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535169145890,
+      "nextUpdateTime": 1535490100109,
       "userAction": ""
     },
     "api.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535317179596,
+      "nextUpdateTime": 1535301364451,
       "userAction": ""
     },
     "api.ooyala.com": {
@@ -1035,7 +873,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535218695801,
+      "nextUpdateTime": 1535306650672,
       "userAction": ""
     },
     "appdynamics.com": {
@@ -1089,13 +927,7 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535501468829,
-      "userAction": ""
-    },
-    "as.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535229691374,
+      "nextUpdateTime": 1535594727054,
       "userAction": ""
     },
     "asos-media.com": {
@@ -1107,13 +939,13 @@
     "assets.adobedtm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535391921965,
+      "nextUpdateTime": 1535394076248,
       "userAction": ""
     },
     "assets.pinterest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535530764372,
+      "nextUpdateTime": 1535510850486,
       "userAction": ""
     },
     "atdmt.com": {
@@ -1152,12 +984,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.tags.newscgp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535164070585,
-      "userAction": ""
-    },
     "audtd.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1185,19 +1011,13 @@
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535355659377,
-      "userAction": ""
-    },
-    "b.nativendo.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535538712482,
+      "nextUpdateTime": 1535386434475,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535483331527,
+      "nextUpdateTime": 1535723388880,
       "userAction": ""
     },
     "b1img.com": {
@@ -1209,13 +1029,7 @@
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535505370686,
-      "userAction": ""
-    },
-    "b92.yahoo.co.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535148881205,
+      "nextUpdateTime": 1535744100522,
       "userAction": ""
     },
     "baidu.com": {
@@ -1233,13 +1047,13 @@
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535529473453,
+      "nextUpdateTime": 1535569138358,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535541829645,
+      "nextUpdateTime": 1535438816329,
       "userAction": ""
     },
     "bazaarvoice.com": {
@@ -1272,16 +1086,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "beacon.krxd.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535487258088,
-      "userAction": ""
-    },
     "beacon.sojern.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535529821305,
+      "nextUpdateTime": 1535622307627,
       "userAction": ""
     },
     "beatport.com": {
@@ -1329,25 +1137,19 @@
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526427623,
-      "userAction": ""
-    },
-    "bid.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535484981338,
+      "nextUpdateTime": 1535711505346,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535558241739,
+      "nextUpdateTime": 1535650884138,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535327480100,
+      "nextUpdateTime": 1535739989901,
       "userAction": ""
     },
     "biddingx.com": {
@@ -1497,7 +1299,7 @@
     "bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535062904378,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "brandcdn.com": {
@@ -1524,28 +1326,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "britishairways.d3.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535552042196,
-      "userAction": ""
-    },
-    "bs.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535430149297,
-      "userAction": ""
-    },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535546439609,
+      "nextUpdateTime": 1535317580022,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535375679856,
+      "nextUpdateTime": 1535402427322,
       "userAction": ""
     },
     "btttag.com": {
@@ -1566,28 +1356,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "c.adsymptotic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535505105536,
-      "userAction": ""
-    },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535571444799,
-      "userAction": ""
-    },
-    "c.deployads.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535584627640,
+      "nextUpdateTime": 1535421865228,
       "userAction": ""
     },
     "c.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535253163372,
+      "nextUpdateTime": 1535330316862,
       "userAction": ""
     },
     "c.ooyala.com": {
@@ -1599,7 +1377,7 @@
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535565223252,
+      "nextUpdateTime": 1535588673925,
       "userAction": ""
     },
     "c212.net": {
@@ -1641,13 +1419,7 @@
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535596662850,
-      "userAction": ""
-    },
-    "capture.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535590260745,
+      "nextUpdateTime": 1535350870640,
       "userAction": ""
     },
     "capturehighered.net": {
@@ -1692,12 +1464,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cdn-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535214837676,
-      "userAction": ""
-    },
     "cdn-hotels.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1710,52 +1476,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cdn.bizible.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535608709373,
-      "userAction": ""
-    },
-    "cdn.blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535256296804,
-      "userAction": ""
-    },
-    "cdn.digitru.st": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535493360512,
-      "userAction": ""
-    },
     "cdn.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535490700346,
+      "nextUpdateTime": 1535368181224,
       "userAction": ""
     },
     "cdn.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535411948604,
+      "nextUpdateTime": 1535681885582,
       "userAction": ""
     },
     "cdn.engine.addroplet.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535446078859,
+      "nextUpdateTime": 1535319832215,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535382379876,
+      "nextUpdateTime": 1535361058019,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535601702055,
+      "nextUpdateTime": 1535470292945,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -1767,55 +1515,37 @@
     "cdn.onthe.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535353300697,
-      "userAction": ""
-    },
-    "cdn.pardot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535617791411,
+      "nextUpdateTime": 1535744920970,
       "userAction": ""
     },
     "cdn.static.zdbb.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535400873241,
+      "nextUpdateTime": 1535611322176,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535121167406,
-      "userAction": ""
-    },
-    "cdn.tinypass.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535467316593,
+      "nextUpdateTime": 1535276039817,
       "userAction": ""
     },
     "cdn.viglink.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535566437816,
+      "nextUpdateTime": 1535336572694,
       "userAction": ""
     },
     "cdn.yldbt.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535334881641,
+      "nextUpdateTime": 1535578016864,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535143354964,
-      "userAction": ""
-    },
-    "cdn2.lockerdome.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535529533114,
+      "nextUpdateTime": 1535277004223,
       "userAction": ""
     },
     "cdnwidget.com": {
@@ -1851,7 +1581,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535134554501,
+      "nextUpdateTime": 1535335339975,
       "userAction": ""
     },
     "chei.com.cn": {
@@ -1950,28 +1680,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cm.e.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535362642071,
-      "userAction": ""
-    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535429314447,
-      "userAction": ""
-    },
-    "cm.l.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535280560755,
-      "userAction": ""
-    },
-    "cms.tanx.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535240105058,
+      "nextUpdateTime": 1535507563124,
       "userAction": ""
     },
     "cnet.com": {
@@ -1983,7 +1695,7 @@
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535142903454,
+      "nextUpdateTime": 1535746884132,
       "userAction": ""
     },
     "cnn.net": {
@@ -2025,7 +1737,7 @@
     "collector-963.tvsquared.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535346254938,
+      "nextUpdateTime": 1535591536333,
       "userAction": ""
     },
     "collegenet.com": {
@@ -2079,7 +1791,7 @@
     "configusa.veinteractive.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535543444411,
+      "nextUpdateTime": 1535312396043,
       "userAction": ""
     },
     "connatix.com": {
@@ -2091,7 +1803,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535174547715,
+      "nextUpdateTime": 1535327816790,
       "userAction": ""
     },
     "connexity.net": {
@@ -2104,12 +1816,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "consent.cmp.oath.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535501732621,
       "userAction": ""
     },
     "consent.google.com": {
@@ -2130,22 +1836,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "contextual.media.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535551827176,
+      "userAction": ""
+    },
     "contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "conv-blizzard-emea.cd.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535326160739,
-      "userAction": ""
-    },
-    "conv-blizzard-na.cd.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535228455740,
       "userAction": ""
     },
     "convertful.com": {
@@ -2175,7 +1875,7 @@
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535193184634,
+      "nextUpdateTime": 1535282313499,
       "userAction": ""
     },
     "cox.net": {
@@ -2265,13 +1965,13 @@
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535218329476,
+      "nextUpdateTime": 1535785680382,
       "userAction": ""
     },
     "ct.pinterest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535231836071,
+      "nextUpdateTime": 1535721841563,
       "userAction": ""
     },
     "ctv.ca": {
@@ -2292,12 +1992,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cx.atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535375224707,
-      "userAction": ""
-    },
     "cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -2307,13 +2001,13 @@
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510911863,
+      "nextUpdateTime": 1535632869291,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535402065299,
+      "nextUpdateTime": 1535589504356,
       "userAction": ""
     },
     "d1af033869koo7.cloudfront.net": {
@@ -2337,7 +2031,7 @@
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535313149602,
+      "nextUpdateTime": 1535550694881,
       "userAction": ""
     },
     "d41.co": {
@@ -2367,7 +2061,7 @@
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535127779521,
+      "nextUpdateTime": 1535731314406,
       "userAction": ""
     },
     "datamind.ru": {
@@ -2406,12 +2100,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "de.ioam.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535553465126,
-      "userAction": ""
-    },
     "deep.bi": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2421,7 +2109,7 @@
     "delivery.h.switchadhub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535249908051,
+      "nextUpdateTime": 1535332408469,
       "userAction": ""
     },
     "dell.com": {
@@ -2496,12 +2184,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "digikulture-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535473213147,
-      "userAction": ""
-    },
     "digitaladsystems.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2529,7 +2211,7 @@
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535514492739,
+      "nextUpdateTime": 1535351853085,
       "userAction": ""
     },
     "disqus.com": {
@@ -2554,12 +2236,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dmx.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535278571573,
       "userAction": ""
     },
     "dmxleo.com": {
@@ -2631,7 +2307,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535220813510,
+      "nextUpdateTime": 1535660981833,
       "userAction": ""
     },
     "dpmsrv.com": {
@@ -2649,7 +2325,7 @@
     "dx.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535284046783,
+      "nextUpdateTime": 1535375666559,
       "userAction": ""
     },
     "dynad.net": {
@@ -2712,12 +2388,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ecdn.firstimpression.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535480744702,
-      "userAction": ""
-    },
     "econda-monitor.de": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2739,7 +2409,7 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535109055535,
+      "nextUpdateTime": 1535709156246,
       "userAction": ""
     },
     "edmunds.com": {
@@ -2793,7 +2463,7 @@
     "engage.commander1.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535417679010,
+      "nextUpdateTime": 1535467267128,
       "userAction": ""
     },
     "envato.com": {
@@ -2812,18 +2482,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eset.marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535324409999,
-      "userAction": ""
-    },
-    "eset.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535172647379,
       "userAction": ""
     },
     "espn.com": {
@@ -2859,7 +2517,7 @@
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535233686356,
+      "nextUpdateTime": 1535668613149,
       "userAction": ""
     },
     "evenhotels.com": {
@@ -2889,7 +2547,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535412667318,
+      "nextUpdateTime": 1535627703429,
       "userAction": ""
     },
     "evise.com": {
@@ -2914,12 +2572,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ewscripps.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535440360689,
       "userAction": ""
     },
     "exactag.com": {
@@ -2961,7 +2613,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535550982016,
+      "nextUpdateTime": 1535776477755,
       "userAction": ""
     },
     "eyeota.net": {
@@ -2991,7 +2643,7 @@
     "facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535067712368,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "facetz.net": {
@@ -3015,13 +2667,13 @@
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535532544281,
+      "nextUpdateTime": 1535767229628,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535476086076,
+      "nextUpdateTime": 1535384258292,
       "userAction": ""
     },
     "fdlstatic.com": {
@@ -3102,12 +2754,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fo-api.omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535110977981,
-      "userAction": ""
-    },
     "fontawesome.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3123,7 +2769,7 @@
     "forms.hubspot.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535114875943,
+      "nextUpdateTime": 1535314602665,
       "userAction": ""
     },
     "formstack.com": {
@@ -3148,12 +2794,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxnet.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535397455637,
       "userAction": ""
     },
     "foxnews.com": {
@@ -3183,7 +2823,7 @@
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535263330795,
+      "nextUpdateTime": 1535545678626,
       "userAction": ""
     },
     "freshdesk.com": {
@@ -3222,16 +2862,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.cn.miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535463525932,
-      "userAction": ""
-    },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535240351512,
+      "nextUpdateTime": 1535321909354,
       "userAction": ""
     },
     "g2crowd.com": {
@@ -3243,13 +2877,7 @@
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535282616525,
-      "userAction": ""
-    },
-    "gakogedifoda.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535324356929,
+      "nextUpdateTime": 1535664024752,
       "userAction": ""
     },
     "gamer-network.net": {
@@ -3261,19 +2889,19 @@
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535406151780,
+      "nextUpdateTime": 1535688623621,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535595384247,
+      "nextUpdateTime": 1535283408614,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535529600416,
+      "nextUpdateTime": 1535451768544,
       "userAction": ""
     },
     "gemius.pl": {
@@ -3291,7 +2919,7 @@
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535470476213,
+      "nextUpdateTime": 1535374294843,
       "userAction": ""
     },
     "getclicky.com": {
@@ -3393,7 +3021,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535299738930,
+      "nextUpdateTime": 1535422625541,
       "userAction": ""
     },
     "gq.com": {
@@ -3405,7 +3033,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535232994108,
+      "nextUpdateTime": 1535323245373,
       "userAction": ""
     },
     "gridsumdissector.com": {
@@ -3474,16 +3102,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hb-api.omnitagjs.com": {
+    "hbevents.1rx.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535149948702,
+      "nextUpdateTime": 1535462113539,
       "userAction": ""
     },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535528458660,
+      "nextUpdateTime": 1535354947278,
       "userAction": ""
     },
     "healte.de": {
@@ -3532,12 +3160,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hm.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535592367417,
       "userAction": ""
     },
     "holidayinn.com": {
@@ -3618,16 +3240,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "i.gridsumdissector.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535258286357,
-      "userAction": ""
-    },
     "i.po.st": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560008032,
+      "nextUpdateTime": 1535360193879,
       "userAction": ""
     },
     "i.ua": {
@@ -3648,16 +3264,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ib.3lift.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535769237395,
+      "userAction": ""
+    },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535558901666,
+      "nextUpdateTime": 1535784604446,
       "userAction": ""
     },
     "ibclick.stream": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535168630812,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ibillboard.com": {
@@ -3675,13 +3297,13 @@
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535611501989,
+      "nextUpdateTime": 1535504362106,
       "userAction": ""
     },
     "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535224773713,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "idealmedia.com": {
@@ -3726,12 +3348,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "img.ak.impact-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535376841775,
-      "userAction": ""
-    },
     "img.purch.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3771,7 +3387,7 @@
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535609251930,
+      "nextUpdateTime": 1535705265312,
       "userAction": ""
     },
     "infolinks.com": {
@@ -3807,7 +3423,7 @@
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535259006632,
+      "nextUpdateTime": 1535293278709,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -3825,7 +3441,7 @@
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535313547846,
+      "nextUpdateTime": 1535314940322,
       "userAction": ""
     },
     "instinctiveads.com": {
@@ -3862,12 +3478,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "investing-channel-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535212585331,
       "userAction": ""
     },
     "investingchannel.com": {
@@ -3933,7 +3543,7 @@
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535302445154,
+      "nextUpdateTime": 1535488196626,
       "userAction": ""
     },
     "janrainsso.com": {
@@ -4224,22 +3834,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load.instinctiveads.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535156309565,
-      "userAction": ""
-    },
     "load.sumo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535193129482,
-      "userAction": ""
-    },
-    "loadus.exelator.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535330758728,
+      "nextUpdateTime": 1535536085224,
       "userAction": ""
     },
     "loc.gov": {
@@ -4251,25 +3849,19 @@
     "lockerdome.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535602667578,
+      "nextUpdateTime": 1535455362196,
       "userAction": ""
     },
     "log.mmstat.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535614693593,
-      "userAction": ""
-    },
-    "logc187.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535533148953,
+      "nextUpdateTime": 1535759748439,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535423452721,
+      "nextUpdateTime": 1535540033786,
       "userAction": ""
     },
     "logly.co.jp": {
@@ -4281,19 +3873,7 @@
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535260246626,
-      "userAction": ""
-    },
-    "logs1136.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535620450441,
-      "userAction": ""
-    },
-    "lptag.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535381494449,
+      "nextUpdateTime": 1535391723972,
       "userAction": ""
     },
     "lqm.io": {
@@ -4324,12 +3904,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "m.reachmax.cn": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535177699423,
       "userAction": ""
     },
     "m6r.eu": {
@@ -4401,13 +3975,7 @@
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535382731107,
-      "userAction": ""
-    },
-    "match.prod.bidr.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535338080427,
+      "nextUpdateTime": 1535384308840,
       "userAction": ""
     },
     "matheranalytics.com": {
@@ -4422,10 +3990,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "me-ssl.effectivemeasure.net": {
+    "mc.webvisor.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535545627821,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535379216286,
       "userAction": ""
     },
     "media.net": {
@@ -4443,7 +4011,7 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535562992042,
+      "nextUpdateTime": 1535641072175,
       "userAction": ""
     },
     "mediaforge.com": {
@@ -4557,7 +4125,7 @@
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535261768429,
+      "nextUpdateTime": 1535498798816,
       "userAction": ""
     },
     "mirtesen.ru": {
@@ -4575,7 +4143,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535088403217,
+      "nextUpdateTime": 1535599816345,
       "userAction": ""
     },
     "mlb.com": {
@@ -4656,12 +4224,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mssl.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535132799668,
-      "userAction": ""
-    },
     "mt0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -4678,12 +4240,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtrx.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535349304856,
       "userAction": ""
     },
     "mts0.google.com": {
@@ -4743,7 +4299,7 @@
     "mx.technolutions.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535512750016,
+      "nextUpdateTime": 1535385268290,
       "userAction": ""
     },
     "mybuys.com": {
@@ -4815,7 +4371,7 @@
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535458022322,
+      "nextUpdateTime": 1535536609168,
       "userAction": ""
     },
     "nativendo.de": {
@@ -4840,12 +4396,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nbcu.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535351358779,
       "userAction": ""
     },
     "nbcuni.com": {
@@ -4908,12 +4458,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "newscorpau.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535270929625,
-      "userAction": ""
-    },
     "newsinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -4960,12 +4504,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nineto5mac-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535458910130,
       "userAction": ""
     },
     "nokia.com": {
@@ -5031,7 +4569,7 @@
     "oasc10.247realmedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535205066735,
+      "nextUpdateTime": 1535771010830,
       "userAction": ""
     },
     "oath.com": {
@@ -5134,12 +4672,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onetag.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535417103733,
       "userAction": ""
     },
     "onetrust.com": {
@@ -5292,30 +4824,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "p.adsymptotic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535365238469,
-      "userAction": ""
-    },
-    "p.cpx.to": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535168480502,
-      "userAction": ""
-    },
-    "p.dlx.addthis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535348749572,
-      "userAction": ""
-    },
-    "p2.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535338824891,
-      "userAction": ""
-    },
     "paddle.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5350,12 +4858,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pba.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535543859020,
       "userAction": ""
     },
     "pbskids.org": {
@@ -5394,16 +4896,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "phonograph2.voxmedia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535325549253,
-      "userAction": ""
-    },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535354151599,
+      "nextUpdateTime": 1535701822972,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -5445,37 +4941,25 @@
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535444780876,
+      "nextUpdateTime": 1535283808671,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535344368148,
+      "nextUpdateTime": 1535599324347,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535558880509,
+      "nextUpdateTime": 1535293467498,
       "userAction": ""
     },
     "pixel.s3xified.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535454023503,
-      "userAction": ""
-    },
-    "pixel.sitescout.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535559337523,
-      "userAction": ""
-    },
-    "pixel.zprk.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535144814767,
+      "nextUpdateTime": 1535351756763,
       "userAction": ""
     },
     "piximedia.com": {
@@ -5505,13 +4989,13 @@
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535124167487,
+      "nextUpdateTime": 1535707414696,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535508990081,
       "userAction": ""
     },
     "play.google.com": {
@@ -5529,19 +5013,13 @@
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535505151187,
+      "nextUpdateTime": 1535784596525,
       "userAction": ""
     },
     "players.brightcove.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "playwire-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535388410492,
       "userAction": ""
     },
     "playwire.com": {
@@ -5586,16 +5064,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535294459416,
-      "userAction": ""
-    },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469659560,
+      "nextUpdateTime": 1535313424134,
       "userAction": ""
     },
     "postrelease.com": {
@@ -5631,7 +5103,7 @@
     "prod-mng-proxy-connext.azurewebsites.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535243906722,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "proparm.jp": {
@@ -5650,12 +5122,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "proximus.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535564390419,
       "userAction": ""
     },
     "proximustv.be": {
@@ -5679,7 +5145,7 @@
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535611640025,
+      "nextUpdateTime": 1535747649954,
       "userAction": ""
     },
     "publishme.se": {
@@ -5718,16 +5184,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "px.adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535176013543,
-      "userAction": ""
-    },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535131329876,
+      "nextUpdateTime": 1535414302086,
       "userAction": ""
     },
     "pxf.io": {
@@ -5757,19 +5217,13 @@
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535033233942,
-      "userAction": ""
-    },
-    "qantas.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535490587938,
+      "nextUpdateTime": 1535707658880,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535345306051,
+      "nextUpdateTime": 1535322507910,
       "userAction": ""
     },
     "qnsr.com": {
@@ -5805,7 +5259,7 @@
     "quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535217833076,
+      "nextUpdateTime": 1535303189218,
       "userAction": ""
     },
     "quantserve.com": {
@@ -5841,7 +5295,7 @@
     "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535217930912,
+      "nextUpdateTime": 1535469636156,
       "userAction": ""
     },
     "rackcdn.com": {
@@ -5889,7 +5343,7 @@
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535304923654,
+      "nextUpdateTime": 1535694127287,
       "userAction": ""
     },
     "reddit.com": {
@@ -6036,12 +5490,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rtax.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535222519189,
-      "userAction": ""
-    },
     "rtb.com.ru": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6066,12 +5514,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rudy.adsnative.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535347337543,
-      "userAction": ""
-    },
     "rundsp.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6093,61 +5535,37 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535352076386,
+      "nextUpdateTime": 1535620231354,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535561577916,
+      "nextUpdateTime": 1535361444004,
       "userAction": ""
     },
     "s.clickability.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535224844708,
-      "userAction": ""
-    },
-    "s.effectivemeasure.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535201225344,
+      "nextUpdateTime": 1535500020630,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535214890098,
-      "userAction": ""
-    },
-    "s.thebrighttag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535434341417,
-      "userAction": ""
-    },
-    "s.yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535216141835,
+      "nextUpdateTime": 1535347553762,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535580705625,
+      "nextUpdateTime": 1535497869463,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535131999264,
-      "userAction": ""
-    },
-    "s2208.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535493968964,
+      "nextUpdateTime": 1535700678259,
       "userAction": ""
     },
     "s3-us-west-2.amazonaws.com": {
@@ -6165,7 +5583,7 @@
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477270241,
+      "nextUpdateTime": 1535567994221,
       "userAction": ""
     },
     "sabavision.com": {
@@ -6201,13 +5619,13 @@
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535121885101,
+      "nextUpdateTime": 1535304655636,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535435991656,
+      "nextUpdateTime": 1535380369509,
       "userAction": ""
     },
     "sbal4kp.com": {
@@ -6225,7 +5643,7 @@
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535441459044,
+      "nextUpdateTime": 1535709010353,
       "userAction": ""
     },
     "scholarlyiq.com": {
@@ -6276,18 +5694,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "scripps.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535244758147,
-      "userAction": ""
-    },
-    "scripps.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535227106148,
-      "userAction": ""
-    },
     "script.ioam.de": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6300,22 +5706,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "se.monetate.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535391241554,
-      "userAction": ""
-    },
     "seadform.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "search.spotxchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535453750224,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -6330,16 +5724,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "seccdn-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535243571282,
-      "userAction": ""
-    },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535119927597,
+      "nextUpdateTime": 1535507877988,
       "userAction": ""
     },
     "secure-cf-c.ooyala.com": {
@@ -6348,64 +5736,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "secure-dcr.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535335494368,
-      "userAction": ""
-    },
-    "secure-ds.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535584481337,
-      "userAction": ""
-    },
-    "secure-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535177741800,
-      "userAction": ""
-    },
-    "secure-it.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535107082511,
-      "userAction": ""
-    },
-    "secure-us.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535292364343,
-      "userAction": ""
-    },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535562920063,
+      "nextUpdateTime": 1535629104659,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535398828987,
-      "userAction": ""
-    },
-    "secure.livechatinc.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535351110245,
+      "nextUpdateTime": 1535541191462,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535579341049,
-      "userAction": ""
-    },
-    "secure.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535254601040,
+      "nextUpdateTime": 1535676669760,
       "userAction": ""
     },
     "securedvisit.com": {
@@ -6417,13 +5763,19 @@
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535591583698,
+      "nextUpdateTime": 1535462521946,
       "userAction": ""
     },
     "seekingalpha.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "segapi.quantserve.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535611375395,
       "userAction": ""
     },
     "sekindo.com": {
@@ -6513,7 +5865,7 @@
     "shop.pe": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1534791910138,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "shopify.com": {
@@ -6594,12 +5946,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sjs.bizographics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535196852776,
-      "userAction": ""
-    },
     "skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -6628,6 +5974,12 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartlock.google.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535639501499,
       "userAction": ""
     },
     "smashing-delivery.herokuapp.com": {
@@ -6732,12 +6084,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "solarwinds.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535180937040,
-      "userAction": ""
-    },
     "soliditet.se": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6777,7 +6123,7 @@
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535161310463,
+      "nextUpdateTime": 1535735045296,
       "userAction": ""
     },
     "sp.global.ssl.fastly.net": {
@@ -6876,52 +6222,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-23-09.config.parsely.com": {
+    "srv-2018-08-25-08.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535292359742,
+      "nextUpdateTime": 1535294050043,
       "userAction": ""
     },
-    "srv-2018-08-23-10.config.parsely.com": {
+    "srv-2018-08-25-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535475527218,
+      "nextUpdateTime": 1535389542000,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535550468582,
+      "nextUpdateTime": 1535333761299,
       "userAction": ""
     },
     "srx.com.sg": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ss3.zedo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535129275153,
-      "userAction": ""
-    },
-    "sslwidget.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535229607025,
-      "userAction": ""
-    },
-    "ssp.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535203697827,
-      "userAction": ""
-    },
-    "st.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535164370467,
       "userAction": ""
     },
     "stackadapt.com": {
@@ -6963,31 +6285,25 @@
     "static.apester.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535270017993,
+      "nextUpdateTime": 1535467557092,
       "userAction": ""
     },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535289627794,
+      "nextUpdateTime": 1535601577779,
       "userAction": ""
     },
     "static.getclicky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535459656103,
+      "nextUpdateTime": 1535707810492,
       "userAction": ""
     },
     "static.mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535318289140,
-      "userAction": ""
-    },
-    "static.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535229325922,
+      "nextUpdateTime": 1535774749817,
       "userAction": ""
     },
     "staticimgfarm.com": {
@@ -6999,19 +6315,19 @@
     "staticxx.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535552916169,
       "userAction": ""
     },
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535508331167,
+      "nextUpdateTime": 1535769350544,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535190455456,
+      "nextUpdateTime": 1535673063982,
       "userAction": ""
     },
     "staybridge.com": {
@@ -7083,7 +6399,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535231190644,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -7119,19 +6435,13 @@
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421948525,
+      "nextUpdateTime": 1535626849664,
       "userAction": ""
     },
     "surveymonkey.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sw88.go.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535311993890,
       "userAction": ""
     },
     "switchadhub.com": {
@@ -7155,43 +6465,25 @@
     "sync.1rx.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436844877,
+      "nextUpdateTime": 1535475220637,
       "userAction": ""
     },
-    "sync.audtd.com": {
+    "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535423682583,
-      "userAction": ""
-    },
-    "sync.datamind.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535591448993,
-      "userAction": ""
-    },
-    "sync.republer.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535227536756,
+      "nextUpdateTime": 1535486045547,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535404928871,
+      "nextUpdateTime": 1535723607166,
       "userAction": ""
     },
     "syndication.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "t.go.sohu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535161788370,
       "userAction": ""
     },
     "taboola.com": {
@@ -7206,46 +6498,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tag-st.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535575760736,
-      "userAction": ""
-    },
     "tag.1rx.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535224096496,
+      "nextUpdateTime": 1535430884961,
       "userAction": ""
     },
     "tag.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535587928642,
+      "nextUpdateTime": 1535529659019,
       "userAction": ""
     },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535172809545,
-      "userAction": ""
-    },
-    "tag.marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535169314524,
-      "userAction": ""
-    },
-    "tag.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535482405835,
-      "userAction": ""
-    },
-    "tag.sp.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535108288134,
+      "nextUpdateTime": 1535308652245,
       "userAction": ""
     },
     "tag4arm.com": {
@@ -7407,7 +6675,7 @@
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535536640170,
+      "nextUpdateTime": 1535635715151,
       "userAction": ""
     },
     "tidaltv.com": {
@@ -7431,7 +6699,7 @@
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535335023989,
+      "nextUpdateTime": 1535282600241,
       "userAction": ""
     },
     "timewarnercable.com": {
@@ -7461,7 +6729,7 @@
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535210811276,
+      "nextUpdateTime": 1535732106207,
       "userAction": ""
     },
     "tm-awx.com": {
@@ -7482,22 +6750,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "token.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535573160300,
-      "userAction": ""
-    },
     "toutapp.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tr.snapchat.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535515643596,
       "userAction": ""
     },
     "tracc.it": {
@@ -7509,13 +6765,13 @@
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535424312057,
+      "nextUpdateTime": 1535492957754,
       "userAction": ""
     },
     "track.hubspot.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535264130780,
+      "nextUpdateTime": 1535789537864,
       "userAction": ""
     },
     "trackad.cz": {
@@ -7528,12 +6784,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tracking.g2crowd.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535237778325,
       "userAction": ""
     },
     "tradedoubler.com": {
@@ -7611,7 +6861,7 @@
     "trends.revcontent.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535603923908,
+      "nextUpdateTime": 1535657111047,
       "userAction": ""
     },
     "tribalfusion.com": {
@@ -7623,7 +6873,7 @@
     "tribl.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535233893141,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tripadvisor.com": {
@@ -7716,6 +6966,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "u.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535337795053,
+      "userAction": ""
+    },
     "ubi.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -7728,12 +6984,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "uconnect.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535393886670,
-      "userAction": ""
-    },
     "ucoz.net": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -7743,7 +6993,7 @@
     "udmserve.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535539694388,
+      "nextUpdateTime": 1535623217710,
       "userAction": ""
     },
     "udnfunlife.com": {
@@ -7770,12 +7020,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "unagi-eu.amazon.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535196808939,
-      "userAction": ""
-    },
     "undertone.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -7794,12 +7038,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "universal.iperceptions.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535325388047,
-      "userAction": ""
-    },
     "unrulymedia.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -7810,12 +7048,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ups.xplosion.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535407396093,
       "userAction": ""
     },
     "upsellit.com": {
@@ -7917,7 +7149,7 @@
     "vendorlist.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535354855735,
+      "nextUpdateTime": 1535496547035,
       "userAction": ""
     },
     "verticalhealth.net": {
@@ -8001,7 +7233,7 @@
     "visitor-service.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535281447453,
+      "nextUpdateTime": 1535328116340,
       "userAction": ""
     },
     "visualstudio.com": {
@@ -8019,7 +7251,7 @@
     "vk.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535214742233,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vogue.com": {
@@ -8044,6 +7276,12 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "w.soundcloud.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535362215363,
       "userAction": ""
     },
     "w55c.net": {
@@ -8091,7 +7329,7 @@
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535205349790,
+      "nextUpdateTime": 1535533523401,
       "userAction": ""
     },
     "webmd.com": {
@@ -8142,6 +7380,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "webvisor.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "weibo.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -8158,12 +7402,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "widget.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535613320681,
       "userAction": ""
     },
     "wikia-services.com": {
@@ -8229,7 +7467,7 @@
     "wkxppshj-qx.global.ssl.fastly.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1534814085104,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wmagazine.com": {
@@ -8277,7 +7515,7 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535133343141,
+      "nextUpdateTime": 1535421603690,
       "userAction": ""
     },
     "wsj.com": {
@@ -8313,13 +7551,13 @@
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535160363763,
+      "nextUpdateTime": 1535462553112,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535121108712,
+      "nextUpdateTime": 1535628441125,
       "userAction": ""
     },
     "www.bing.com": {
@@ -8331,25 +7569,19 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535515298218,
+      "nextUpdateTime": 1535435837859,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535253088334,
+      "nextUpdateTime": 1535722692599,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535377541215,
-      "userAction": ""
-    },
-    "www.epicurious.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535332528512,
+      "nextUpdateTime": 1535540695148,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -8361,13 +7593,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535373992834,
+      "nextUpdateTime": 1535352083508,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535478659047,
+      "nextUpdateTime": 1535442239807,
       "userAction": ""
     },
     "www.google.com": {
@@ -8379,73 +7611,73 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535109212248,
+      "nextUpdateTime": 1535415783243,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535353938304,
+      "nextUpdateTime": 1535584719804,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535324760182,
+      "nextUpdateTime": 1535690782225,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535412184727,
+      "nextUpdateTime": 1535413588731,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535371018711,
+      "nextUpdateTime": 1535761756013,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535524961484,
+      "nextUpdateTime": 1535413948315,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535401655245,
+      "nextUpdateTime": 1535346939476,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535364193938,
+      "nextUpdateTime": 1535476281376,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535307422760,
+      "nextUpdateTime": 1535547170595,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535212366928,
+      "nextUpdateTime": 1535552612700,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535257180613,
+      "nextUpdateTime": 1535323278489,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535432091170,
+      "nextUpdateTime": 1535773685713,
       "userAction": ""
     },
     "wwwimages.adobe.com": {
@@ -8463,7 +7695,7 @@
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535372826747,
+      "nextUpdateTime": 1535595886319,
       "userAction": ""
     },
     "xad.com": {
@@ -8559,7 +7791,7 @@
     "yastatic.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535288290126,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "yieldify.com": {
@@ -8595,7 +7827,7 @@
     "ymetrica1.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535543854128,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "yoox.it": {
@@ -8643,19 +7875,19 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535312844355,
+      "nextUpdateTime": 1535418328014,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535168425931,
+      "nextUpdateTime": 1535371320121,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535346541264,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "zedo.com": {
@@ -8762,13 +7994,25 @@
       "aappublications.org",
       "americanbar.org"
     ],
+    "254a.com": [
+      "zerohedge.com"
+    ],
     "2mdnsys.com": [
       "liveuamap.com"
     ],
     "2o7.net": [
       "mysql.com",
       "cdc.gov",
-      "theatlantic.com"
+      "theatlantic.com",
+      "prnewswire.com",
+      "earthlink.net",
+      "inc.com",
+      "qz.com",
+      "philips.com",
+      "fastcompany.com",
+      "infoseek.co.jp",
+      "ahajournals.org",
+      "sbs.com.au"
     ],
     "33across.com": [
       "accuweather.com"
@@ -8786,12 +8030,16 @@
     ],
     "3gl.net": [
       "istockphoto.com",
-      "gettyimages.com"
+      "gettyimages.com",
+      "thedailybeast.com"
     ],
     "3lift.com": [
       "nature.com",
       "springer.com",
-      "theverge.com"
+      "theverge.com",
+      "wunderground.com",
+      "macworld.com",
+      "polygon.com"
     ],
     "4dsply.com": [
       "wnd.com"
@@ -8863,7 +8111,8 @@
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "bartleby.com"
+      "bartleby.com",
+      "dropbox.com"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
@@ -8892,12 +8141,16 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com"
+      "washingtonexaminer.com",
+      "tinypic.com"
     ],
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
-      "yahoo.com"
+      "yahoo.com",
+      "dropbox.com",
+      "business-standard.com",
+      "gulfnews.com"
     ],
     "addtoany.com": [
       "irs.gov"
@@ -8909,7 +8162,10 @@
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com"
+      "springer.com",
+      "shutterstock.com",
+      "si.com",
+      "helsinki.fi"
     ],
     "adfox.ru": [
       "livejournal.com",
@@ -8933,7 +8189,9 @@
     "adition.com": [
       "bloomberg.com",
       "dailymotion.com",
-      "spiegel.de"
+      "spiegel.de",
+      "t-online.de",
+      "focus.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -8949,8 +8207,7 @@
     ],
     "admaster.com.cn": [
       "autohome.com.cn",
-      "bshare.cn",
-      "youku.com"
+      "bshare.cn"
     ],
     "admission.net": [
       "edmunds.com"
@@ -8961,18 +8218,22 @@
     "adnxs.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "jsonline.com",
+      "hgtv.com"
     ],
     "adobe.com": [
       "wikipedia.org",
-      "apache.org",
       "behance.net",
-      "msnbc.com"
+      "history.com",
+      "fotolia.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
       "bbb.org",
-      "bizjournals.com"
+      "bizjournals.com",
+      "worldbank.org"
     ],
     "adotmob.com": [
       "standard.co.uk",
@@ -8986,7 +8247,9 @@
     "adroll.com": [
       "stumbleupon.com",
       "nature.com",
-      "nginx.org"
+      "nginx.org",
+      "cloudflare.com",
+      "zenfolio.com"
     ],
     "adscale.de": [
       "t-online.de",
@@ -9004,7 +8267,10 @@
     "adsrvr.org": [
       "adobe.com",
       "yahoo.com",
-      "googletagmanager.com"
+      "googletagmanager.com",
+      "sourceforge.net",
+      "jsonline.com",
+      "gizmodo.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -9014,7 +8280,10 @@
     "adsymptotic.com": [
       "tinyurl.com",
       "etsy.com",
-      "tripadvisor.com"
+      "tripadvisor.com",
+      "foursquare.com",
+      "jsonline.com",
+      "realtor.com"
     ],
     "adtags.pro": [
       "tomsk.ru"
@@ -9025,7 +8294,10 @@
     "advertising.com": [
       "amazon.com",
       "sourceforge.net",
-      "dropbox.com"
+      "dropbox.com",
+      "msn.com",
+      "nordstrom.com",
+      "pitchfork.com"
     ],
     "advertur.ru": [
       "radikal.ru"
@@ -9054,7 +8326,9 @@
     "agkn.com": [
       "amazon.com",
       "t-online.de",
-      "bloomberg.com"
+      "bloomberg.com",
+      "dropbox.com",
+      "att.net"
     ],
     "aid-ad.jp": [
       "shinobi.jp"
@@ -9073,7 +8347,8 @@
     "akamaihd.net": [
       "voanews.com",
       "repubblica.it",
-      "iyfubh.com"
+      "iyfubh.com",
+      "forbes.com"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -9086,14 +8361,13 @@
     "alibaba.com": [
       "youku.com",
       "taobao.com",
-      "aliexpress.com",
-      "tmall.com"
+      "aliexpress.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
-      "aliexpress.com"
+      "1688.com"
     ],
     "alipay.com": [
       "alibaba.com",
@@ -9105,15 +8379,22 @@
     "allure.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "am15.net": [
       "radikal.ru"
     ],
+    "amap.com": [
+      "zhaopin.com"
+    ],
     "amazon-adsystem.com": [
       "amazon.com",
       "nytimes.com",
-      "reddit.com"
+      "reddit.com",
+      "forbes.com",
+      "ocregister.com",
+      "gizmodo.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -9121,10 +8402,7 @@
     "amazon.com": [
       "qq.com",
       "imdb.com",
-      "amazon.co.uk",
-      "amazon.de",
-      "amazon.co.jp",
-      "amazon.es"
+      "amazon.co.uk"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -9165,7 +8443,8 @@
     "app.link": [
       "foursquare.com",
       "history.com",
-      "nbc.com"
+      "nbc.com",
+      "edx.org"
     ],
     "appdynamics.com": [
       "nfl.com"
@@ -9173,7 +8452,8 @@
     "apple.com": [
       "digitaltrends.com",
       "icloud.com",
-      "softpedia.com"
+      "softpedia.com",
+      "thinkgeek.com"
     ],
     "aqtracker.com": [
       "nikkei.com"
@@ -9184,7 +8464,8 @@
     "architecturaldigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
@@ -9206,7 +8487,9 @@
     "atdmt.com": [
       "facebook.com",
       "yahoo.com",
-      "msn.com"
+      "msn.com",
+      "t-online.de",
+      "upwork.com"
     ],
     "atemda.com": [
       "springer.com",
@@ -9241,7 +8524,8 @@
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com"
+      "ifeng.com",
+      "coremail.cn"
     ],
     "bam-x.com": [
       "gq.com"
@@ -9283,10 +8567,14 @@
       "tomsk.ru",
       "radikal.ru"
     ],
+    "bf-tools.net": [
+      "focus.de"
+    ],
     "bfmio.com": [
       "symantec.com",
       "tinypic.com",
-      "venturebeat.com"
+      "venturebeat.com",
+      "livescience.com"
     ],
     "bfmtv.com": [
       "liberation.fr",
@@ -9298,12 +8586,17 @@
     "bidr.io": [
       "adobe.com",
       "dailymotion.com",
-      "hootsuite.com"
+      "hootsuite.com",
+      "hp.com",
+      "upwork.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
-      "amazon.com"
+      "amazon.com",
+      "dropbox.com",
+      "jsonline.com",
+      "zerohedge.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -9316,7 +8609,10 @@
       "vimeo.com",
       "cnn.com",
       "weebly.com",
-      "msn.com"
+      "msn.com",
+      "microsoft.com",
+      "here.com",
+      "pingdom.com"
     ],
     "bitbucket.org": [
       "atlassian.com"
@@ -9324,7 +8620,10 @@
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com"
+      "zendesk.com",
+      "shutterstock.com",
+      "here.com",
+      "gitlab.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
@@ -9332,12 +8631,15 @@
     "bizographics.com": [
       "zend.com",
       "nginx.com",
-      "oreilly.com"
+      "oreilly.com",
+      "jimdo.com"
     ],
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com",
+      "si.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -9347,12 +8649,14 @@
     ],
     "bluecava.com": [
       "history.com",
-      "biography.com"
+      "biography.com",
+      "complex.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
-      "sfgate.com"
+      "sfgate.com",
+      "discovermagazine.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -9364,9 +8668,6 @@
       "jigsy.com",
       "bravenet.com"
     ],
-    "bobo.com": [
-      "163.com"
-    ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
@@ -9375,10 +8676,14 @@
     "bonappetit.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "boston.com": [
       "bostonglobe.com"
+    ],
+    "bostonglobemedia.com": [
+      "boston.com"
     ],
     "botradar.tech": [
       "radikal.ru"
@@ -9389,7 +8694,10 @@
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com"
+      "wired.com",
+      "latimes.com",
+      "si.com",
+      "pitchfork.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
@@ -9397,12 +8705,14 @@
     "brides.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "brightcove.com": [
       "scholastic.com",
       "si.com",
       "federalreserve.gov",
+      "theaustralian.com.au",
       "informationweek.com",
       "straitstimes.com"
     ],
@@ -9414,7 +8724,9 @@
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
-      "zendesk.com"
+      "zendesk.com",
+      "theverge.com",
+      "alternet.org"
     ],
     "btttag.com": [
       "samsung.com",
@@ -9454,12 +8766,18 @@
     "casalemedia.com": [
       "amazon.com",
       "dropbox.com",
-      "myspace.com"
+      "myspace.com",
+      "washingtonpost.com",
+      "macworld.com",
+      "pitchfork.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
-      "gamespot.com"
+      "gamespot.com",
+      "cnet.com",
+      "cbsnews.com",
+      "cbssports.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -9480,6 +8798,9 @@
     ],
     "cdnwidget.com": [
       "photoshelter.com"
+    ],
+    "cedexis-test.com": [
+      "tumblr.com"
     ],
     "cern.ch": [
       "home.cern"
@@ -9512,7 +8833,8 @@
     "circularhub.com": [
       "suntimes.com",
       "tampabay.com",
-      "bostonherald.com"
+      "bostonherald.com",
+      "stltoday.com"
     ],
     "civicscience.com": [
       "post-gazette.com",
@@ -9522,10 +8844,6 @@
     "ckies.net": [
       "abril.com.br"
     ],
-    "cleveland.com": [
-      "nola.com",
-      "al.com"
-    ],
     "clickability.com": [
       "prnewswire.com",
       "philly.com",
@@ -9533,8 +8851,7 @@
     ],
     "clicktale.net": [
       "xbox.com",
-      "office.com",
-      "microsoft.com"
+      "office.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
@@ -9547,6 +8864,7 @@
       "uci.edu",
       "nbcnews.com",
       "sciencemag.org",
+      "nginx.com",
       "allaboutcookies.org"
     ],
     "cnet.com": [
@@ -9558,7 +8876,8 @@
     "cntraveler.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "cnzz.com": [
       "zol.com.cn"
@@ -9584,12 +8903,15 @@
     "commander1.com": [
       "ovh.com",
       "ubisoft.com",
-      "arte.tv"
+      "arte.tv",
+      "ovh.co.uk"
     ],
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com"
+      "redhat.com",
+      "hp.com",
+      "upwork.com"
     ],
     "complex.com": [
       "knowyourmeme.com",
@@ -9602,7 +8924,9 @@
     "condenastdigital.com": [
       "wired.com",
       "arstechnica.com",
-      "nj.com"
+      "nj.com",
+      "newyorker.com",
+      "pitchfork.com"
     ],
     "conductrics.com": [
       "nginx.com"
@@ -9617,10 +8941,15 @@
     "consensu.org": [
       "rollingstone.com",
       "variety.com",
-      "adweek.com"
+      "adweek.com",
+      "buzzfeed.com",
+      "alternet.org"
     ],
     "consumable.com": [
       "xfinity.com"
+    ],
+    "content.ad": [
+      "tinypic.com"
     ],
     "contentabc.com": [
       "pornhub.com"
@@ -9628,7 +8957,9 @@
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "forbes.com",
+      "colourlovers.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -9656,7 +8987,10 @@
     "cpx.to": [
       "express.co.uk",
       "digitaltrends.com",
-      "techradar.com"
+      "techradar.com",
+      "independent.co.uk",
+      "allmusic.com",
+      "rfi.fr"
     ],
     "cquotient.com": [
       "gopro.com"
@@ -9674,7 +9008,10 @@
     "criteo.com": [
       "tinyurl.com",
       "washingtonpost.com",
-      "dailymail.co.uk"
+      "dailymail.co.uk",
+      "dropbox.com",
+      "alternet.org",
+      "hgtv.com"
     ],
     "croissed.info": [
       "4shared.com"
@@ -9686,9 +9023,6 @@
       "sourceforge.net",
       "slashdot.org",
       "bartleby.com"
-    ],
-    "crwdcntrl.net": [
-      "bloomberg.com"
     ],
     "cssrvsync.com": [
       "springer.com",
@@ -9706,7 +9040,9 @@
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
-      "gizmodo.com"
+      "gizmodo.com",
+      "wsj.com",
+      "jalopnik.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -9758,13 +9094,19 @@
     "deep.bi": [
       "hrw.org"
     ],
+    "deepintent.com": [
+      "infoplease.com"
+    ],
     "dell.com": [
       "rsa.com"
     ],
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "amazon.com"
+      "amazon.com",
+      "soundcloud.com",
+      "jsonline.com",
+      "skynet.be"
     ],
     "departapp.com": [
       "liveuamap.com"
@@ -9772,7 +9114,8 @@
     "deployads.com": [
       "tinyurl.com",
       "lycos.com",
-      "sciencedaily.com"
+      "sciencedaily.com",
+      "zerohedge.com"
     ],
     "deqwas.net": [
       "rakuten.co.jp"
@@ -9783,12 +9126,16 @@
     "dezeenjobs.com": [
       "dezeen.com"
     ],
+    "df-srv.de": [
+      "focus.de"
+    ],
     "dhs.gov": [
       "fema.gov"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
-      "starwars.com"
+      "starwars.com",
+      "go.com"
     ],
     "dianomi.com": [
       "businessinsider.com",
@@ -9809,7 +9156,10 @@
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk"
+      "express.co.uk",
+      "gizmodo.com",
+      "alternet.org",
+      "bostonherald.com"
     ],
     "disney.com": [
       "starwars.com"
@@ -9821,12 +9171,15 @@
       "rollingstone.com"
     ],
     "distiltag.com": [
-      "reuters.com"
+      "reuters.com",
+      "merriam-webster.com"
     ],
     "districtm.io": [
       "barnesandnoble.com",
       "urbandictionary.com",
-      "axs.com"
+      "axs.com",
+      "observer.com",
+      "infoplease.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
       "4shared.com"
@@ -9849,7 +9202,9 @@
     "dotomi.com": [
       "tinyurl.com",
       "samsung.com",
-      "webmd.com"
+      "webmd.com",
+      "forbes.com",
+      "jsonline.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -9857,7 +9212,10 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com"
+      "linkedin.com",
+      "sourceforge.net",
+      "macworld.com",
+      "focus.de"
     ],
     "doublemax.net": [
       "udn.com"
@@ -9872,7 +9230,9 @@
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com"
+      "techtarget.com",
+      "adweek.com",
+      "rd.com"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -9934,7 +9294,10 @@
     "eloqua.com": [
       "intel.com",
       "cisco.com",
-      "prnewswire.com"
+      "prnewswire.com",
+      "redhat.com",
+      "uq.edu.au",
+      "eset.com"
     ],
     "elsevier.com": [
       "sciencedirect.com",
@@ -9961,7 +9324,11 @@
     "epicurious.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
+    ],
+    "epital.gdn": [
+      "4shared.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -9992,7 +9359,9 @@
     "everesttech.net": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "dropbox.com",
+      "jsonline.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
@@ -10023,7 +9392,9 @@
     "exelator.com": [
       "soundcloud.com",
       "forbes.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "businessinsider.com",
+      "gizmodo.com"
     ],
     "exosrv.com": [
       "pornhub.com"
@@ -10034,7 +9405,9 @@
     "eyeota.net": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "dropbox.com",
+      "seagate.com"
     ],
     "eyereturn.com": [
       "thestar.com",
@@ -10050,7 +9423,10 @@
     "facebook.com": [
       "instagram.com",
       "wordpress.org",
-      "adobe.com"
+      "adobe.com",
+      "nytimes.com",
+      "leeds.ac.uk",
+      "designboom.com"
     ],
     "facetz.net": [
       "novostimira.com",
@@ -10115,12 +9491,18 @@
       "clinicaltrials.gov",
       "moonfruit.com",
       "webex.com",
-      "sitepoint.com"
+      "sitepoint.com",
+      "emarketer.com"
+    ],
+    "force.com": [
+      "salesforce.com"
     ],
     "foresee.com": [
       "epa.gov",
       "si.edu",
-      "theglobeandmail.com"
+      "theglobeandmail.com",
+      "sec.gov",
+      "kidshealth.org"
     ],
     "formstack.com": [
       "in.gov"
@@ -10167,7 +9549,8 @@
     "fwmrm.net": [
       "yahoo.com",
       "mlb.com",
-      "xfinity.com"
+      "xfinity.com",
+      "hgtv.com"
     ],
     "g2crowd.com": [
       "prezi.com",
@@ -10183,7 +9566,8 @@
     "gemius.pl": [
       "sapo.pt",
       "interia.pl",
-      "ria.ru"
+      "ria.ru",
+      "onet.pl"
     ],
     "gentags.net": [
       "sina.com.cn"
@@ -10210,7 +9594,10 @@
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au"
+      "abc.net.au",
+      "mirror.co.uk",
+      "francetvinfo.fr",
+      "hgtv.com"
     ],
     "giphy.com": [
       "urbandictionary.com",
@@ -10223,12 +9610,14 @@
     "glamour.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com"
+      "fortune.com",
+      "si.com"
     ],
     "gmossp-sp.jp": [
       "shinobi.jp",
@@ -10243,7 +9632,8 @@
     "golfdigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
@@ -10255,14 +9645,17 @@
       "youtube.com",
       "linkedin.com",
       "google.de",
-      "scmp.com",
+      "sourceforge.net",
+      "google.ca",
       "chromium.org",
-      "google.be"
+      "xrea.com",
+      "focus.de"
     ],
     "gq.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "gridsumdissector.com": [
       "qq.com",
@@ -10271,9 +9664,6 @@
     ],
     "groupondata.com": [
       "groupon.com"
-    ],
-    "grubstreet.com": [
-      "nymag.com"
     ],
     "gsimedia.net": [
       "acehardware.com"
@@ -10297,7 +9687,9 @@
     "gwallet.com": [
       "adobe.com",
       "ox.ac.uk",
-      "ihg.com"
+      "ihg.com",
+      "economist.com",
+      "business2community.com"
     ],
     "gwmtracking.com": [
       "proofpoint.com"
@@ -10363,7 +9755,8 @@
     "hubspot.com": [
       "wpengine.com",
       "shopify.com",
-      "technologyreview.com"
+      "technologyreview.com",
+      "scoop.it"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
@@ -10453,12 +9846,19 @@
     "impact-ad.jp": [
       "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com"
+      "bbc.com",
+      "wsj.com",
+      "libero.it",
+      "gizmodo.com"
+    ],
+    "ineity.pro": [
+      "4shared.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
@@ -10490,12 +9890,14 @@
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu"
+      "arizona.edu",
+      "guinnessworldrecords.com"
     ],
     "instinctiveads.com": [
       "variety.com",
       "dp.ua",
-      "blackberry.com"
+      "blackberry.com",
+      "bgr.com"
     ],
     "intentiq.com": [
       "sourceforge.net",
@@ -10509,7 +9911,9 @@
     "intercom.io": [
       "themeforest.net",
       "ft.com",
-      "elegantthemes.com"
+      "elegantthemes.com",
+      "visual.ly",
+      "iconfinder.com"
     ],
     "intergient.com": [
       "infoplease.com"
@@ -10530,7 +9934,8 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com"
+      "xing.com",
+      "focus.de"
     ],
     "iolam.it": [
       "virgilio.it"
@@ -10545,7 +9950,8 @@
     ],
     "ipredictive.com": [
       "myspace.com",
-      "dailymotion.com"
+      "dailymotion.com",
+      "theverge.com"
     ],
     "irs01.com": [
       "youku.com"
@@ -10565,7 +9971,7 @@
       "dyn.com",
       "fujitsu.com",
       "liveleak.com",
-      "lemonde.fr"
+      "hhs.gov"
     ],
     "jrs5.com": [
       "nike.com",
@@ -10602,20 +10008,30 @@
     "keywee.co": [
       "latimes.com",
       "nationalgeographic.com",
-      "chicagotribune.com"
+      "chicagotribune.com",
+      "nytimes.com",
+      "complex.com",
+      "apartmenttherapy.com"
     ],
     "kinja.com": [
       "gizmodo.com",
       "lifehacker.com",
-      "kotaku.com"
+      "kotaku.com",
+      "jalopnik.com"
     ],
     "kiwiirc.com": [
       "enlightenment.org"
     ],
+    "knet.cn": [
+      "dzwww.com"
+    ],
     "krxd.net": [
       "inhabitat.com",
       "bgr.com",
-      "jalopnik.com"
+      "jalopnik.com",
+      "cnn.com",
+      "fastcompany.com",
+      "gizmodo.com"
     ],
     "ladsp.com": [
       "exblog.jp",
@@ -10638,7 +10054,8 @@
     "liadm.com": [
       "webmd.com",
       "nj.com",
-      "patch.com"
+      "patch.com",
+      "cbssports.com"
     ],
     "libero.it": [
       "virgilio.it"
@@ -10652,17 +10069,22 @@
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "home.pl"
+      "home.pl",
+      "orange.fr"
     ],
     "lightboxcdn.com": [
       "zdnet.com",
       "fastcompany.com",
-      "adweek.com"
+      "adweek.com",
+      "jalopnik.com",
+      "gizmodo.com"
     ],
     "lijit.com": [
       "sourceforge.net",
       "bloomberg.com",
-      "deviantart.com"
+      "deviantart.com",
+      "slashdot.org",
+      "zimbio.com"
     ],
     "lincoln.com": [
       "ford.com"
@@ -10674,12 +10096,16 @@
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "dropbox.com",
+      "here.com",
+      "lexisnexis.com"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
       "pcworld.com",
-      "nike.com"
+      "nike.com",
+      "macworld.com"
     ],
     "list-manage.com": [
       "boingboing.net"
@@ -10691,8 +10117,9 @@
       "paypal.com",
       "skype.com",
       "msn.com",
-      "microsoft.com",
-      "office.com"
+      "bing.com",
+      "office.com",
+      "microsoft.com"
     ],
     "livechatinc.com": [
       "ning.com",
@@ -10709,7 +10136,9 @@
     "liveperson.net": [
       "apache.org",
       "prnewswire.com",
-      "ibm.com"
+      "ibm.com",
+      "virginmedia.com",
+      "lexisnexis.com"
     ],
     "lkqd.net": [
       "allafrica.com"
@@ -10755,7 +10184,8 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com"
+      "google.com",
+      "yandex.ru"
     ],
     "mailchimp.com": [
       "colorlib.com",
@@ -10768,7 +10198,8 @@
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "hootsuite.com"
+      "hootsuite.com",
+      "smugmug.com"
     ],
     "marketlinc.com": [
       "kaspersky.com",
@@ -10784,17 +10215,21 @@
     "matheranalytics.com": [
       "theglobeandmail.com",
       "thestar.com",
-      "seattletimes.com"
+      "seattletimes.com",
+      "kansascity.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "forbes.com",
+      "jsonline.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
-      "forbes.com"
+      "forbes.com",
+      "reuters.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
@@ -10842,7 +10277,11 @@
     ],
     "metadsp.co.uk": [
       "nypost.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "theverge.com"
+    ],
+    "mfadsrvr.com": [
+      "att.net"
     ],
     "mg2connext.com": [
       "mercurynews.com",
@@ -10860,7 +10299,8 @@
     "miaozhen.com": [
       "sina.com.cn",
       "163.com",
-      "dzwww.com"
+      "dzwww.com",
+      "autohome.com.cn"
     ],
     "microad.jp": [
       "rakuten.co.jp",
@@ -10887,12 +10327,18 @@
     "mktoresp.com": [
       "parallels.com",
       "prnewswire.com",
-      "zend.com"
+      "zend.com",
+      "nginx.com",
+      "here.com",
+      "pingdom.com"
     ],
     "ml314.com": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "wsj.com",
+      "seagate.com",
+      "zerohedge.com"
     ],
     "mlb.com": [
       "nhl.com"
@@ -10903,7 +10349,8 @@
     "mmstat.com": [
       "alibaba.com",
       "youku.com",
-      "taobao.com"
+      "taobao.com",
+      "aliexpress.com"
     ],
     "mmtro.com": [
       "upwork.com"
@@ -10922,7 +10369,8 @@
     "mookie1.com": [
       "t-online.de",
       "nbcnews.com",
-      "theglobeandmail.com"
+      "theglobeandmail.com",
+      "dropbox.com"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -10984,7 +10432,8 @@
     "myvisualiq.net": [
       "soundcloud.com",
       "surveymonkey.com",
-      "spotify.com"
+      "spotify.com",
+      "paypal.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
@@ -11012,7 +10461,8 @@
     ],
     "naver.com": [
       "unity3d.com",
-      "cafe24.com"
+      "cafe24.com",
+      "yonhapnews.co.kr"
     ],
     "naver.jp": [
       "line.me",
@@ -11025,7 +10475,8 @@
     "nbcuni.com": [
       "cnbc.com",
       "msnbc.com",
-      "nbc.com"
+      "nbc.com",
+      "nbcsports.com"
     ],
     "netdna-ssl.com": [
       "alternet.org"
@@ -11033,7 +10484,8 @@
     "netmng.com": [
       "lenovo.com",
       "theknot.com",
-      "shopko.com"
+      "shopko.com",
+      "jsonline.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -11058,7 +10510,8 @@
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
-      "thesun.co.uk"
+      "thesun.co.uk",
+      "wsj.com"
     ],
     "newsinc.com": [
       "latimes.com",
@@ -11079,7 +10532,8 @@
     "newyorker.com": [
       "wired.com",
       "vanityfair.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -11091,9 +10545,6 @@
       "medlineplus.gov",
       "clinicaltrials.gov"
     ],
-    "nj.com": [
-      "bleacherreport.com"
-    ],
     "nokia.com": [
       "bell-labs.com"
     ],
@@ -11103,7 +10554,10 @@
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com"
+      "oracle.com",
+      "huffingtonpost.com",
+      "codecanyon.net",
+      "helsinki.fi"
     ],
     "nsaudience.pl": [
       "interia.pl"
@@ -11174,12 +10628,16 @@
     "omnitagjs.com": [
       "springer.com",
       "standard.co.uk",
-      "home.pl"
+      "home.pl",
+      "knowyourmeme.com"
     ],
     "omtrdc.net": [
       "adobe.com",
       "amazon.com",
-      "telegraph.co.uk"
+      "telegraph.co.uk",
+      "marriott.com",
+      "kansascity.com",
+      "pingdom.com"
     ],
     "onclickmega.com": [
       "brothersoft.com"
@@ -11193,7 +10651,9 @@
     "onetrust.com": [
       "themeisle.com",
       "bitbucket.org",
-      "namecheap.com"
+      "namecheap.com",
+      "cnn.com",
+      "active.com"
     ],
     "onevision.com.tw": [
       "udn.com"
@@ -11207,7 +10667,9 @@
     "onthe.io": [
       "indiatimes.com",
       "wn.com",
-      "express.co.uk"
+      "express.co.uk",
+      "tass.ru",
+      "gulfnews.com"
     ],
     "ooyala.com": [
       "accuweather.com",
@@ -11224,7 +10686,10 @@
     "openx.net": [
       "yahoo.com",
       "amazon.com",
-      "nytimes.com"
+      "nytimes.com",
+      "dropbox.com",
+      "libero.it",
+      "active.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -11239,43 +10704,45 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
-      "nytimes.com",
-      "bbc.com",
-      "live.com",
       "ibm.com",
+      "microsoft.com",
       "hp.com",
+      "bbc.com",
+      "wiley.com",
       "npr.org",
       "springer.com",
+      "mashable.com",
       "cbsnews.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
       "evernote.com",
       "box.com",
-      "prezi.com",
       "prweb.com",
       "dictionary.com",
-      "bitbucket.org",
       "accorhotels.com",
       "uber.com",
       "xbox.com",
+      "history.com",
       "bestbuy.com",
       "jamanetwork.com",
       "imageshack.com",
       "atlassian.com",
+      "live.com",
       "dallasnews.com",
       "metmuseum.org",
-      "intuit.com",
       "blizzard.com",
-      "office.com",
-      "squareup.com",
+      "intuit.com",
+      "ama-assn.org",
       "starbucks.com",
+      "squareup.com",
       "ajc.com",
       "justgiving.com",
       "dreamhost.com",
       "edx.org",
+      "cbssports.com",
       "bartleby.com",
-      "malwarebytes.com",
+      "gotomeeting.com",
       "theknot.com",
       "zenfolio.com",
       "fourseasons.com",
@@ -11311,7 +10778,10 @@
     "outbrain.com": [
       "nature.com",
       "scribd.com",
-      "foxnews.com"
+      "foxnews.com",
+      "msn.com",
+      "si.com",
+      "focus.de"
     ],
     "ovh.com": [
       "ovh.co.uk"
@@ -11330,12 +10800,16 @@
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org"
+      "ap.org",
+      "guinnessworldrecords.com"
     ],
     "parsely.com": [
       "time.com",
       "wired.com",
-      "wikia.com"
+      "wikia.com",
+      "wsj.com",
+      "ocregister.com",
+      "dezeen.com"
     ],
     "paypal.com": [
       "paypal.me"
@@ -11364,10 +10838,14 @@
     "perimeterx.net": [
       "bloomberg.com",
       "pixnet.net",
-      "macrumors.com"
+      "macrumors.com",
+      "upwork.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
+    ],
+    "photobucket.com": [
+      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
@@ -11375,7 +10853,8 @@
     "pinterest.com": [
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "nytimes.com"
+      "nytimes.com",
+      "etsy.com"
     ],
     "pitchfork.com": [
       "wired.com",
@@ -11421,7 +10900,10 @@
     "postrelease.com": [
       "reuters.com",
       "independent.co.uk",
-      "chicagotribune.com"
+      "chicagotribune.com",
+      "wsj.com",
+      "macworld.com",
+      "bostonherald.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
@@ -11433,12 +10915,14 @@
     ],
     "prfct.co": [
       "smugmug.com",
-      "marthastewart.com"
+      "marthastewart.com",
+      "business2community.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
       "symantec.com",
-      "slashdot.org"
+      "slashdot.org",
+      "business2community.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
@@ -11472,7 +10956,10 @@
     "pubmatic.com": [
       "dropbox.com",
       "tinyurl.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "usatoday.com",
+      "jsonline.com",
+      "infoplease.com"
     ],
     "pubmine.com": [
       "foreignpolicy.com",
@@ -11505,7 +10992,8 @@
     "pymx5.com": [
       "seattletimes.com",
       "seattlepi.com",
-      "sfgate.com"
+      "sfgate.com",
+      "rd.com"
     ],
     "qnsr.com": [
       "serverwatch.com"
@@ -11513,7 +11001,8 @@
     "qq.com": [
       "sina.com.cn",
       "ctrip.com",
-      "weather.com.cn"
+      "weather.com.cn",
+      "tencent.com"
     ],
     "qsstats.com": [
       "serverwatch.com",
@@ -11526,12 +11015,17 @@
       "adidas.com",
       "cnet.com",
       "babycenter.com",
-      "mayoclinic.org"
+      "cbssports.com",
+      "mayoclinic.org",
+      "hgtv.com"
     ],
     "quantserve.com": [
       "wordpress.org",
       "vimeo.com",
-      "reddit.com"
+      "reddit.com",
+      "soundcloud.com",
+      "jsonline.com",
+      "gizmodo.com"
     ],
     "quantummetric.com": [
       "macys.com"
@@ -11545,7 +11039,10 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com"
+      "ning.com",
+      "webnode.com",
+      "upwork.com",
+      "eset.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -11573,9 +11070,15 @@
       "autohome.com.cn",
       "bshare.cn"
     ],
+    "readcube.com": [
+      "wiley.com"
+    ],
     "reddit.com": [
       "acm.org",
       "perl.com"
+    ],
+    "redditmedia.com": [
+      "reddit.com"
     ],
     "redlink.com": [
       "jamanetwork.com",
@@ -11616,7 +11119,8 @@
     "revjet.com": [
       "homedepot.com",
       "expedia.com",
-      "bankrate.com"
+      "bankrate.com",
+      "nordstrom.com"
     ],
     "rezync.com": [
       "economist.com"
@@ -11624,7 +11128,9 @@
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
-      "npr.org"
+      "npr.org",
+      "foursquare.com",
+      "yellowpages.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -11644,12 +11150,18 @@
     "rkdms.com": [
       "time.com",
       "wired.com",
-      "cbsnews.com"
+      "cbsnews.com",
+      "dropbox.com",
+      "cbssports.com",
+      "gizmodo.com"
     ],
     "rlcdn.com": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "reddit.com",
+      "jsonline.com",
+      "bostonherald.com"
     ],
     "rnengage.com": [
       "oracle.com",
@@ -11665,23 +11177,29 @@
     "roymorgan.com": [
       "smh.com.au"
     ],
+    "rqtrk.eu": [
+      "dropbox.com"
+    ],
     "rtb.com.ru": [
       "radikal.ru",
       "diary.ru"
     ],
     "rtk.io": [
       "post-gazette.com",
-      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "sony.com"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "libero.it",
+      "gizmodo.com"
     ],
     "rundsp.com": [
       "hpe.com",
@@ -11706,7 +11224,7 @@
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
-      "salesforce.com"
+      "eset.com"
     ],
     "salesloft.com": [
       "techtarget.com",
@@ -11719,7 +11237,8 @@
     "samba.tv": [
       "imdb.com",
       "gizmodo.com",
-      "lifehacker.com"
+      "lifehacker.com",
+      "jalopnik.com"
     ],
     "sbal4kp.com": [
       "dropbox.com"
@@ -11753,7 +11272,10 @@
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
-      "tumblr.com"
+      "tumblr.com",
+      "nytimes.com",
+      "macworld.com",
+      "gizmodo.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
@@ -11762,6 +11284,9 @@
     ],
     "sddan.com": [
       "upwork.com"
+    ],
+    "sdp-campaign.de": [
+      "t-online.de"
     ],
     "seadform.net": [
       "bloomberg.com"
@@ -11782,12 +11307,15 @@
     "selectablemedia.com": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com",
+      "si.com"
     ],
     "self.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "semasio.net": [
       "bloomberg.com"
@@ -11810,7 +11338,10 @@
     "serving-sys.com": [
       "dropbox.com",
       "t-online.de",
-      "nbcnews.com"
+      "nbcnews.com",
+      "businessinsider.com",
+      "att.net",
+      "hgtv.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -11823,12 +11354,14 @@
     "sharethis.com": [
       "www.uk.com",
       "whatsapp.com",
-      "lycos.com"
+      "lycos.com",
+      "us.org"
     ],
     "sharethrough.com": [
       "yahoo.com",
       "cnn.com",
-      "time.com"
+      "time.com",
+      "cnet.com"
     ],
     "sheego.de": [
       "t-online.de"
@@ -11848,7 +11381,8 @@
     "simpli.fi": [
       "symantec.com",
       "washingtontimes.com",
-      "thinkgeek.com"
+      "thinkgeek.com",
+      "tampabay.com"
     ],
     "sina.cn": [
       "sina.com.cn"
@@ -11868,7 +11402,10 @@
     "siteimprove.com": [
       "usda.gov",
       "verisign.com",
-      "udel.edu"
+      "udel.edu",
+      "berkeley.edu",
+      "jhu.edu",
+      "helsinki.fi"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
@@ -11884,12 +11421,17 @@
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "seattletimes.com"
+      "seattletimes.com",
+      "sciencedaily.com",
+      "cbssports.com",
+      "zerohedge.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com"
+      "gizmodo.com",
+      "arstechnica.com",
+      "zimbio.com"
     ],
     "sky.com": [
       "skygroup.sky",
@@ -11901,7 +11443,8 @@
     "smartadserver.com": [
       "springer.com",
       "skyrock.com",
-      "sapo.pt"
+      "sapo.pt",
+      "liberation.fr"
     ],
     "smartclip.net": [
       "infoplease.com"
@@ -11926,7 +11469,9 @@
     "snapchat.com": [
       "jimdo.com",
       "overstock.com",
-      "complex.com"
+      "complex.com",
+      "wsj.com",
+      "sbs.com.au"
     ],
     "snapwidget.com": [
       "udel.edu"
@@ -11977,7 +11522,10 @@
     "sonobi.com": [
       "photobucket.com",
       "deviantart.com",
-      "springer.com"
+      "springer.com",
+      "myspace.com",
+      "jsonline.com",
+      "couchsurfing.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -11986,7 +11534,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "irishtimes.com"
+      "mo.gov"
     ],
     "sourceforge.net": [
       "libpng.org"
@@ -12003,7 +11551,9 @@
     "spiceworks.com": [
       "cloudflare.com",
       "symantec.com",
-      "sophos.com"
+      "sophos.com",
+      "hp.com",
+      "seagate.com"
     ],
     "spineuniverse.com": [
       "psychcentral.com"
@@ -12027,7 +11577,10 @@
     "spotxchange.com": [
       "amazon.com",
       "dropbox.com",
-      "dailymotion.com"
+      "dailymotion.com",
+      "thenextweb.com",
+      "alternet.org",
+      "bostonherald.com"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -12066,7 +11619,10 @@
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org"
+      "man7.org",
+      "cbslocal.com",
+      "namebright.com",
+      "zerohedge.com"
     ],
     "staticimgfarm.com": [
       "excite.com"
@@ -12091,7 +11647,8 @@
     "stickyadstv.com": [
       "bloomberg.com",
       "dailymotion.com",
-      "feedburner.com"
+      "feedburner.com",
+      "liberation.fr"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
@@ -12118,7 +11675,8 @@
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com"
+      "studiopress.com",
+      "sitepoint.com"
     ],
     "sundaysky.com": [
       "overstock.com",
@@ -12134,7 +11692,8 @@
       "yesky.com"
     ],
     "supplyframe.com": [
-      "ti.com"
+      "ti.com",
+      "arduino.cc"
     ],
     "survata.com": [
       "tripadvisor.com"
@@ -12147,7 +11706,8 @@
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
-      "indianexpress.com"
+      "indianexpress.com",
+      "springer.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -12159,7 +11719,10 @@
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
-      "t-online.de"
+      "t-online.de",
+      "msn.com",
+      "att.net",
+      "edmunds.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -12186,12 +11749,15 @@
       "sina.com.cn",
       "1688.com",
       "tmall.com",
-      "alibaba.com"
+      "coremail.cn"
     ],
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
-      "soundcloud.com"
+      "soundcloud.com",
+      "dropbox.com",
+      "complex.com",
+      "bostonherald.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -12208,12 +11774,16 @@
     "tealiumiq.com": [
       "ibm.com",
       "cbsnews.com",
-      "evernote.com"
+      "evernote.com",
+      "cnet.com",
+      "cbssports.com",
+      "active.com"
     ],
     "technolutions.net": [
       "illinois.edu",
       "upenn.edu",
-      "uci.edu"
+      "uci.edu",
+      "udel.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -12221,7 +11791,8 @@
     "teenvogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "telegraph.co.uk": [
       "wordpress.com"
@@ -12235,7 +11806,9 @@
     "theadex.com": [
       "t-online.de",
       "gnu.org",
-      "spiegel.de"
+      "spiegel.de",
+      "liberation.fr",
+      "focus.de"
     ],
     "theatlas.com": [
       "qz.com"
@@ -12243,7 +11816,9 @@
     "thebrighttag.com": [
       "netflix.com",
       "wufoo.com",
-      "playstation.com"
+      "playstation.com",
+      "nordstrom.com",
+      "zappos.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -12268,7 +11843,9 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com",
+      "si.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -12276,14 +11853,19 @@
     "tinypass.com": [
       "businessinsider.com",
       "techcrunch.com",
-      "kickstarter.com"
+      "kickstarter.com",
+      "bloomberg.com",
+      "jalopnik.com",
+      "gizmodo.com"
     ],
     "tiqcdn.com": [
       "cisco.com",
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
-      "hpe.com"
+      "hpe.com",
+      "orange.fr",
+      "here.com"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -12298,7 +11880,10 @@
     "tns-counter.ru": [
       "livejournal.com",
       "vk.com",
-      "yandex.ru"
+      "yandex.ru",
+      "mail.ru",
+      "tass.ru",
+      "radikal.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
@@ -12354,7 +11939,9 @@
     "tribalfusion.com": [
       "dailymotion.com",
       "pastebin.com",
-      "liveleak.com"
+      "liveleak.com",
+      "marriott.com",
+      "jsonline.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -12387,19 +11974,24 @@
     "trustpilot.com": [
       "jalbum.net",
       "avira.com",
-      "moonfruit.com"
+      "moonfruit.com",
+      "ccleaner.com"
     ],
     "trvl-px.com": [
       "hotels.com",
       "expedia.com"
     ],
     "tumblr.com": [
-      "dailydot.com"
+      "dailydot.com",
+      "sony.com"
     ],
     "turn.com": [
       "bloomberg.com",
       "wired.com",
-      "webmd.com"
+      "webmd.com",
+      "tinyurl.com",
+      "libero.it",
+      "pitchfork.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
@@ -12407,7 +11999,8 @@
     "tvsquared.com": [
       "telegraph.co.uk",
       "jimdo.com",
-      "squarespace.com"
+      "squarespace.com",
+      "economist.com"
     ],
     "twimg.com": [
       "coe.int",
@@ -12418,8 +12011,14 @@
       "wordpress.org",
       "yahoo.com",
       "chicagotribune.com",
-      "cnn.com",
-      "cnet.com"
+      "nytimes.com",
+      "dropbox.com",
+      "cnet.com",
+      "macworld.com",
+      "seattlepi.com",
+      "lexisnexis.com",
+      "helsinki.fi",
+      "edmunds.com"
     ],
     "tynt.com": [
       "accuweather.com",
@@ -12476,7 +12075,8 @@
     "upsellit.com": [
       "samsung.com",
       "garmin.com",
-      "motorola.com"
+      "motorola.com",
+      "ccleaner.com"
     ],
     "uptolike.com": [
       "live4fun.ru"
@@ -12497,6 +12097,10 @@
     ],
     "userreport.com": [
       "scotsman.com"
+    ],
+    "uservoice.com": [
+      "scoop.it",
+      "theknot.com"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -12519,7 +12123,8 @@
     "vanityfair.com": [
       "wired.com",
       "newyorker.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "veinteractive.com": [
       "prweb.com",
@@ -12551,17 +12156,22 @@
       "hpe.com"
     ],
     "videohub.tv": [
-      "liveuamap.com"
+      "liveuamap.com",
+      "wsj.com",
+      "bloomberg.com"
     ],
     "vidible.tv": [
       "aol.com",
       "nydailynews.com",
-      "autoblog.com"
+      "autoblog.com",
+      "huffingtonpost.com"
     ],
     "viglink.com": [
       "zdnet.com",
       "softonic.com",
-      "techrepublic.com"
+      "techrepublic.com",
+      "cnet.com",
+      "sheknows.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
@@ -12574,12 +12184,17 @@
       "livestream.com",
       "wufoo.com",
       "heroku.com",
-      "designboom.com"
+      "emarketer.com",
+      "designboom.com",
+      "oclc.org"
     ],
     "vindicosuite.com": [
       "myspace.com",
       "fortune.com",
-      "people.com"
+      "people.com",
+      "time.com",
+      "si.com",
+      "zappos.com"
     ],
     "virgilio.it": [
       "libero.it"
@@ -12593,12 +12208,14 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru"
+      "ria.ru",
+      "yandex.ru"
     ],
     "vogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "volvelle.tech": [
       "prweb.com",
@@ -12614,13 +12231,11 @@
     "vtracy.de": [
       "bloomberg.com"
     ],
-    "vulture.com": [
-      "nymag.com"
-    ],
     "w55c.net": [
       "hpe.com",
       "ebay.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "forbes.com"
     ],
     "wallst.com": [
       "reuters.com"
@@ -12630,6 +12245,9 @@
     ],
     "warnerbros.com": [
       "tmz.com"
+    ],
+    "wayfair.com": [
+      "msn.com"
     ],
     "wbtrk.net": [
       "repubblica.it",
@@ -12675,6 +12293,9 @@
       "abc.net.au",
       "oup.com"
     ],
+    "webvisor.org": [
+      "kharkov.ua"
+    ],
     "weibo.com": [
       "sina.com.cn"
     ],
@@ -12697,7 +12318,8 @@
     "wired.com": [
       "newyorker.com",
       "vanityfair.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "wise.space": [
       "purevolume.com"
@@ -12707,6 +12329,8 @@
       "suntimes.com",
       "canada.com",
       "globalnews.ca",
+      "tampabay.com",
+      "bostonherald.com",
       "vancouversun.com"
     ],
     "wishpond.com": [
@@ -12718,7 +12342,8 @@
     "wistia.com": [
       "zendesk.com",
       "typeform.com",
-      "photoshelter.com"
+      "photoshelter.com",
+      "buffer.com"
     ],
     "wistia.net": [
       "nielsen.com"
@@ -12734,7 +12359,8 @@
     "wmagazine.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "wnyc.org": [
       "newyorker.com",
@@ -12755,11 +12381,11 @@
       "prnewswire.com",
       "cbslocal.com",
       "fortune.com",
-      "nypost.com",
       "akismet.com",
+      "nypost.com",
       "news.com.au",
-      "metro.co.uk",
-      "variety.com"
+      "variety.com",
+      "metro.co.uk"
     ],
     "wrating.com": [
       "163.com",
@@ -12802,17 +12428,21 @@
     "xiti.com": [
       "lemonde.fr",
       "unblog.fr",
-      "uefa.com"
+      "uefa.com",
+      "ovh.co.uk",
+      "rfi.fr"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
       "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "xplosion.de": [
       "t-online.de",
       "spiegel.de",
-      "faz.net"
+      "faz.net",
+      "focus.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
@@ -12823,17 +12453,25 @@
     "yadro.ru": [
       "vk.com",
       "novostimira.com",
-      "mail.ru"
+      "mail.ru",
+      "rt.com",
+      "qip.ru",
+      "radikal.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
-      "rakuten.co.jp"
+      "rakuten.co.jp",
+      "economist.com",
+      "ocn.ne.jp"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
-      "flickr.com"
+      "flickr.com",
+      "sourceforge.net",
+      "att.net",
+      "eset.com"
     ],
     "yahoosmallbusiness.com": [
       "yahoo.com"
@@ -12843,7 +12481,11 @@
       "opera.com",
       "stanford.edu",
       "ning.com",
-      "fourseasons.com"
+      "rt.com",
+      "qip.ru",
+      "fourseasons.com",
+      "radikal.ru",
+      "yandex.com"
     ],
     "yandex.ua": [
       "kharkov.ua",
@@ -12860,24 +12502,30 @@
     "yieldlab.net": [
       "spiegel.de",
       "heise.de",
-      "faz.net"
+      "faz.net",
+      "t-online.de",
+      "focus.de"
     ],
     "yieldoptimizer.com": [
       "ihg.com",
       "hyatt.com",
-      "philly.com"
+      "philly.com",
+      "fourseasons.com"
     ],
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
       "dropbox.com",
+      "qualtrics.com",
+      "att.net",
       "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
-      "newyorker.com"
+      "newyorker.com",
+      "macworld.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -12903,8 +12551,10 @@
       "nih.gov",
       "telegraph.co.uk",
       "caltech.edu",
-      "acm.org",
-      "honeywell.com"
+      "tmz.com",
+      "dailykos.com",
+      "honeywell.com",
+      "vancouversun.com"
     ],
     "youvisit.com": [
       "osu.edu",
@@ -12930,7 +12580,10 @@
     "zemanta.com": [
       "independent.co.uk",
       "thehill.com",
-      "farfetch.com"
+      "farfetch.com",
+      "paypal.com",
+      "orange.fr",
+      "infoplease.com"
     ],
     "zendesk.com": [
       "jugem.jp",
@@ -12941,7 +12594,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "wunderground.com"
+      "marketwatch.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -12973,5 +12626,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.23"
+  "version": "2018.8.24"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,7 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535788795191,
+      "nextUpdateTime": 1535574366154,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,31 +27,37 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535401551141,
+      "nextUpdateTime": 1535940577860,
+      "userAction": ""
+    },
+    "1dmp.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535675926040,
+      "nextUpdateTime": 1535651482302,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526413536,
+      "nextUpdateTime": 1535556135314,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535446296434,
+      "nextUpdateTime": 1535695702688,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535464900319,
+      "nextUpdateTime": 1535927532754,
       "userAction": ""
     },
     "2o7.net": {
@@ -69,163 +75,157 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535761492828,
+      "nextUpdateTime": 1535895120778,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535388823758,
+      "nextUpdateTime": 1535610484977,
       "userAction": ""
     },
     "4303900.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535478816612,
+      "nextUpdateTime": 1535857837364,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535759188077,
+      "nextUpdateTime": 1535596840473,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535688182526,
+      "nextUpdateTime": 1535803262487,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535386344298,
+      "nextUpdateTime": 1535560640124,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535654852731,
+      "nextUpdateTime": 1535564507606,
       "userAction": ""
     },
     "516-dgm-318.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535777195298,
+      "nextUpdateTime": 1535612912168,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469873107,
+      "nextUpdateTime": 1535672353106,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535673581756,
+      "nextUpdateTime": 1535922487903,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389517664,
+      "nextUpdateTime": 1535748710087,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535862929541,
+      "nextUpdateTime": 1535720157703,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535450680018,
+      "nextUpdateTime": 1535922263721,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535699002706,
+      "nextUpdateTime": 1535558701365,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535735755008,
+      "nextUpdateTime": 1535705793636,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535856801759,
+      "nextUpdateTime": 1535729644705,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535737606634,
+      "nextUpdateTime": 1535817179790,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694525374,
+      "nextUpdateTime": 1535695345166,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535541776370,
+      "nextUpdateTime": 1535690460813,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535586462406,
+      "nextUpdateTime": 1535515726416,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535692286771,
+      "nextUpdateTime": 1535681555823,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535584735036,
-      "userAction": ""
-    },
-    "a6264210458.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535775205652,
+      "nextUpdateTime": 1535644294827,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535709114205,
+      "nextUpdateTime": 1535738145329,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535877883165,
+      "nextUpdateTime": 1535467395021,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535710239051,
+      "nextUpdateTime": 1535598814522,
       "userAction": ""
     },
     "aax.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526366481,
+      "nextUpdateTime": 1535901789257,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -237,13 +237,13 @@
     "accounts.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535397748018,
+      "nextUpdateTime": 1535736262835,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535499002047,
+      "nextUpdateTime": 1535895412521,
       "userAction": ""
     },
     "acpm.fr": {
@@ -255,37 +255,43 @@
     "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535492709945,
+      "nextUpdateTime": 1535510347212,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535703175969,
+      "nextUpdateTime": 1535451360532,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535624113348,
+      "nextUpdateTime": 1535546516924,
+      "userAction": ""
+    },
+    "ad-score.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535795181462,
+      "nextUpdateTime": 1535755342766,
       "userAction": ""
     },
-    "ad.turn.com": {
+    "ad.mail.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535645779490,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535793253863,
       "userAction": ""
     },
     "ad.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535465359379,
+      "nextUpdateTime": 1535951806065,
       "userAction": ""
     },
     "addthis.com": {
@@ -300,10 +306,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adlmerge.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535497530432,
       "userAction": ""
     },
     "adm.fwmrm.net": {
@@ -321,7 +339,7 @@
     "ado.pro-market.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535496181306,
+      "nextUpdateTime": 1535748637442,
       "userAction": ""
     },
     "adroll.com": {
@@ -330,57 +348,57 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.creative-serving.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535547437788,
-      "userAction": ""
-    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535622785616,
+      "nextUpdateTime": 1535458586592,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535644312504,
+      "nextUpdateTime": 1535871108745,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535374198969,
+      "nextUpdateTime": 1535471847357,
       "userAction": ""
     },
     "ads.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535698534424,
+      "nextUpdateTime": 1535837937648,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535762468415,
+      "nextUpdateTime": 1535522038868,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535801173589,
+      "nextUpdateTime": 1535535646707,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535805192169,
+      "nextUpdateTime": 1535549205489,
       "userAction": ""
     },
     "adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -396,10 +414,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adtags.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx.com.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535858535725,
       "userAction": ""
     },
     "agkn.com": {
@@ -408,10 +438,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aimfar.solution.weborama.fr": {
+    "aidata.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535411075710,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aimfar.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535679293961,
       "userAction": ""
     },
     "allure.com": {
@@ -435,31 +471,31 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535875271545,
+      "nextUpdateTime": 1535852651670,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535627226385,
+      "nextUpdateTime": 1535756031250,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535453996514,
+      "nextUpdateTime": 1535739670165,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535666267445,
+      "nextUpdateTime": 1535489431737,
       "userAction": ""
     },
     "analytics.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535406703135,
+      "nextUpdateTime": 1535497570934,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -471,61 +507,61 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535677918307,
+      "nextUpdateTime": 1535545407977,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535404214200,
+      "nextUpdateTime": 1535734725089,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535728889831,
+      "nextUpdateTime": 1535646885704,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535824772269,
+      "nextUpdateTime": 1535496392864,
       "userAction": ""
     },
     "api.adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535869432705,
+      "nextUpdateTime": 1535610556073,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535382298584,
+      "nextUpdateTime": 1535667795032,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535785037169,
+      "nextUpdateTime": 1535799853232,
       "userAction": ""
     },
     "api.nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535718185775,
+      "nextUpdateTime": 1535573272097,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535527024950,
+      "nextUpdateTime": 1535526188562,
       "userAction": ""
     },
     "api.viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535637161762,
+      "nextUpdateTime": 1535837253495,
       "userAction": ""
     },
     "apis.google.com": {
@@ -537,7 +573,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535495358983,
+      "nextUpdateTime": 1535705741301,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -549,7 +585,7 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535541366255,
+      "nextUpdateTime": 1535778737155,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -561,49 +597,49 @@
     "au.audience.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535814559640,
+      "nextUpdateTime": 1535493275684,
       "userAction": ""
     },
     "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535677376528,
+      "nextUpdateTime": 1535533997563,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535872214563,
+      "nextUpdateTime": 1535486459205,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535424935792,
+      "nextUpdateTime": 1535826163427,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535376045654,
+      "nextUpdateTime": 1535850919219,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517044616,
+      "nextUpdateTime": 1535503086090,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535856575288,
+      "nextUpdateTime": 1535857829768,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535852563130,
+      "nextUpdateTime": 1535588620683,
       "userAction": ""
     },
     "bfmio.com": {
@@ -615,19 +651,19 @@
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535415374852,
+      "nextUpdateTime": 1535918584905,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535474628495,
+      "nextUpdateTime": 1535462855319,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535431025536,
+      "nextUpdateTime": 1535847717423,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -675,7 +711,7 @@
     "boxinc.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535712697947,
+      "nextUpdateTime": 1535788486927,
       "userAction": ""
     },
     "brides.com": {
@@ -687,61 +723,73 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535842806454,
+      "nextUpdateTime": 1535882683488,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399016694,
+      "nextUpdateTime": 1535742566208,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535736023435,
+      "nextUpdateTime": 1535714537026,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535782500293,
+      "nextUpdateTime": 1535499348118,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535392363633,
+      "nextUpdateTime": 1535593788843,
+      "userAction": ""
+    },
+    "c.datpix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535929878835,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535786966647,
+      "nextUpdateTime": 1535843909307,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535852907247,
+      "nextUpdateTime": 1535745741276,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535445294990,
+      "nextUpdateTime": 1535633412069,
+      "userAction": ""
+    },
+    "c1.adform.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535883830729,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535750341028,
+      "nextUpdateTime": 1535694406005,
       "userAction": ""
     },
     "cache.vindicosuite.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535798036507,
+      "nextUpdateTime": 1535646678212,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -750,16 +798,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "caltat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535524141208,
+      "nextUpdateTime": 1535936828607,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434052072,
+      "nextUpdateTime": 1535585773243,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -771,31 +825,37 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535430074265,
+      "nextUpdateTime": 1535478492051,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535636853472,
+      "nextUpdateTime": 1535678194329,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535554773399,
+      "nextUpdateTime": 1535878784206,
+      "userAction": ""
+    },
+    "cdn.inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535620914588,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535689602008,
+      "nextUpdateTime": 1535489425202,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535464365388,
+      "nextUpdateTime": 1535640903944,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -807,31 +867,31 @@
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535592534219,
+      "nextUpdateTime": 1535916357377,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535840819214,
+      "nextUpdateTime": 1535647079432,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535447686266,
+      "nextUpdateTime": 1535754928056,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535589550351,
+      "nextUpdateTime": 1535598133851,
       "userAction": ""
     },
     "cdns.gigya.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535647245640,
+      "nextUpdateTime": 1535604636517,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -843,7 +903,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535574432947,
+      "nextUpdateTime": 1535912957647,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -861,13 +921,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535663337899,
+      "nextUpdateTime": 1535545995328,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535553091314,
+      "nextUpdateTime": 1535500216943,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -879,7 +939,7 @@
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535827604724,
+      "nextUpdateTime": 1535914813920,
       "userAction": ""
     },
     "company-target.com": {
@@ -891,7 +951,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535374260391,
+      "nextUpdateTime": 1535961983554,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -903,7 +963,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535847059054,
+      "nextUpdateTime": 1535610657582,
       "userAction": ""
     },
     "consensu.org": {
@@ -921,13 +981,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535761812068,
+      "nextUpdateTime": 1535644691945,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535878685866,
+      "nextUpdateTime": 1535769653005,
       "userAction": ""
     },
     "contextweb.com": {
@@ -939,18 +999,12 @@
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535679702748,
+      "nextUpdateTime": 1535484862572,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creative-serving.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -966,16 +1020,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "csm2waycm-atl.netmng.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535410980550,
-      "userAction": ""
-    },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535439755325,
+      "nextUpdateTime": 1535817088302,
       "userAction": ""
     },
     "cxense.com": {
@@ -987,67 +1035,91 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535430010745,
+      "nextUpdateTime": 1535892452597,
       "userAction": ""
     },
     "d.agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535878099411,
+      "nextUpdateTime": 1535636389666,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535631040531,
+      "nextUpdateTime": 1535557003597,
       "userAction": ""
     },
     "d.df-srv.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535827462928,
+      "nextUpdateTime": 1535942927369,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535848586849,
+      "nextUpdateTime": 1535683801735,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535668347467,
+      "nextUpdateTime": 1535759989893,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535504240917,
+      "nextUpdateTime": 1535711046845,
+      "userAction": ""
+    },
+    "data.ad-score.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535770730900,
+      "userAction": ""
+    },
+    "data.dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535762735169,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535749458146,
+      "nextUpdateTime": 1535857345882,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535454047672,
+      "nextUpdateTime": 1535789663952,
+      "userAction": ""
+    },
+    "datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "datpix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535863673793,
+      "nextUpdateTime": 1535873979413,
       "userAction": ""
     },
     "de.ioam.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535379626780,
+      "nextUpdateTime": 1535466422250,
       "userAction": ""
     },
     "deepintent.com": {
@@ -1080,6 +1152,24 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaladsystems.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaltarget.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1089,19 +1179,13 @@
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535628369138,
+      "nextUpdateTime": 1535670042661,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535449581444,
-      "userAction": ""
-    },
-    "districtm-match.dotomi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535854298539,
+      "nextUpdateTime": 1535720094693,
       "userAction": ""
     },
     "districtm.io": {
@@ -1110,10 +1194,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dm-us.hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535589581939,
+      "userAction": ""
+    },
+    "dm.hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535689555708,
+      "userAction": ""
+    },
+    "dmg.digitaltarget.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535852281239,
+      "userAction": ""
+    },
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535378721840,
+      "nextUpdateTime": 1535595988233,
       "userAction": ""
     },
     "docs.google.com": {
@@ -1137,7 +1239,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535831172248,
+      "nextUpdateTime": 1535607931755,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1149,13 +1251,7 @@
     "dsum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535678767436,
-      "userAction": ""
-    },
-    "dsum.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535609816884,
+      "nextUpdateTime": 1535938750810,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1167,7 +1263,7 @@
     "eb2.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535722569370,
+      "nextUpdateTime": 1535826511101,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1179,7 +1275,7 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535753398903,
+      "nextUpdateTime": 1535881020504,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1203,19 +1299,25 @@
     "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535856865212,
+      "nextUpdateTime": 1535674741536,
+      "userAction": ""
+    },
+    "eu.track.digitaladsystems.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535871670836,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535641546461,
+      "nextUpdateTime": 1535957567699,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535653806247,
+      "nextUpdateTime": 1535542299351,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1227,7 +1329,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535738201505,
+      "nextUpdateTime": 1535624124109,
       "userAction": ""
     },
     "exelator.com": {
@@ -1239,7 +1341,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535558917724,
+      "nextUpdateTime": 1535598114496,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1260,16 +1362,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "faggrim.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535612994323,
+      "userAction": ""
+    },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510602994,
+      "nextUpdateTime": 1535463240415,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535503704591,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535905176352,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1293,13 +1401,13 @@
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535786137485,
+      "nextUpdateTime": 1535788047904,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535672050463,
+      "nextUpdateTime": 1535744855557,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1317,55 +1425,61 @@
     "g.cn.miaozhen.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535453186928,
+      "nextUpdateTime": 1535694446011,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535882689211,
+      "nextUpdateTime": 1535682782409,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535656273590,
+      "nextUpdateTime": 1535628645321,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535727758035,
+      "nextUpdateTime": 1535579017912,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535797268646,
+      "nextUpdateTime": 1535532577705,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535705787427,
+      "nextUpdateTime": 1535738506516,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535540739730,
+      "nextUpdateTime": 1535558203644,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535730629382,
+      "nextUpdateTime": 1535485170416,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535626747902,
+      "nextUpdateTime": 1535563893270,
+      "userAction": ""
+    },
+    "geosync.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535926178244,
       "userAction": ""
     },
     "gigya.com": {
@@ -1401,7 +1515,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535826656370,
+      "nextUpdateTime": 1535598569331,
       "userAction": ""
     },
     "gq.com": {
@@ -1413,7 +1527,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535759414387,
+      "nextUpdateTime": 1535711236388,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1425,19 +1539,19 @@
     "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535507099814,
+      "nextUpdateTime": 1535770595777,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535649797924,
+      "nextUpdateTime": 1535871768873,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535648232623,
+      "nextUpdateTime": 1535579223748,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1455,49 +1569,73 @@
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535553980236,
+      "nextUpdateTime": 1535585198153,
+      "userAction": ""
+    },
+    "hgbn.rocks": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535863358694,
+      "userAction": ""
+    },
+    "hgbnr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535728786580,
       "userAction": ""
     },
     "hpr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535743743028,
+      "nextUpdateTime": 1535497040220,
+      "userAction": ""
+    },
+    "hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535512774273,
+      "nextUpdateTime": 1535739388610,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584943973,
+      "nextUpdateTime": 1535735230278,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535787032117,
+      "nextUpdateTime": 1535579900537,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535513900580,
+      "nextUpdateTime": 1535879292043,
       "userAction": ""
     },
     "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535842083486,
+      "nextUpdateTime": 1535551583447,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535758065418,
+      "nextUpdateTime": 1535730891780,
+      "userAction": ""
+    },
+    "images.taboola.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535479823214,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1509,13 +1647,19 @@
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535808038725,
+      "nextUpdateTime": 1535542941029,
+      "userAction": ""
+    },
+    "inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535671726914,
+      "nextUpdateTime": 1535576906508,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -1527,7 +1671,7 @@
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535612904028,
+      "nextUpdateTime": 1535916640573,
       "userAction": ""
     },
     "intercom.io": {
@@ -1539,13 +1683,7 @@
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535735061426,
-      "userAction": ""
-    },
-    "io.narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535606837889,
+      "nextUpdateTime": 1535958592894,
       "userAction": ""
     },
     "ioam.de": {
@@ -1563,13 +1701,19 @@
     "ips-invite.iperceptions.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535375027028,
+      "nextUpdateTime": 1535746109483,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535770127897,
+      "nextUpdateTime": 1535501210103,
+      "userAction": ""
+    },
+    "js.adsrvr.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535523156086,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1683,49 +1827,55 @@
     "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535428983326,
+      "nextUpdateTime": 1535541362768,
       "userAction": ""
     },
     "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535568292353,
+      "nextUpdateTime": 1535938747750,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535748410763,
+      "nextUpdateTime": 1535583123603,
       "userAction": ""
     },
     "log.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370949838,
+      "nextUpdateTime": 1535577619677,
       "userAction": ""
     },
     "login-ds.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535825469673,
+      "nextUpdateTime": 1535487720538,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535874272649,
+      "nextUpdateTime": 1535602940193,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535689077144,
+      "nextUpdateTime": 1535800795531,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535461732087,
+      "nextUpdateTime": 1535797170899,
+      "userAction": ""
+    },
+    "mail.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1749,19 +1899,25 @@
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535538905152,
+      "nextUpdateTime": 1535858739536,
       "userAction": ""
     },
     "match.deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535666184280,
+      "nextUpdateTime": 1535770736865,
       "userAction": ""
     },
     "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535472065106,
+      "nextUpdateTime": 1535669407198,
+      "userAction": ""
+    },
+    "matching.adtags.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535931796491,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1773,13 +1929,13 @@
     "mc.webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535487104791,
+      "nextUpdateTime": 1535584418815,
       "userAction": ""
     },
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535384523811,
+      "nextUpdateTime": 1535737532185,
       "userAction": ""
     },
     "media.net": {
@@ -1797,12 +1953,18 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535521562609,
+      "nextUpdateTime": 1535842898170,
       "userAction": ""
     },
     "mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mfadsrvr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1815,7 +1977,7 @@
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535678969255,
+      "nextUpdateTime": 1535865290211,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1827,7 +1989,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535583104262,
+      "nextUpdateTime": 1535541848986,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1878,22 +2040,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370153417,
-      "userAction": ""
-    },
-    "netmng.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535560186363,
       "userAction": ""
     },
     "newscgp.com": {
@@ -1905,7 +2055,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535570964190,
+      "nextUpdateTime": 1535858989061,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1917,13 +2067,13 @@
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535589900794,
+      "nextUpdateTime": 1535683012789,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535639927435,
+      "nextUpdateTime": 1535610146889,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1935,7 +2085,7 @@
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535764787069,
+      "nextUpdateTime": 1535501585551,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -1965,7 +2115,7 @@
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535776170008,
+      "nextUpdateTime": 1535895613989,
       "userAction": ""
     },
     "optimizely.com": {
@@ -1989,43 +2139,43 @@
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535464989725,
+      "nextUpdateTime": 1535495458906,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535587202023,
+      "nextUpdateTime": 1535875406126,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535753838397,
+      "nextUpdateTime": 1535716223948,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535599122136,
+      "nextUpdateTime": 1535555301108,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535416241814,
+      "nextUpdateTime": 1535760257854,
       "userAction": ""
     },
     "p.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535444945040,
+      "nextUpdateTime": 1535783323409,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535521835134,
+      "nextUpdateTime": 1535815373509,
       "userAction": ""
     },
     "pardot.com": {
@@ -2043,19 +2193,19 @@
     "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535764673436,
+      "nextUpdateTime": 1535792440906,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470402299,
+      "nextUpdateTime": 1535797919846,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535690679472,
+      "nextUpdateTime": 1535582597532,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -2073,73 +2223,73 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535419137841,
+      "nextUpdateTime": 1535876656131,
       "userAction": ""
     },
     "pixel-geo.prfct.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535473701074,
+      "nextUpdateTime": 1535836609372,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535791753209,
+      "nextUpdateTime": 1535531983715,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535454724028,
+      "nextUpdateTime": 1535859784800,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584375101,
+      "nextUpdateTime": 1535459106331,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535431775060,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535748451871,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470366014,
+      "nextUpdateTime": 1535639969032,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535494298982,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535645678163,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535827732761,
+      "nextUpdateTime": 1535635208019,
       "userAction": ""
     },
     "pixel.tapad.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535550390073,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535610784392,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535443656582,
+      "nextUpdateTime": 1535897272070,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535862853985,
+      "nextUpdateTime": 1535554574334,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2157,13 +2307,13 @@
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535634741658,
+      "nextUpdateTime": 1535916234173,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535602138418,
+      "nextUpdateTime": 1535930452354,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2175,13 +2325,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535694456088,
+      "nextUpdateTime": 1535756748496,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535608927078,
+      "nextUpdateTime": 1535710477120,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2193,7 +2343,7 @@
     "pr-bh.ybp.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535721998785,
+      "nextUpdateTime": 1535914334685,
       "userAction": ""
     },
     "prfct.co": {
@@ -2208,28 +2358,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "profile.justuno.com": {
+    "profile.ssp.rambler.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535868066793,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535789715456,
       "userAction": ""
     },
     "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535775857188,
+      "nextUpdateTime": 1535737146713,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535440273805,
+      "nextUpdateTime": 1535788753573,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535537986452,
+      "nextUpdateTime": 1535909696148,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2241,55 +2391,55 @@
     "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535447877021,
+      "nextUpdateTime": 1535842539658,
       "userAction": ""
     },
-    "purch-sync.go.sonobi.com": {
+    "px.adhigh.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535442782846,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535700996611,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535475285092,
+      "nextUpdateTime": 1535686118831,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535501609306,
+      "nextUpdateTime": 1535707783947,
       "userAction": ""
     },
     "px.owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535800014348,
+      "nextUpdateTime": 1535951971781,
       "userAction": ""
     },
     "px.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535366852912,
+      "nextUpdateTime": 1535887595495,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535668867614,
+      "nextUpdateTime": 1535801751541,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535644633942,
+      "nextUpdateTime": 1535857711077,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535552433183,
+      "nextUpdateTime": 1535884922283,
       "userAction": ""
     },
     "quantserve.com": {
@@ -2307,7 +2457,7 @@
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535814046934,
+      "nextUpdateTime": 1535790117318,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2319,31 +2469,43 @@
     "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535373600303,
+      "nextUpdateTime": 1535724135338,
       "userAction": ""
     },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535496894433,
+      "nextUpdateTime": 1535943279957,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535666183003,
+      "nextUpdateTime": 1535922335285,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535584949059,
+      "nextUpdateTime": 1535959894691,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711947766,
+      "nextUpdateTime": 1535760317951,
+      "userAction": ""
+    },
+    "relap.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535610652702,
+      "userAction": ""
+    },
+    "republer-sync.rutarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535696676261,
       "userAction": ""
     },
     "rfihub.com": {
@@ -2366,25 +2528,37 @@
     },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535845692253,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535789708558,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535583943990,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535574550900,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535699311885,
+      "nextUpdateTime": 1535878658398,
+      "userAction": ""
+    },
+    "rtb.mfadsrvr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535602308341,
       "userAction": ""
     },
     "rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rutarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2397,73 +2571,79 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535807522405,
+      "nextUpdateTime": 1535635426495,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535399131116,
+      "nextUpdateTime": 1535692857867,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535856992384,
+      "nextUpdateTime": 1535952869756,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535407116454,
+      "nextUpdateTime": 1535783451713,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517735871,
+      "nextUpdateTime": 1535498662982,
       "userAction": ""
     },
     "s.po.st": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535601704447,
+      "nextUpdateTime": 1535560094637,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470740234,
+      "nextUpdateTime": 1535860326137,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535548076811,
+      "nextUpdateTime": 1535818293290,
+      "userAction": ""
+    },
+    "s.yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535622978260,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535650294754,
+      "nextUpdateTime": 1535617312775,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535442162234,
+      "nextUpdateTime": 1535723340329,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535683133775,
+      "nextUpdateTime": 1535575485409,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436416136,
+      "nextUpdateTime": 1535580484432,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2472,28 +2652,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sape.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535554044154,
+      "nextUpdateTime": 1535700559367,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535640650960,
+      "nextUpdateTime": 1535725608507,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535622073754,
+      "nextUpdateTime": 1535951923078,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535641445518,
+      "nextUpdateTime": 1535728176589,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2505,7 +2691,7 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535699162400,
+      "nextUpdateTime": 1535742086735,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -2517,7 +2703,7 @@
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535406047367,
+      "nextUpdateTime": 1535520532074,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2529,85 +2715,85 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535475183501,
+      "nextUpdateTime": 1535677815299,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535590066515,
+      "nextUpdateTime": 1535800058823,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535681640966,
+      "nextUpdateTime": 1535465743467,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535516546452,
+      "nextUpdateTime": 1535785998221,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535508368840,
+      "nextUpdateTime": 1535914435468,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535791057311,
+      "nextUpdateTime": 1535948798377,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711269325,
+      "nextUpdateTime": 1535877945891,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535537879488,
+      "nextUpdateTime": 1535597555162,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535460219033,
+      "nextUpdateTime": 1535791667902,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535643556045,
+      "nextUpdateTime": 1535639340469,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535879474697,
+      "nextUpdateTime": 1535564812848,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535619679394,
+      "nextUpdateTime": 1535650108629,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535654613358,
+      "nextUpdateTime": 1535464387320,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535573504719,
+      "nextUpdateTime": 1535734903711,
       "userAction": ""
     },
     "self.com": {
@@ -2643,7 +2829,7 @@
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535633318133,
+      "nextUpdateTime": 1535730445037,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -2673,7 +2859,7 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535372330669,
+      "nextUpdateTime": 1535498866607,
       "userAction": ""
     },
     "snapchat.com": {
@@ -2697,7 +2883,7 @@
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535631243909,
+      "nextUpdateTime": 1535555922438,
       "userAction": ""
     },
     "spotxchange.com": {
@@ -2712,52 +2898,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-26-09.config.parsely.com": {
+    "srv-2018-08-27-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535415293805,
+      "nextUpdateTime": 1535606591829,
       "userAction": ""
     },
-    "srv-2018-08-26-09.pixel.parsely.com": {
+    "srv-2018-08-27-09.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535541971804,
+      "nextUpdateTime": 1535775011168,
       "userAction": ""
     },
-    "srv-2018-08-26-10.config.parsely.com": {
+    "srv-2018-08-27-10.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535427058911,
+      "nextUpdateTime": 1535756373485,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535673135301,
+      "nextUpdateTime": 1535710872574,
       "userAction": ""
     },
     "ssl.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535545018325,
+      "nextUpdateTime": 1535689859677,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535743749252,
+      "nextUpdateTime": 1535454314181,
+      "userAction": ""
+    },
+    "sso.caltat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535761951625,
+      "userAction": ""
+    },
+    "ssp-rtb.sape.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535766755060,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535749834287,
+      "nextUpdateTime": 1535761311673,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535393160160,
+      "nextUpdateTime": 1535924056645,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2772,22 +2970,28 @@
       "nextUpdateTime": 1529315030088,
       "userAction": ""
     },
+    "static.datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535845316114,
+      "userAction": ""
+    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535471382942,
+      "nextUpdateTime": 1535639204569,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535539060159,
+      "nextUpdateTime": 1535592093085,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535587267608,
+      "nextUpdateTime": 1535861273600,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2799,13 +3003,13 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535416632424,
+      "nextUpdateTime": 1535757740002,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535669657331,
+      "nextUpdateTime": 1535490242831,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -2823,7 +3027,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535410096945,
+      "nextUpdateTime": 1535936086555,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2835,61 +3039,91 @@
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535775576457,
+      "nextUpdateTime": 1535543303368,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535509470133,
+      "nextUpdateTime": 1535878443632,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535599232106,
+      "nextUpdateTime": 1535753717531,
+      "userAction": ""
+    },
+    "sync.1dmp.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535866711433,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535727505148,
+      "nextUpdateTime": 1535474216425,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535386374072,
+      "nextUpdateTime": 1535616105586,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535823492565,
+      "nextUpdateTime": 1535792114790,
+      "userAction": ""
+    },
+    "sync.datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535757781917,
+      "userAction": ""
+    },
+    "sync.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535699991298,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535499554312,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535939733228,
       "userAction": ""
     },
     "sync.multiview.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535446837680,
+      "nextUpdateTime": 1535809892152,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535533239526,
+      "nextUpdateTime": 1535465474316,
       "userAction": ""
     },
     "sync.teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535693045071,
+      "nextUpdateTime": 1535793050783,
+      "userAction": ""
+    },
+    "sync.upravel.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535705180457,
+      "userAction": ""
+    },
+    "sync3.adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535672244398,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2907,7 +3141,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695664896,
+      "nextUpdateTime": 1535701257955,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -2919,19 +3153,13 @@
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535750776402,
+      "nextUpdateTime": 1535764731289,
       "userAction": ""
     },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tapestry.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535791510610,
       "userAction": ""
     },
     "teads.tv": {
@@ -2967,13 +3195,13 @@
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535800953607,
+      "nextUpdateTime": 1535484616929,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535498571655,
+      "nextUpdateTime": 1535590619071,
       "userAction": ""
     },
     "tinypass.com": {
@@ -2985,7 +3213,7 @@
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535433221586,
+      "nextUpdateTime": 1535694887621,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -2997,25 +3225,25 @@
     "top100.rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535878948535,
+      "nextUpdateTime": 1535891887087,
       "userAction": ""
     },
     "tr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535529445629,
+      "nextUpdateTime": 1535664544534,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535691727010,
+      "nextUpdateTime": 1535741046224,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535502278546,
+      "nextUpdateTime": 1535674993267,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3027,7 +3255,7 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535381700109,
+      "nextUpdateTime": 1535758029438,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -3045,7 +3273,7 @@
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535459821318,
+      "nextUpdateTime": 1535677023679,
       "userAction": ""
     },
     "turn.com": {
@@ -3069,37 +3297,43 @@
     "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535420971761,
+      "nextUpdateTime": 1535606318085,
+      "userAction": ""
+    },
+    "upravel.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ups.xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483153937,
+      "nextUpdateTime": 1535897007154,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535571457788,
+      "nextUpdateTime": 1535697248099,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535862306211,
+      "nextUpdateTime": 1535464144110,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535560041560,
+      "nextUpdateTime": 1535699974981,
       "userAction": ""
     },
     "va.v.liveperson.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535510754633,
+      "nextUpdateTime": 1535466934945,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -3135,7 +3369,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535374260274,
+      "nextUpdateTime": 1535733808496,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -3147,7 +3381,7 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535879370927,
+      "nextUpdateTime": 1535601239497,
       "userAction": ""
     },
     "vogue.com": {
@@ -3159,7 +3393,7 @@
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535532865527,
+      "nextUpdateTime": 1535498479361,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3171,19 +3405,25 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535786495983,
+      "nextUpdateTime": 1535636170372,
+      "userAction": ""
+    },
+    "wam-yahoo.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535796722948,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535427771016,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535855791363,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535518923351,
+      "nextUpdateTime": 1535923593881,
       "userAction": ""
     },
     "weborama.fr": {
@@ -3207,7 +3447,7 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535766647842,
+      "nextUpdateTime": 1535670143608,
       "userAction": ""
     },
     "wired.com": {
@@ -3231,25 +3471,25 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445893357,
+      "nextUpdateTime": 1535840821698,
       "userAction": ""
     },
     "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535369602618,
+      "nextUpdateTime": 1535813179789,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535680288285,
+      "nextUpdateTime": 1535765401859,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535572118422,
+      "nextUpdateTime": 1535489564334,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3261,25 +3501,25 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535662491591,
+      "nextUpdateTime": 1535595495451,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535456082317,
+      "nextUpdateTime": 1535586988900,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535602597669,
+      "nextUpdateTime": 1535930397006,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535383347016,
+      "nextUpdateTime": 1535509674049,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -3291,13 +3531,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535684316433,
+      "nextUpdateTime": 1535739774613,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535777753978,
+      "nextUpdateTime": 1535560046524,
       "userAction": ""
     },
     "www.google.com": {
@@ -3309,97 +3549,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535533301706,
-      "userAction": ""
-    },
-    "www.justuno.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535835623263,
+      "nextUpdateTime": 1535756312610,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535634668073,
+      "nextUpdateTime": 1535879616929,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535647703467,
+      "nextUpdateTime": 1535800042571,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535713896951,
+      "nextUpdateTime": 1535800256120,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535717161877,
+      "nextUpdateTime": 1535749245992,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535472362868,
+      "nextUpdateTime": 1535728733870,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535775225012,
+      "nextUpdateTime": 1535468979631,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535779192331,
+      "nextUpdateTime": 1535776576351,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535854231963,
+      "nextUpdateTime": 1535467088529,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535683085556,
+      "nextUpdateTime": 1535653525547,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535492902964,
+      "nextUpdateTime": 1535873679290,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535633330954,
+      "nextUpdateTime": 1535804763970,
       "userAction": ""
     },
     "www.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535622719621,
+      "nextUpdateTime": 1535541713916,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535870220028,
+      "nextUpdateTime": 1535773470002,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535717582854,
+      "nextUpdateTime": 1535481472835,
+      "userAction": ""
+    },
+    "x01.aidata.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535957511051,
       "userAction": ""
     },
     "xiti.com": {
@@ -3411,7 +3651,7 @@
     "xpl.theadex.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535552741878,
+      "nextUpdateTime": 1535914264605,
       "userAction": ""
     },
     "xplosion.de": {
@@ -3450,6 +3690,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3459,19 +3705,19 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535731599614,
+      "nextUpdateTime": 1535571133437,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535474370166,
+      "nextUpdateTime": 1535964428669,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535712458694,
+      "nextUpdateTime": 1535649235764,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3494,7 +3740,8 @@
     ],
     "1dmp.io": [
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "1rx.io": [
       "tinyurl.com",
@@ -3512,6 +3759,9 @@
       "aappublications.org",
       "americanbar.org"
     ],
+    "254a.com": [
+      "thehindu.com"
+    ],
     "2mdnsys.com": [
       "liveuamap.com"
     ],
@@ -3523,7 +3773,6 @@
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
-      "philips.com",
       "oclc.org"
     ],
     "33across.com": [
@@ -3549,7 +3798,8 @@
       "nature.com",
       "springer.com",
       "theverge.com",
-      "deviantart.com",
+      "usatoday.com",
+      "infoworld.com",
       "focus.de"
     ],
     "4dsply.com": [
@@ -3628,6 +3878,9 @@
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
+    "ad-score.com": [
+      "infoplease.com"
+    ],
     "ad-stir.com": [
       "sakura.ne.jp",
       "biglobe.ne.jp",
@@ -3652,14 +3905,14 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com",
-      "tinypic.com"
+      "washingtonexaminer.com"
     ],
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
       "yahoo.com",
       "who.int",
+      "unenvironment.org",
       "gulfnews.com"
     ],
     "addtoany.com": [
@@ -3674,12 +3927,14 @@
       "bloomberg.com",
       "springer.com",
       "sciencemag.org",
+      "thehindu.com",
       "helsinki.fi"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "rambler.ru"
+      "rambler.ru",
+      "ria.ru"
     ],
     "adfront.org": [
       "joomla.org"
@@ -3687,7 +3942,8 @@
     "adhigh.net": [
       "rambler.ru",
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "adidas.fi": [
       "adidas.com"
@@ -3699,7 +3955,6 @@
       "bloomberg.com",
       "dailymotion.com",
       "spiegel.de",
-      "t-online.de",
       "lemonde.fr"
     ],
     "adjust-net.jp": [
@@ -3710,16 +3965,16 @@
       "venturebeat.com",
       "livescience.com",
       "space.com",
-      "t-online.de",
+      "xda-developers.com",
       "dailydot.com"
     ],
     "adlmerge.com": [
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "admaster.com.cn": [
       "autohome.com.cn",
-      "bshare.cn",
-      "youku.com"
+      "bshare.cn"
     ],
     "admission.net": [
       "edmunds.com"
@@ -3732,13 +3987,14 @@
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "telegraph.co.uk",
+      "thehindu.com",
       "rfi.fr"
     ],
     "adobe.com": [
       "wikipedia.org",
       "behance.net",
-      "history.com"
+      "history.com",
+      "fotolia.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
@@ -3749,24 +4005,28 @@
     "adotmob.com": [
       "standard.co.uk",
       "upwork.com",
-      "nypost.com"
+      "variety.com"
     ],
     "adriver.ru": [
       "ria.ru",
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "home.pl"
     ],
     "adroll.com": [
       "stumbleupon.com",
       "nature.com",
       "nginx.org",
       "cloudflare.com",
+      "sitepoint.com",
       "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com"
+      "springer.com",
+      "statista.com",
+      "home.pl"
     ],
     "adsnative.com": [
       "autodesk.com",
@@ -3775,15 +4035,16 @@
       "bostonherald.com"
     ],
     "adsniper.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "radikal.ru"
     ],
     "adsrvr.org": [
       "adobe.com",
       "yahoo.com",
       "googletagmanager.com",
       "sourceforge.net",
-      "cnet.com",
-      "gizmodo.com"
+      "thehindu.com",
+      "hgtv.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -3794,11 +4055,13 @@
       "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "economist.com",
+      "usatoday.com",
+      "thehindu.com",
       "realtor.com"
     ],
     "adtags.pro": [
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "adtdp.com": [
       "biglobe.ne.jp"
@@ -3808,7 +4071,7 @@
       "sourceforge.net",
       "dropbox.com",
       "wsj.com",
-      "dailymotion.com",
+      "home.pl",
       "walgreens.com"
     ],
     "advertur.ru": [
@@ -3819,7 +4082,8 @@
     ],
     "adx.com.ru": [
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "adx1.com": [
       "venturebeat.com",
@@ -3840,6 +4104,7 @@
       "t-online.de",
       "bloomberg.com",
       "cnet.com",
+      "bankrate.com",
       "gizmodo.com"
     ],
     "aid-ad.jp": [
@@ -3848,7 +4113,8 @@
     "aidata.io": [
       "rambler.ru",
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "aili.com": [
       "sina.com.cn"
@@ -3881,7 +4147,8 @@
       "alibaba.com",
       "youku.com",
       "aliexpress.com",
-      "1688.com"
+      "1688.com",
+      "2345.com"
     ],
     "alipay.com": [
       "alibaba.com",
@@ -3894,6 +4161,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "am15.net": [
@@ -3907,7 +4175,7 @@
       "nytimes.com",
       "reddit.com",
       "cnn.com",
-      "telegraph.co.uk",
+      "mentalfloss.com",
       "bostonherald.com"
     ],
     "amazon.co.uk": [
@@ -3923,6 +4191,9 @@
     "ameba.jp": [
       "ameblo.jp"
     ],
+    "analytics-egain.com": [
+      "virginmedia.com"
+    ],
     "and.co.uk": [
       "dailymail.co.uk"
     ],
@@ -3933,7 +4204,8 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "walgreens.com"
+      "nintendo.com",
+      "realtor.com"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -3962,7 +4234,7 @@
       "foursquare.com",
       "history.com",
       "nbc.com",
-      "airbnb.com",
+      "allrecipes.com",
       "strava.com"
     ],
     "appdynamics.com": [
@@ -3984,6 +4256,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "arcpublishing.com": [
@@ -4007,7 +4280,7 @@
       "facebook.com",
       "yahoo.com",
       "msn.com",
-      "t-online.de"
+      "upwork.com"
     ],
     "atemda.com": [
       "springer.com",
@@ -4043,13 +4316,11 @@
       "sina.com.cn",
       "163.com",
       "ifeng.com",
-      "sohu.com"
+      "sohu.com",
+      "2345.com"
     ],
     "bam-x.com": [
       "gq.com"
-    ],
-    "baur.de": [
-      "t-online.de"
     ],
     "bazaarvoice.com": [
       "target.com",
@@ -4106,15 +4377,16 @@
       "adobe.com",
       "dailymotion.com",
       "hootsuite.com",
-      "hp.com"
+      "hp.com",
+      "upwork.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
       "amazon.com",
-      "forbes.com",
-      "npr.org",
-      "newatlas.com"
+      "dropbox.com",
+      "thehindu.com",
+      "radikal.ru"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -4128,8 +4400,8 @@
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "telegraph.co.uk",
-      "office.com",
+      "motorola.com",
+      "microsoft.com",
       "pingdom.com"
     ],
     "bitbucket.org": [
@@ -4140,10 +4412,12 @@
       "cloudflare.com",
       "zendesk.com",
       "ibm.com",
+      "here.com",
       "gitlab.com"
     ],
     "bizibly.com": [
-      "eventbrite.com"
+      "eventbrite.com",
+      "cloudflare.com"
     ],
     "bizographics.com": [
       "zend.com",
@@ -4154,7 +4428,8 @@
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -4164,14 +4439,14 @@
     ],
     "bluecava.com": [
       "history.com",
-      "biography.com",
-      "jimdo.com"
+      "biography.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
       "sfgate.com",
-      "chron.com"
+      "chron.com",
+      "ajc.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -4193,6 +4468,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "boston.com": [
@@ -4212,6 +4488,7 @@
       "time.com",
       "wired.com",
       "usatoday.com",
+      "allrecipes.com",
       "pitchfork.com"
     ],
     "brandcdn.com": [
@@ -4221,6 +4498,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "brightcove.com": [
@@ -4228,12 +4506,14 @@
       "si.com",
       "federalreserve.gov",
       "theaustralian.com.au",
-      "informationweek.com"
+      "informationweek.com",
+      "straitstimes.com"
     ],
     "brightcove.net": [
       "lefigaro.fr",
       "politico.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "aljazeera.com"
     ],
     "bttrack.com": [
       "yahoo.com",
@@ -4264,7 +4544,8 @@
       "economist.com"
     ],
     "caltat.com": [
-      "live4fun.ru"
+      "live4fun.ru",
+      "radikal.ru"
     ],
     "candlewoodsuites.com": [
       "ihg.com"
@@ -4282,14 +4563,16 @@
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
-      "dailymail.co.uk",
+      "thehindu.com",
       "pitchfork.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
       "gamespot.com",
-      "cnet.com"
+      "cnet.com",
+      "cbsnews.com",
+      "cbssports.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -4310,6 +4593,9 @@
     ],
     "cdnwidget.com": [
       "photoshelter.com"
+    ],
+    "cedexis-test.com": [
+      "tumblr.com"
     ],
     "cern.ch": [
       "home.cern"
@@ -4386,6 +4672,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "cnzz.com": [
@@ -4419,6 +4706,7 @@
       "ibm.com",
       "redhat.com",
       "hp.com",
+      "upwork.com",
       "box.com"
     ],
     "complex.com": [
@@ -4434,6 +4722,7 @@
       "arstechnica.com",
       "nj.com",
       "newyorker.com",
+      "nola.com",
       "pitchfork.com"
     ],
     "conductrics.com": [
@@ -4450,14 +4739,11 @@
       "rollingstone.com",
       "variety.com",
       "adweek.com",
-      "buzzfeed.com",
+      "independent.co.uk",
       "nme.com"
     ],
     "consumable.com": [
       "xfinity.com"
-    ],
-    "content.ad": [
-      "tinypic.com"
     ],
     "contentabc.com": [
       "pornhub.com"
@@ -4467,7 +4753,7 @@
       "myspace.com",
       "bloomberg.com",
       "forbes.com",
-      "samsung.com",
+      "thehindu.com",
       "coindesk.com"
     ],
     "convertful.com": [
@@ -4490,6 +4776,9 @@
     "coxbusiness.com": [
       "cox.com"
     ],
+    "coxmediagroup.com": [
+      "ajc.com"
+    ],
     "cpex.cz": [
       "idnes.cz"
     ],
@@ -4498,6 +4787,7 @@
       "digitaltrends.com",
       "techradar.com",
       "independent.co.uk",
+      "allmusic.com",
       "rfi.fr"
     ],
     "cquotient.com": [
@@ -4505,9 +4795,6 @@
     ],
     "cr-nielsen.com": [
       "youku.com"
-    ],
-    "creative-serving.com": [
-      "newatlas.com"
     ],
     "creativecdn.com": [
       "ria.ru",
@@ -4521,7 +4808,7 @@
       "washingtonpost.com",
       "dailymail.co.uk",
       "dropbox.com",
-      "cnet.com",
+      "newegg.com",
       "sedo.com"
     ],
     "croissed.info": [
@@ -4534,6 +4821,9 @@
       "sourceforge.net",
       "slashdot.org",
       "bartleby.com"
+    ],
+    "crwdcntrl.net": [
+      "wunderground.com"
     ],
     "cssrvsync.com": [
       "springer.com",
@@ -4553,7 +4843,6 @@
       "talktalk.co.uk",
       "gizmodo.com",
       "wsj.com",
-      "cbc.ca",
       "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
@@ -4583,10 +4872,14 @@
     "datamind.ru": [
       "novostimira.com",
       "rambler.ru",
-      "kharkov.ua"
+      "kharkov.ua",
+      "radikal.ru"
     ],
     "datasteam.io": [
       "ama-assn.org"
+    ],
+    "datpix.net": [
+      "radikal.ru"
     ],
     "daum.net": [
       "shutterstock.com",
@@ -4617,7 +4910,7 @@
       "yahoo.com",
       "amazon.com",
       "soundcloud.com",
-      "telegraph.co.uk",
+      "thehindu.com",
       "skynet.be"
     ],
     "departapp.com": [
@@ -4651,18 +4944,21 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com"
+      "entrepreneur.com",
+      "zerohedge.com"
     ],
     "dictionary.com": [
       "thesaurus.com"
     ],
     "digitaladsystems.com": [
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "digitaltarget.ru": [
       "liveinternet.ru",
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "digitru.st": [
       "britannica.com",
@@ -4688,7 +4984,7 @@
       "barnesandnoble.com",
       "urbandictionary.com",
       "axs.com",
-      "timeanddate.com",
+      "thehindu.com",
       "newatlas.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
@@ -4715,7 +5011,7 @@
       "samsung.com",
       "webmd.com",
       "forbes.com",
-      "economist.com",
+      "thehindu.com",
       "walgreens.com"
     ],
     "dotsub.com": [
@@ -4726,7 +5022,7 @@
       "twitter.com",
       "linkedin.com",
       "sourceforge.net",
-      "telegraph.co.uk",
+      "haaretz.com",
       "focus.de"
     ],
     "doublemax.net": [
@@ -4744,6 +5040,9 @@
       "theregister.co.uk",
       "techtarget.com",
       "adweek.com"
+    ],
+    "dxpmedia.com": [
+      "sina.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4809,6 +5108,7 @@
       "cisco.com",
       "prnewswire.com",
       "redhat.com",
+      "infoworld.com",
       "eset.com"
     ],
     "elsevier.com": [
@@ -4837,7 +5137,11 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
+    ],
+    "epital.gdn": [
+      "4shared.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -4852,7 +5156,7 @@
       "over-blog.com",
       "canalblog.com",
       "lefigaro.fr",
-      "sfgate.com"
+      "tomshardware.com"
     ],
     "etracker.de": [
       "sedo.com"
@@ -4870,8 +5174,8 @@
       "adobe.com",
       "yahoo.com",
       "sourceforge.net",
-      "tinyurl.com",
-      "telegraph.co.uk",
+      "dropbox.com",
+      "thehindu.com",
       "newatlas.com"
     ],
     "everyaction.com": [
@@ -4904,7 +5208,8 @@
       "soundcloud.com",
       "forbes.com",
       "bloomberg.com",
-      "surveymonkey.com",
+      "businessinsider.com",
+      "genius.com",
       "gizmodo.com"
     ],
     "exosrv.com": [
@@ -4917,7 +5222,7 @@
       "sourceforge.net",
       "forbes.com",
       "bloomberg.com",
-      "news.com.au",
+      "gizmodo.com",
       "heraldsun.com.au"
     ],
     "eyereturn.com": [
@@ -4938,13 +5243,16 @@
       "wordpress.org",
       "adobe.com",
       "nytimes.com",
-      "telegraph.co.uk",
+      "haaretz.com",
       "focus.de"
     ],
     "facetz.net": [
       "novostimira.com",
       "rambler.ru",
       "kharkov.ua"
+    ],
+    "faggrim.com": [
+      "radikal.ru"
     ],
     "fairfax.com.au": [
       "smh.com.au",
@@ -4979,8 +5287,7 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu",
-      "bmj.com"
+      "msu.edu"
     ],
     "flickr.com": [
       "state.gov",
@@ -5006,16 +5313,15 @@
       "clinicaltrials.gov",
       "moonfruit.com",
       "webex.com",
+      "ucsc.edu",
       "sitepoint.com"
-    ],
-    "foreignpolicy.com": [
-      "onecount.net"
     ],
     "foresee.com": [
       "epa.gov",
       "si.edu",
       "theglobeandmail.com",
-      "sec.gov"
+      "sec.gov",
+      "worldcat.org"
     ],
     "formstack.com": [
       "in.gov"
@@ -5099,7 +5405,8 @@
     "getsmartcontent.com": [
       "pcworld.com",
       "computerworld.com",
-      "hpe.com"
+      "hpe.com",
+      "networkworld.com"
     ],
     "gfycat.com": [
       "reddit.com"
@@ -5108,7 +5415,8 @@
       "cnn.com",
       "independent.co.uk",
       "abc.net.au",
-      "sfgate.com",
+      "cbslocal.com",
+      "abc.es",
       "hgtv.com"
     ],
     "giphy.com": [
@@ -5123,12 +5431,14 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com"
+      "fortune.com",
+      "si.com"
     ],
     "gmossp-sp.jp": [
       "shinobi.jp",
@@ -5144,6 +5454,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "goo.ne.jp": [
@@ -5157,8 +5468,8 @@
       "linkedin.com",
       "google.de",
       "sourceforge.net",
-      "telegraph.co.uk",
       "scmp.com",
+      "sendspace.com",
       "chromium.org",
       "focus.de"
     ],
@@ -5191,6 +5502,7 @@
       "liveuamap.com",
       "colourlovers.com",
       "infoplease.com",
+      "thehindu.com",
       "coindesk.com"
     ],
     "guoshipartners.com": [
@@ -5228,6 +5540,12 @@
     "help.com": [
       "comodo.com",
       "couchsurfing.com"
+    ],
+    "hgbn.rocks": [
+      "radikal.ru"
+    ],
+    "hgbnr.com": [
+      "radikal.ru"
     ],
     "hiexpress.com": [
       "ihg.com"
@@ -5285,7 +5603,8 @@
     "hybrid.ai": [
       "rambler.ru",
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "hypemarks.com": [
       "uchicago.edu",
@@ -5320,7 +5639,8 @@
       "bloomberg.com",
       "venturebeat.com",
       "dailymotion.com",
-      "livescience.com"
+      "livescience.com",
+      "xda-developers.com"
     ],
     "idealmedia.com": [
       "alternet.org",
@@ -5332,7 +5652,8 @@
     "igodigital.com": [
       "apa.org",
       "adidas.com",
-      "motorola.com"
+      "motorola.com",
+      "nintendo.com"
     ],
     "iheart.com": [
       "variety.com"
@@ -5361,14 +5682,15 @@
       "rakuten.co.jp",
       "yahoo.co.jp",
       "goo.ne.jp",
-      "economist.com"
+      "economist.com",
+      "ocn.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
       "bbc.com",
       "wsj.com",
-      "cnet.com",
+      "popsugar.com",
       "gizmodo.com"
     ],
     "infinity-tracking.net": [
@@ -5387,7 +5709,8 @@
       "ups.com"
     ],
     "inquisitr.com": [
-      "www.poznan.pl"
+      "www.poznan.pl",
+      "flipboard.com"
     ],
     "inside-graph.com": [
       "staples.com"
@@ -5403,8 +5726,7 @@
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu",
-      "tmz.com"
+      "arizona.edu"
     ],
     "instinctiveads.com": [
       "variety.com",
@@ -5426,7 +5748,7 @@
       "themeforest.net",
       "ft.com",
       "elegantthemes.com",
-      "bigcartel.com",
+      "codecanyon.net",
       "iconfinder.com"
     ],
     "intergient.com": [
@@ -5474,8 +5796,7 @@
       "indianexpress.com"
     ],
     "janrainsso.com": [
-      "vancouversun.com",
-      "nationalpost.com"
+      "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
@@ -5527,7 +5848,7 @@
       "nationalgeographic.com",
       "chicagotribune.com",
       "nytimes.com",
-      "rollingstone.com",
+      "complex.com",
       "zappos.com"
     ],
     "kinja.com": [
@@ -5543,7 +5864,7 @@
       "bgr.com",
       "jalopnik.com",
       "cnn.com",
-      "usatoday.com",
+      "allrecipes.com",
       "gizmodo.com"
     ],
     "ladsp.com": [
@@ -5569,14 +5890,15 @@
       "nj.com",
       "patch.com",
       "bloomberg.com",
-      "economist.com",
+      "cbssports.com",
       "washingtonexaminer.com"
     ],
     "libero.it": [
       "virgilio.it"
     ],
     "licasd.com": [
-      "nj.com"
+      "nj.com",
+      "cbssports.com"
     ],
     "licdn.com": [
       "linkedin.com"
@@ -5584,7 +5906,8 @@
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "home.pl"
+      "home.pl",
+      "orange.fr"
     ],
     "lightboxcdn.com": [
       "zdnet.com",
@@ -5598,6 +5921,7 @@
       "bloomberg.com",
       "deviantart.com",
       "uci.edu",
+      "zimbio.com",
       "infoplease.com"
     ],
     "lincoln.com": [
@@ -5611,14 +5935,15 @@
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "forbes.com",
-      "hp.com",
+      "dropbox.com",
+      "mentalfloss.com",
       "lexisnexis.com"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
       "pcworld.com",
-      "nike.com"
+      "nike.com",
+      "infoworld.com"
     ],
     "list-manage.com": [
       "boingboing.net"
@@ -5650,7 +5975,7 @@
       "apache.org",
       "prnewswire.com",
       "ibm.com",
-      "talktalk.co.uk",
+      "thetimes.co.uk",
       "lexisnexis.com"
     ],
     "lkqd.net": [
@@ -5698,7 +6023,11 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com"
+      "google.com",
+      "yandex.ru",
+      "ria.ru",
+      "ok.ru",
+      "radikal.ru"
     ],
     "mailchimp.com": [
       "colorlib.com",
@@ -5725,27 +6054,29 @@
       "nokia.com",
       "panasonic.com",
       "dyn.com",
+      "searchengineland.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
       "thestar.com",
-      "seattletimes.com"
+      "seattletimes.com",
+      "ajc.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
       "forbes.com",
-      "usatoday.com",
-      "pitchfork.com"
+      "thehindu.com",
+      "walgreens.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
       "forbes.com",
       "reuters.com",
-      "npr.org",
+      "medicinenet.com",
       "cracked.com"
     ],
     "media6degrees.com": [
@@ -5765,8 +6096,7 @@
     "mediaplex.com": [
       "dell.com",
       "shutterfly.com",
-      "military.com",
-      "economist.com"
+      "military.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
@@ -5801,12 +6131,13 @@
       "variety.com"
     ],
     "mfadsrvr.com": [
-      "forbes.com"
+      "infoplease.com"
     ],
     "mg2connext.com": [
       "mercurynews.com",
       "philly.com",
-      "denverpost.com"
+      "denverpost.com",
+      "ajc.com"
     ],
     "mgid.com": [
       "liveleak.com",
@@ -5848,6 +6179,7 @@
       "prnewswire.com",
       "zend.com",
       "oreilly.com",
+      "ebsco.com",
       "pingdom.com"
     ],
     "ml314.com": [
@@ -5855,7 +6187,7 @@
       "forbes.com",
       "bloomberg.com",
       "wsj.com",
-      "businessinsider.com",
+      "networkworld.com",
       "zerohedge.com"
     ],
     "mlb.com": [
@@ -5888,7 +6220,7 @@
       "t-online.de",
       "nbcnews.com",
       "theglobeandmail.com",
-      "thetimes.co.uk"
+      "businessinsider.com"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -5953,7 +6285,7 @@
       "surveymonkey.com",
       "spotify.com",
       "paypal.com",
-      "economist.com"
+      "redbubble.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
@@ -5963,7 +6295,7 @@
     ],
     "narrative.io": [
       "sourceforge.net",
-      "business2community.com"
+      "gizmodo.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -6007,7 +6339,8 @@
       "lenovo.com",
       "theknot.com",
       "shopko.com",
-      "pitchfork.com"
+      "usatoday.com",
+      "thehindu.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -6034,13 +6367,13 @@
       "nypost.com",
       "thesun.co.uk",
       "wsj.com",
-      "news.com.au",
       "heraldsun.com.au"
     ],
     "newsinc.com": [
       "latimes.com",
       "nydailynews.com",
-      "hollywoodreporter.com"
+      "hollywoodreporter.com",
+      "ajc.com"
     ],
     "newsmemory.com": [
       "cleveland.com"
@@ -6057,6 +6390,7 @@
       "wired.com",
       "vanityfair.com",
       "vogue.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "nexac.com": [
@@ -6080,7 +6414,7 @@
       "wsj.com",
       "oracle.com",
       "huffingtonpost.com",
-      "harvard.edu",
+      "allrecipes.com",
       "helsinki.fi"
     ],
     "nsaudience.pl": [
@@ -6098,7 +6432,8 @@
     "nxtck.com": [
       "nike.com",
       "shutterstock.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "orange.fr"
     ],
     "nymag.com": [
       "vulture.com"
@@ -6112,7 +6447,8 @@
     "oath.com": [
       "tumblr.com",
       "huffingtonpost.co.uk",
-      "techradar.com"
+      "techradar.com",
+      "autoblog.com"
     ],
     "ocdn.eu": [
       "onet.pl",
@@ -6160,6 +6496,7 @@
       "amazon.com",
       "telegraph.co.uk",
       "marriott.com",
+      "ancestry.com",
       "eset.com"
     ],
     "onclickmega.com": [
@@ -6176,7 +6513,7 @@
       "bitbucket.org",
       "namecheap.com",
       "cnn.com",
-      "thesun.co.uk",
+      "haaretz.com",
       "active.com"
     ],
     "onevision.com.tw": [
@@ -6210,8 +6547,8 @@
       "yahoo.com",
       "amazon.com",
       "nytimes.com",
-      "forbes.com",
-      "telegraph.co.uk",
+      "dropbox.com",
+      "thehindu.com",
       "active.com"
     ],
     "opinionstage.com": [
@@ -6227,21 +6564,24 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
-      "ibm.com",
-      "microsoft.com",
       "bbc.com",
+      "live.com",
+      "ibm.com",
+      "hp.com",
       "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
+      "foxnews.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
       "evernote.com",
+      "box.com",
       "prezi.com",
       "prweb.com",
-      "ign.com",
       "dictionary.com",
+      "ehow.com",
       "bitbucket.org",
       "gotomeeting.com",
       "accorhotels.com",
@@ -6250,26 +6590,24 @@
       "history.com",
       "bestbuy.com",
       "jamanetwork.com",
-      "www.nhs.uk",
       "imageshack.com",
-      "atlassian.com",
       "dallasnews.com",
       "metmuseum.org",
       "blizzard.com",
       "intuit.com",
       "starbucks.com",
       "squareup.com",
-      "ajc.com",
       "justgiving.com",
       "dreamhost.com",
       "edx.org",
+      "microsoft.com",
+      "cbssports.com",
       "bartleby.com",
       "theknot.com",
       "zenfolio.com",
       "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
-      "box.com",
       "fox.com"
     ],
     "optimove.events": [
@@ -6280,8 +6618,7 @@
       "alternet.org"
     ],
     "oracleimg.com": [
-      "dyn.com",
-      "oracle.com"
+      "dyn.com"
     ],
     "orangeads.fr": [
       "orange.fr"
@@ -6303,7 +6640,7 @@
       "scribd.com",
       "foxnews.com",
       "cnn.com",
-      "telegraph.co.uk",
+      "globalnews.ca",
       "focus.de"
     ],
     "ovh.com": [
@@ -6313,6 +6650,7 @@
       "lycos.com",
       "lg.com",
       "washingtontimes.com",
+      "thehindu.com",
       "pitchfork.com"
     ],
     "owox.com": [
@@ -6332,7 +6670,7 @@
       "wired.com",
       "wikia.com",
       "wsj.com",
-      "techcrunch.com",
+      "nola.com",
       "dezeen.com"
     ],
     "paypal.com": [
@@ -6362,13 +6700,11 @@
     "perimeterx.net": [
       "bloomberg.com",
       "pixnet.net",
-      "macrumors.com"
+      "macrumors.com",
+      "upwork.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
-    ],
-    "photobucket.com": [
-      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
@@ -6377,12 +6713,14 @@
       "huffingtonpost.com",
       "dailymail.co.uk",
       "nytimes.com",
-      "etsy.com"
+      "themeforest.net",
+      "popsugar.com"
     ],
     "pitchfork.com": [
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "epicurious.com"
     ],
     "pixanalytics.com": [
@@ -6427,14 +6765,15 @@
       "independent.co.uk",
       "chicagotribune.com",
       "wsj.com",
-      "marketwatch.com",
+      "ajc.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
       "livescience.com",
       "standard.co.uk",
-      "variety.com"
+      "variety.com",
+      "orange.fr"
     ],
     "pressboard.ca": [
       "observer.com"
@@ -6484,6 +6823,7 @@
       "tinyurl.com",
       "bloomberg.com",
       "usatoday.com",
+      "thehindu.com",
       "walgreens.com"
     ],
     "pubmine.com": [
@@ -6526,7 +6866,8 @@
     "qq.com": [
       "sina.com.cn",
       "ctrip.com",
-      "weather.com.cn"
+      "weather.com.cn",
+      "tencent.com"
     ],
     "qsstats.com": [
       "serverwatch.com",
@@ -6539,6 +6880,7 @@
       "adidas.com",
       "cnet.com",
       "babycenter.com",
+      "cbssports.com",
       "mayoclinic.org"
     ],
     "quantserve.com": [
@@ -6546,7 +6888,7 @@
       "vimeo.com",
       "reddit.com",
       "soundcloud.com",
-      "jimdo.com",
+      "thehindu.com",
       "gizmodo.com"
     ],
     "quantummetric.com": [
@@ -6563,6 +6905,7 @@
       "bloomberg.com",
       "ning.com",
       "nypost.com",
+      "thehindu.com",
       "eset.com"
     ],
     "rackcdn.com": [
@@ -6579,6 +6922,7 @@
       "washingtonpost.com",
       "novostimira.com",
       "ria.ru",
+      "radikal.ru",
       "kharkov.ua"
     ],
     "rbnt.org": [
@@ -6610,7 +6954,8 @@
       "theregister.co.uk"
     ],
     "relap.io": [
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "republer.com": [
       "tomsk.ru",
@@ -6649,8 +6994,11 @@
       "tinyurl.com",
       "npr.org",
       "forbes.com",
-      "economist.com",
+      "yellowpages.com",
       "gopro.com"
+    ],
+    "rhombusads.com": [
+      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6658,7 +7006,8 @@
     "richmetrics.com": [
       "nj.com",
       "oregonlive.com",
-      "mlive.com"
+      "mlive.com",
+      "nola.com"
     ],
     "richrelevance.com": [
       "hbr.org",
@@ -6671,7 +7020,8 @@
       "time.com",
       "wired.com",
       "cbsnews.com",
-      "npr.org",
+      "zdnet.com",
+      "thebalance.com",
       "gizmodo.com"
     ],
     "rlcdn.com": [
@@ -6679,7 +7029,7 @@
       "yahoo.com",
       "sourceforge.net",
       "reddit.com",
-      "hp.com",
+      "thehindu.com",
       "box.com"
     ],
     "rnengage.com": [
@@ -6696,33 +7046,38 @@
     "roymorgan.com": [
       "smh.com.au"
     ],
+    "rqtrk.eu": [
+      "dropbox.com"
+    ],
     "rtb.com.ru": [
       "radikal.ru",
       "diary.ru"
     ],
     "rtk.io": [
       "post-gazette.com",
+      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
       "bloomberg.com",
-      "npr.org"
+      "uci.edu"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
       "sourceforge.net",
-      "nytimes.com",
-      "dailymail.co.uk",
-      "gizmodo.com"
+      "cnn.com",
+      "thehindu.com",
+      "pitchfork.com"
     ],
     "rundsp.com": [
       "hpe.com",
       "alternet.org"
     ],
     "rutarget.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "radikal.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "codepen.io",
@@ -6740,6 +7095,7 @@
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
+      "teamviewer.us",
       "salesforce.com",
       "eset.com"
     ],
@@ -6755,6 +7111,9 @@
       "imdb.com",
       "gizmodo.com",
       "lifehacker.com"
+    ],
+    "sape.ru": [
+      "radikal.ru"
     ],
     "sbal4kp.com": [
       "dropbox.com"
@@ -6790,7 +7149,7 @@
       "yahoo.com",
       "tumblr.com",
       "nytimes.com",
-      "telegraph.co.uk",
+      "thehindu.com",
       "gizmodo.com"
     ],
     "scribblelive.com": [
@@ -6800,9 +7159,6 @@
     ],
     "sddan.com": [
       "upwork.com"
-    ],
-    "sdp-campaign.de": [
-      "t-online.de"
     ],
     "seadform.net": [
       "bloomberg.com"
@@ -6824,12 +7180,14 @@
       "fortune.com",
       "people.com",
       "ew.com",
-      "time.com"
+      "time.com",
+      "allrecipes.com"
     ],
     "self.com": [
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "semasio.net": [
@@ -6843,6 +7201,7 @@
       "venturebeat.com",
       "livescience.com",
       "space.com",
+      "xda-developers.com",
       "dailydot.com"
     ],
     "servedby-buysellads.com": [
@@ -6856,6 +7215,7 @@
       "t-online.de",
       "nbcnews.com",
       "businessinsider.com",
+      "nintendo.com",
       "hgtv.com"
     ],
     "sessioncam.com": [
@@ -6878,7 +7238,7 @@
       "cnn.com",
       "time.com",
       "forbes.com",
-      "cnet.com",
+      "home.pl",
       "walgreens.com"
     ],
     "sheego.de": [
@@ -6921,8 +7281,8 @@
       "verisign.com",
       "udel.edu",
       "berkeley.edu",
-      "jhu.edu",
-      "ethz.ch",
+      "emory.edu",
+      "ucsc.edu",
       "helsinki.fi",
       "case.edu",
       "oclc.org"
@@ -6942,14 +7302,16 @@
       "barnesandnoble.com",
       "tinypic.com",
       "seattletimes.com",
-      "sciencedaily.com",
+      "usatoday.com",
+      "thehindu.com",
       "networksolutions.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
-      "jimdo.com",
+      "fastcompany.com",
+      "mentalfloss.com",
       "coindesk.com"
     ],
     "sky.com": [
@@ -6963,7 +7325,8 @@
       "springer.com",
       "skyrock.com",
       "sapo.pt",
-      "elpais.com"
+      "elpais.com",
+      "home.pl"
     ],
     "smartclip.net": [
       "infoplease.com"
@@ -6990,7 +7353,7 @@
       "overstock.com",
       "complex.com",
       "wsj.com",
-      "giphy.com",
+      "redbubble.com",
       "zappos.com"
     ],
     "snapwidget.com": [
@@ -7005,7 +7368,8 @@
     "socdm.com": [
       "rakuten.co.jp",
       "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "sociomantic.com": [
       "springer.com",
@@ -7044,8 +7408,8 @@
       "deviantart.com",
       "springer.com",
       "myspace.com",
-      "cnet.com",
-      "edmunds.com"
+      "home.pl",
+      "detroitnews.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -7054,7 +7418,6 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "irishtimes.com",
       "mo.gov"
     ],
     "sourceforge.net": [
@@ -7098,7 +7461,7 @@
       "amazon.com",
       "dropbox.com",
       "dailymotion.com",
-      "npr.org",
+      "express.co.uk",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -7152,6 +7515,7 @@
       "prezi.com",
       "wpengine.com",
       "istockphoto.com",
+      "newegg.com",
       "careerbuilder.com"
     ],
     "steepto.com": [
@@ -7190,13 +7554,11 @@
       "feedly.com",
       "documentcloud.org"
     ],
-    "stripe.network": [
-      "smashballoon.com"
-    ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
       "studiopress.com",
+      "sitepoint.com",
       "makezine.com"
     ],
     "sundaysky.com": [
@@ -7223,13 +7585,15 @@
     "surveymonkey.com": [
       "cambridge.org",
       "investopedia.com",
-      "foreignpolicy.com"
+      "foreignpolicy.com",
+      "iop.org"
     ],
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
       "indianexpress.com",
-      "springer.com"
+      "springer.com",
+      "thehindu.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -7243,8 +7607,8 @@
       "dropbox.com",
       "t-online.de",
       "msn.com",
-      "telegraph.co.uk",
-      "edmunds.com"
+      "ajc.com",
+      "infoplease.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -7266,21 +7630,23 @@
       "sina.com.cn",
       "alibaba.com",
       "ifeng.com",
-      "tmall.com"
+      "tmall.com",
+      "2345.com"
     ],
     "taobao.com": [
       "sina.com.cn",
       "1688.com",
       "tmall.com",
-      "alibaba.com"
+      "alibaba.com",
+      "2345.com"
     ],
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
       "soundcloud.com",
-      "paypal.com",
-      "jimdo.com",
-      "bostonherald.com"
+      "dropbox.com",
+      "globalnews.ca",
+      "networksolutions.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -7300,6 +7666,7 @@
       "cbsnews.com",
       "evernote.com",
       "cnet.com",
+      "ancestry.com",
       "usmagazine.com"
     ],
     "technolutions.net": [
@@ -7314,6 +7681,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "telegraph.co.uk": [
@@ -7340,6 +7708,9 @@
       "playstation.com",
       "zappos.com"
     ],
+    "thecut.com": [
+      "nymag.com"
+    ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
     ],
@@ -7363,7 +7734,9 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com",
+      "allrecipes.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -7373,7 +7746,7 @@
       "techcrunch.com",
       "kickstarter.com",
       "bloomberg.com",
-      "cnbc.com",
+      "thenation.com",
       "gizmodo.com"
     ],
     "tiqcdn.com": [
@@ -7381,8 +7754,8 @@
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
-      "marketwatch.com",
       "hpe.com",
+      "orange.fr",
       "francetvinfo.fr"
     ],
     "tl813.com": [
@@ -7400,6 +7773,7 @@
       "vk.com",
       "yandex.ru",
       "mail.ru",
+      "ria.ru",
       "radikal.ru"
     ],
     "toutapp.com": [
@@ -7458,7 +7832,8 @@
       "dailymotion.com",
       "pastebin.com",
       "liveleak.com",
-      "marriott.com"
+      "usatoday.com",
+      "thehindu.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -7504,8 +7879,8 @@
       "bloomberg.com",
       "wired.com",
       "webmd.com",
-      "tinyurl.com",
       "hp.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
@@ -7529,8 +7904,8 @@
       "nytimes.com",
       "cnn.com",
       "msn.com",
-      "hp.com",
-      "sfgate.com",
+      "haaretz.com",
+      "medicinenet.com",
       "lexisnexis.com",
       "edmunds.com"
     ],
@@ -7568,9 +7943,6 @@
       "cnn.com",
       "nba.com"
     ],
-    "ultimedia.com": [
-      "sfgate.com"
-    ],
     "undertone.com": [
       "dallasnews.com",
       "alternet.org"
@@ -7584,12 +7956,12 @@
     "unrulymedia.com": [
       "nypost.com",
       "earthlink.net",
-      "boingboing.net",
-      "networkadvertising.org"
+      "boingboing.net"
     ],
     "upravel.com": [
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "upsellit.com": [
       "samsung.com",
@@ -7642,6 +8014,7 @@
       "wired.com",
       "newyorker.com",
       "vogue.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "veinteractive.com": [
@@ -7665,7 +8038,8 @@
     "viafoura.co": [
       "cbc.ca",
       "columbia.edu",
-      "nj.com"
+      "nj.com",
+      "nola.com"
     ],
     "viafoura.net": [
       "cbc.ca"
@@ -7709,6 +8083,8 @@
       "myspace.com",
       "fortune.com",
       "people.com",
+      "time.com",
+      "allrecipes.com",
       "zappos.com"
     ],
     "virgilio.it": [
@@ -7723,7 +8099,9 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru"
+      "ria.ru",
+      "yandex.ru",
+      "sonymobile.com"
     ],
     "vmmpxl.com": [
       "networksolutions.com"
@@ -7732,6 +8110,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "volvelle.tech": [
@@ -7757,9 +8136,6 @@
       "sourceforge.net",
       "hp.com"
     ],
-    "wal.co": [
-      "walmart.com"
-    ],
     "wallst.com": [
       "reuters.com"
     ],
@@ -7778,7 +8154,8 @@
       "goethe.de"
     ],
     "wcfbc.net": [
-      "bild.de"
+      "bild.de",
+      "goethe.de"
     ],
     "weather.com": [
       "wunderground.com"
@@ -7810,13 +8187,13 @@
     "webtrekk.net": [
       "springer.com",
       "localiser-ip.com",
-      "welt.de"
+      "welt.de",
+      "goethe.de"
     ],
     "webtrendslive.com": [
       "nature.com",
       "abc.net.au",
       "oup.com",
-      "ethz.ch",
       "dhl.com"
     ],
     "webvisor.org": [
@@ -7845,6 +8222,7 @@
       "newyorker.com",
       "vanityfair.com",
       "vogue.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "wise.space": [
@@ -7883,6 +8261,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "wnyc.org": [
@@ -7907,8 +8286,7 @@
       "akismet.com",
       "nypost.com",
       "news.com.au",
-      "variety.com",
-      "metro.co.uk"
+      "variety.com"
     ],
     "wrating.com": [
       "163.com",
@@ -7953,12 +8331,14 @@
       "unblog.fr",
       "uefa.com",
       "skyrock.com",
+      "ovh.com",
       "leparisien.fr"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
       "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "xplosion.de": [
       "t-online.de",
@@ -7976,21 +8356,23 @@
       "vk.com",
       "novostimira.com",
       "mail.ru",
-      "rt.com",
+      "narod.ru",
+      "ria.ru",
       "radikal.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
       "rakuten.co.jp",
-      "economist.com"
+      "economist.com",
+      "ocn.ne.jp"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
       "flickr.com",
       "sourceforge.net",
-      "hp.com",
+      "ancestry.com",
       "eset.com"
     ],
     "yandex.ru": [
@@ -7998,7 +8380,8 @@
       "opera.com",
       "stanford.edu",
       "ning.com",
-      "rt.com",
+      "ria.ru",
+      "qip.ru",
       "radikal.ru",
       "kharkov.ua"
     ],
@@ -8018,8 +8401,8 @@
       "spiegel.de",
       "heise.de",
       "faz.net",
-      "t-online.de",
       "springer.com",
+      "home.pl",
       "focus.de"
     ],
     "yieldoptimizer.com": [
@@ -8030,13 +8413,19 @@
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
-      "nytimes.com"
+      "nytimes.com",
+      "dropbox.com",
+      "iop.org",
+      "cnet.com",
+      "sbs.com.au",
+      "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
       "newyorker.com",
-      "pcworld.com"
+      "pcworld.com",
+      "infoworld.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -8061,9 +8450,9 @@
       "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
-      "harvard.edu",
       "caltech.edu",
-      "francetvinfo.fr",
+      "ucr.edu",
+      "onet.pl",
       "honeywell.com"
     ],
     "youvisit.com": [
@@ -8092,7 +8481,8 @@
       "independent.co.uk",
       "thehill.com",
       "farfetch.com",
-      "lemonde.fr",
+      "paypal.com",
+      "orange.fr",
       "infoplease.com"
     ],
     "zendesk.com": [
@@ -8136,5 +8526,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.26"
+  "version": "2018.8.27"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -1,17 +1,5 @@
 {
   "action_map": {
-    "107-coj-713.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538180650544,
-      "userAction": ""
-    },
-    "112-tzm-766.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538394933849,
-      "userAction": ""
-    },
     "112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -42,34 +30,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "194-vvc-221.mktoresp.com": {
+    "247-inc.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538483514256,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "247realmedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "254a.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "2771890.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538368660302,
-      "userAction": ""
-    },
-    "2912a.v.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538256664930,
       "userAction": ""
     },
     "2o7.net": {
@@ -92,7 +62,7 @@
     },
     "360yield.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -108,58 +78,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "4139589.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538385347766,
-      "userAction": ""
-    },
-    "4272175.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538095276395,
-      "userAction": ""
-    },
-    "4292932.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538443166948,
-      "userAction": ""
-    },
-    "4635217.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538206007436,
-      "userAction": ""
-    },
-    "4645712.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538083902504,
-      "userAction": ""
-    },
-    "4d.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538456849026,
-      "userAction": ""
-    },
     "50bang.org": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "5420914.fls.doubleclick.net": {
+    "540-wem-854.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538323409082,
-      "userAction": ""
-    },
-    "5496506.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538531334136,
+      "nextUpdateTime": 1538343204573,
       "userAction": ""
     },
     "58.com": {
@@ -174,130 +102,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "5p4rk13.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "6126321.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538145560460,
-      "userAction": ""
-    },
-    "6901690.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538338401506,
-      "userAction": ""
-    },
     "6sc.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "8117415.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538334719410,
-      "userAction": ""
-    },
-    "8136595.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538150124402,
-      "userAction": ""
-    },
-    "8242400.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538132491651,
-      "userAction": ""
-    },
-    "8329645.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538200870446,
-      "userAction": ""
-    },
-    "899-ihp-202.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538500225994,
-      "userAction": ""
-    },
-    "a.postrelease.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538059890436,
-      "userAction": ""
-    },
-    "a.quora.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538122796132,
-      "userAction": ""
-    },
-    "a.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294298158,
-      "userAction": ""
-    },
-    "a.wishabi.com": {
+    "a8270235338.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538194589363,
-      "userAction": ""
-    },
-    "a2364010203.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538427938823,
-      "userAction": ""
-    },
-    "a6250770393.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538404954879,
-      "userAction": ""
-    },
-    "a6264210458.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538338901088,
-      "userAction": ""
-    },
-    "a7718922374.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538508807697,
-      "userAction": ""
-    },
-    "a8298190319.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538384086156,
-      "userAction": ""
-    },
-    "aa.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538142584062,
+      "nextUpdateTime": 1538228855491,
       "userAction": ""
     },
     "aamsitecertifier.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aax-eu.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538049200350,
       "userAction": ""
     },
     "aaxads.com": {
@@ -308,7 +128,7 @@
     },
     "abmr.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -330,18 +150,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538249417948,
-      "userAction": ""
-    },
-    "acdn.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538062628696,
-      "userAction": ""
-    },
     "acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
@@ -354,16 +162,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "activenetwork-d.openx.net": {
+    "actionnetwork.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538535925079,
-      "userAction": ""
-    },
-    "activenetworks-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538355264350,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acuityplatform.com": {
@@ -372,13 +174,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "acxiomapac.com": {
+    "ad-hatena.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ad-hatena.com": {
+    "ad-plus.cn": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -396,22 +198,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ad.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538277008771,
-      "userAction": ""
-    },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538242542788,
-      "userAction": ""
-    },
-    "ad.wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538425057023,
+      "nextUpdateTime": 1538275124714,
       "userAction": ""
     },
     "adapf.com": {
@@ -421,12 +211,6 @@
       "userAction": ""
     },
     "adc-srv.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adclear.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -450,6 +234,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adfarm.mediaplex.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538220421317,
+      "userAction": ""
+    },
     "adform.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -459,12 +249,6 @@
     "adfox.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -498,10 +282,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admiral.mgr.consensu.org": {
+    "admaster.com.cn": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538420953790,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "admission.net": {
@@ -522,6 +306,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adobecqms.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adobedtm.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -530,7 +320,7 @@
     },
     "adotmob.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -552,64 +342,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538447339353,
-      "userAction": ""
-    },
-    "ads.pubmatic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538496601089,
-      "userAction": ""
-    },
-    "ads.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538445794602,
-      "userAction": ""
-    },
-    "ads.servebom.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538373205501,
-      "userAction": ""
-    },
-    "ads.yap.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538418132951,
-      "userAction": ""
-    },
-    "adsafety.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adscale.de": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adserver-us.adtech.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538488159302,
-      "userAction": ""
-    },
-    "adserver.intentiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538557381542,
-      "userAction": ""
-    },
-    "adservice.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538153556785,
       "userAction": ""
     },
     "adsnative.com": {
@@ -636,21 +372,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtng.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx.com.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -722,7 +446,13 @@
     },
     "allure.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "amap.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -750,46 +480,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "amazonwebservices.d2.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538516307010,
-      "userAction": ""
-    },
-    "amazonwebservicesinc.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538414598582,
-      "userAction": ""
-    },
     "ameba.jp": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ampcid.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538212864175,
-      "userAction": ""
-    },
-    "amplify.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538500466583,
-      "userAction": ""
-    },
-    "amplifypixel.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538293517643,
-      "userAction": ""
-    },
-    "an.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538328395538,
       "userAction": ""
     },
     "ancestry.ca": {
@@ -864,64 +558,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ap.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538225149247,
-      "userAction": ""
-    },
-    "apester.com": {
+    "aol.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "apex.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538364760079,
-      "userAction": ""
-    },
-    "api.adsnative.com": {
+    "apester.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538168277917,
-      "userAction": ""
-    },
-    "api.adsymptotic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538545671107,
-      "userAction": ""
-    },
-    "api.circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538545915720,
-      "userAction": ""
-    },
-    "api.company-target.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538204919804,
-      "userAction": ""
-    },
-    "api.flyertown.ca": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538343500501,
-      "userAction": ""
-    },
-    "api.pymx5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538328923918,
-      "userAction": ""
-    },
-    "api.sabavision.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538058807775,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apis.google.com": {
@@ -939,13 +585,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538267380235,
-      "userAction": ""
-    },
-    "app.vssps.visualstudio.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538349547779,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apple.com": {
@@ -954,15 +594,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aps.hearstnp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538071048301,
-      "userAction": ""
-    },
     "architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -976,36 +610,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "as-sec.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538321865785,
-      "userAction": ""
-    },
-    "as.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538094506065,
-      "userAction": ""
-    },
-    "assets-gulfnews.sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538268936081,
-      "userAction": ""
-    },
-    "assets.adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538518662620,
-      "userAction": ""
-    },
-    "assets.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538397145272,
       "userAction": ""
     },
     "atdmt.com": {
@@ -1022,14 +626,8 @@
     },
     "ati-host.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atlasobscura-travel.t.domdex.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538333342983,
       "userAction": ""
     },
     "att.com": {
@@ -1044,13 +642,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.tags.newscgp.com": {
+    "attvlt2.azurewebsites.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538525497075,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "audtd.com": {
+    "audiencemanager.de": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1064,26 +662,8 @@
     },
     "autopilothq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "b-code.liadm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538297140111,
-      "userAction": ""
-    },
-    "b.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294619765,
-      "userAction": ""
-    },
-    "b1sync.zemanta.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538132077041,
       "userAction": ""
     },
     "baidu.com": {
@@ -1101,13 +681,7 @@
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538443530778,
-      "userAction": ""
-    },
-    "bat.bing.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538247008130,
+      "nextUpdateTime": 1538523364120,
       "userAction": ""
     },
     "baur.de": {
@@ -1128,12 +702,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bdimg.share.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538404525556,
-      "userAction": ""
-    },
     "beemray.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1141,6 +709,12 @@
       "userAction": ""
     },
     "beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "betrad.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1152,28 +726,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bh.contextweb.com": {
+    "bfmtv.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421717180,
-      "userAction": ""
-    },
-    "bid.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538470282368,
-      "userAction": ""
-    },
-    "bid.g.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538243655658,
-      "userAction": ""
-    },
-    "bidder.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538449269932,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "biddingx.com": {
@@ -1200,6 +756,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bitbucket.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1218,15 +780,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "block.lp1block.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538176389447,
-      "userAction": ""
-    },
     "bluecava.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1254,12 +810,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bobo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1268,7 +818,7 @@
     },
     "bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1304,7 +854,7 @@
     },
     "brides.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1320,28 +870,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bs.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538238980390,
-      "userAction": ""
-    },
     "bshare.cn": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bshare.optimix.asia": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538143370691,
-      "userAction": ""
-    },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538135297080,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "btttag.com": {
@@ -1356,46 +894,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "c.adsymptotic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538456439921,
-      "userAction": ""
-    },
-    "c.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538109343951,
-      "userAction": ""
-    },
-    "c.deployads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538317787251,
-      "userAction": ""
-    },
-    "c.jsrdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538549605036,
-      "userAction": ""
-    },
-    "c.pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538231054008,
-      "userAction": ""
-    },
     "c1.neweggimages.com": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538193299183,
-      "userAction": ""
-    },
-    "c2.taboola.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538552135048,
+      "nextUpdateTime": 1538335697441,
       "userAction": ""
     },
     "c212.net": {
@@ -1422,10 +924,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "capture.condenastdigital.com": {
+    "capturehighered.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538149772927,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "carambo.la": {
@@ -1458,106 +960,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cdn-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538505275561,
-      "userAction": ""
-    },
-    "cdn.bizible.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538183210921,
-      "userAction": ""
-    },
-    "cdn.blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538409772024,
-      "userAction": ""
-    },
-    "cdn.digitru.st": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538464924771,
-      "userAction": ""
-    },
-    "cdn.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538502123391,
-      "userAction": ""
-    },
-    "cdn.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538054972489,
-      "userAction": ""
-    },
-    "cdn.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538056897091,
-      "userAction": ""
-    },
     "cdn.native.ai": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538112716764,
-      "userAction": ""
-    },
-    "cdn.oas-c18.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538491657369,
-      "userAction": ""
-    },
-    "cdn.selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538325259903,
-      "userAction": ""
-    },
-    "cdn.siftscience.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538255124011,
-      "userAction": ""
-    },
-    "cdn.static.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538423691203,
-      "userAction": ""
-    },
-    "cdn.taboola.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538052152256,
-      "userAction": ""
-    },
-    "cdn.tinypass.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538350048168,
-      "userAction": ""
-    },
-    "cdn.tynt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538121563634,
-      "userAction": ""
-    },
-    "cdn.viglink.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538552819503,
-      "userAction": ""
-    },
-    "cdn1-res.sundaysky.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538331283935,
+      "nextUpdateTime": 1538359925677,
       "userAction": ""
     },
     "cdnwidget.com": {
@@ -1572,16 +978,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "changeagain.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "checkout.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "checkout.stripe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538056961121,
       "userAction": ""
     },
     "chei.com.cn": {
@@ -1614,16 +1020,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ck.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538079083152,
-      "userAction": ""
-    },
     "ckies.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538290612775,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "clickability.com": {
@@ -1662,16 +1062,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cm.g.doubleclick.net": {
+    "cmgdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538084946321,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cms.tanx.com": {
+    "cmp.smartadserver.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538314445492,
+      "nextUpdateTime": 1538208881807,
+      "userAction": ""
+    },
+    "cmsadmin30.convio.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538440206675,
       "userAction": ""
     },
     "cnet.com": {
@@ -1680,21 +1086,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cnid.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538212613316,
-      "userAction": ""
-    },
-    "cnn.net": {
+    "cntraveler.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cntraveler.com": {
+    "cnzz.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1708,24 +1108,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collecte.audience.acpm.fr": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538216572940,
-      "userAction": ""
-    },
-    "collector-963.tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538075212407,
-      "userAction": ""
-    },
-    "collector-pxbecn7fqx.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538178626553,
       "userAction": ""
     },
     "collegenet.com": {
@@ -1746,28 +1128,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "complex.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "conative.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "config.lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538224661599,
-      "userAction": ""
-    },
     "connatix.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "connect.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538044706175,
       "userAction": ""
     },
     "connexity.net": {
@@ -1782,12 +1164,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consent-pref.trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538382256612,
-      "userAction": ""
-    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1800,16 +1176,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "contextual.media.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538123517033,
-      "userAction": ""
-    },
     "contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "conv-blizzard-emea.cd.serving-sys.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538493335476,
+      "userAction": ""
+    },
+    "conv-blizzard-na.cd.serving-sys.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538480483471,
       "userAction": ""
     },
     "convertro.com": {
@@ -1818,22 +1200,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "core.connatix.com": {
+    "convio.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538077162990,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cornell.edu": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "counter.yadro.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538315953930,
       "userAction": ""
     },
     "coxmediagroup.com": {
@@ -1849,6 +1225,12 @@
       "userAction": ""
     },
     "creativecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecommons.org": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1878,40 +1260,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ct.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538334484197,
-      "userAction": ""
-    },
-    "cx.atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538107799509,
-      "userAction": ""
-    },
     "cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d.company-target.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538510704544,
-      "userAction": ""
-    },
-    "d.la1-c2-dfw.salesforceliveagent.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538196982209,
-      "userAction": ""
-    },
-    "d.turn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294378750,
       "userAction": ""
     },
     "d1af033869koo7.cloudfront.net": {
@@ -1944,13 +1296,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "data.dianomi.com": {
+    "datamind.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538215972432,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datamind.ru": {
+    "daum.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1960,24 +1312,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dc.ads.linkedin.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538143536390,
-      "userAction": ""
-    },
-    "decajo.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538503040838,
-      "userAction": ""
-    },
-    "delivery.zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538180066266,
       "userAction": ""
     },
     "demdex.net": {
@@ -2016,22 +1350,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "display.apester.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538272371129,
       "userAction": ""
     },
     "disqus.com": {
@@ -2052,13 +1374,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dmx.districtm.io": {
+    "dmxleo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538077158657,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dmxleo.com": {
+    "dnnapi.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2067,12 +1389,6 @@
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dol.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2106,12 +1422,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dpm.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538127110451,
-      "userAction": ""
-    },
     "dpmsrv.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -2124,22 +1434,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dt.admission.net": {
+    "dsp.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538348346597,
-      "userAction": ""
-    },
-    "dt.cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538296791629,
-      "userAction": ""
-    },
-    "dx.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538412044496,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynad.net": {
@@ -2160,10 +1458,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "e-2072.adzerk.net": {
+    "ebay-us.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538325723457,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ebay.com": {
@@ -2174,7 +1472,7 @@
     },
     "ebayrtm.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2184,28 +1482,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "echo.intergient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538161191136,
-      "userAction": ""
-    },
-    "eclick.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421526521,
-      "userAction": ""
-    },
     "edge-cdn.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "edge.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538303768684,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -2232,33 +1512,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "embed.sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538199320008,
-      "userAction": ""
-    },
     "emlgrid.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "engage.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538534356108,
-      "userAction": ""
-    },
-    "engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538467483460,
-      "userAction": ""
-    },
     "epicurious.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2268,28 +1530,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eset.marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538430898085,
-      "userAction": ""
-    },
-    "eset.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538356537340,
-      "userAction": ""
-    },
     "estat.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "events.mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538345920195,
       "userAction": ""
     },
     "everesttech.net": {
@@ -2298,10 +1542,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "everydayhealth.demdex.net": {
+    "everyaction.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538552306958,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "evise.com": {
@@ -2313,13 +1557,13 @@
     "evvnt-api.global.ssl.fastly.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538336434789,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ewscripps.hb.omtrdc.net": {
+    "ew3.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538506157825,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "exactag.com": {
@@ -2338,12 +1582,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "experience.tinypass.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538171166728,
       "userAction": ""
     },
     "eyeota.net": {
@@ -2382,18 +1620,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fastlane-adv.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538455076395,
-      "userAction": ""
-    },
-    "fastlane.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538277861999,
-      "userAction": ""
-    },
     "fdlstatic.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2426,7 +1652,7 @@
     },
     "firstimpression.io": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2448,12 +1674,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538174863248,
-      "userAction": ""
-    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -2472,12 +1692,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "forms.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538138908700,
-      "userAction": ""
-    },
     "formstack.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2490,6 +1704,18 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "foxbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxsports.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "foxycart.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2497,6 +1723,18 @@
       "userAction": ""
     },
     "freshdesk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "friendbuy.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "funnyordie.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2514,43 +1752,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.3gl.net": {
+    "g.cn.miaozhen.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538410704427,
+      "nextUpdateTime": 1538491763887,
       "userAction": ""
     },
-    "g.ign.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538148864057,
-      "userAction": ""
-    },
-    "gateway.answerscloud.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538395883518,
-      "userAction": ""
-    },
-    "gemius.pl": {
+    "geetest.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "geocoding.internetbrands.com": {
+    "gemius.pl": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538536149847,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "geolocation.onetrust.com": {
+    "gentags.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538218189361,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "getclicky.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getsmartcontent.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2570,7 +1802,7 @@
     },
     "glamour.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2578,6 +1810,12 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gmglobalcorporatefunctions.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538558542584,
       "userAction": ""
     },
     "go.com": {
@@ -2588,7 +1826,7 @@
     },
     "golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2607,19 +1845,13 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538370377555,
+      "nextUpdateTime": 1538340601964,
       "userAction": ""
     },
     "gq.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "graph.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538295132337,
       "userAction": ""
     },
     "gridsumdissector.com": {
@@ -2640,15 +1872,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gslbeacon.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538471693280,
-      "userAction": ""
-    },
     "gtags.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2664,10 +1890,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gwiqcdn.globalwebindex.net": {
+    "gxbr.cnzz.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538329164909,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538181812392,
       "userAction": ""
     },
     "hatena.com": {
@@ -2682,10 +1908,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hbopenbid.pubmatic.com": {
+    "hdslb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538228306081,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "healte.de": {
@@ -2718,10 +1944,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hm.baidu.com": {
+    "hiwoenrep.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538383968817,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "horyzon-media.com": {
@@ -2730,9 +1956,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "huanqiu.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hubpd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "hubspot.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huffingtonpost.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2754,34 +1998,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "i.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538433396017,
-      "userAction": ""
-    },
-    "i.tianqi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538262509948,
-      "userAction": ""
-    },
     "iasds01.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ib.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538182536434,
       "userAction": ""
     },
     "ibclick.stream": {
@@ -2802,34 +2022,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "id.rlcdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538459618997,
-      "userAction": ""
-    },
     "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "idealmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "identityssl.newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538550188509,
-      "userAction": ""
-    },
-    "idsync.rlcdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538467403404,
       "userAction": ""
     },
     "ign.com": {
@@ -2856,12 +2052,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "img.purch.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "imgur.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2880,22 +2070,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "in.getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538484989853,
-      "userAction": ""
-    },
     "infinity-tracking.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "infinityid.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538163838777,
       "userAction": ""
     },
     "inq.com": {
@@ -2904,10 +2082,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "insight.adsrvr.org": {
+    "inquisitr.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538092323704,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -2922,15 +2100,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "insticator-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538177453642,
-      "userAction": ""
-    },
     "instinctiveads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2964,12 +2136,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "investing-channel-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538398006786,
-      "userAction": ""
-    },
     "investingchannel.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2996,38 +2162,26 @@
     },
     "iperceptions.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ipinyou.com": {
+      "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "ipredictive.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ips-invite.iperceptions.com": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538513891249,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "irs01.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "italiaonline01.wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538262101357,
-      "userAction": ""
-    },
-    "jadserve.postrelease.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538426276329,
       "userAction": ""
     },
     "janrainsso.com": {
@@ -3050,20 +2204,14 @@
     },
     "jrs5.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "js.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538190129186,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1538279062905,
+      "nextUpdateTime": 1538500509571,
       "userAction": ""
     },
     "jsrdn.com": {
@@ -3073,6 +2221,12 @@
       "userAction": ""
     },
     "justuno.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kakao.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3159,7 +2313,7 @@
     "leadintel.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538046595757,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "leadlander.com": {
@@ -3168,21 +2322,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "legocdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licasd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3234,12 +2376,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "live.sekindo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538332400243,
-      "userAction": ""
-    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3258,18 +2394,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load.sumo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538194386904,
-      "userAction": ""
-    },
-    "loadus.exelator.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538189709302,
-      "userAction": ""
-    },
     "loc.gov": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3279,19 +2403,7 @@
     "lockerdome.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538146284566,
-      "userAction": ""
-    },
-    "log.mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538355091856,
-      "userAction": ""
-    },
-    "login.dotomi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538513913912,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "logly.co.jp": {
@@ -3300,28 +2412,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "logs11.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538403190845,
-      "userAction": ""
-    },
-    "logs1136.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538251719016,
-      "userAction": ""
-    },
     "lp1block.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lptag.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538533427768,
       "userAction": ""
     },
     "lqm.io": {
@@ -3348,9 +2442,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "madeleine.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mail.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mailchimp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3380,7 +2486,7 @@
     },
     "marketlinc.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3388,18 +2494,6 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "match.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538200836706,
-      "userAction": ""
-    },
-    "match.prod.bidr.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538339384874,
       "userAction": ""
     },
     "matheranalytics.com": {
@@ -3414,6 +2508,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mct01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "media.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3424,12 +2524,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediadc-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538439252020,
       "userAction": ""
     },
     "mediaforge.com": {
@@ -3446,19 +2540,13 @@
     },
     "mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "mediav.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediawallahscript.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3481,12 +2569,6 @@
       "userAction": ""
     },
     "metadsp.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mfadsrvr.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3528,12 +2610,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mid.rkdms.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538247909740,
-      "userAction": ""
-    },
     "mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3543,7 +2619,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538394141616,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mmstat.com": {
@@ -3594,12 +2670,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mssl.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538487358307,
-      "userAction": ""
-    },
     "mt0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3610,12 +2680,6 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtrx.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538555902065,
       "userAction": ""
     },
     "mts0.google.com": {
@@ -3654,6 +2718,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "myhard.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mynativeplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3678,12 +2748,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "nasdaq.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3700,12 +2764,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "native.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538320667027,
       "userAction": ""
     },
     "nativendo.de": {
@@ -3726,15 +2784,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nbcu.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538463121539,
-      "userAction": ""
-    },
     "nbcuni.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "netmng.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3758,13 +2816,13 @@
     },
     "news.com.au": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "newscdn.com.au": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3772,12 +2830,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newscorpau.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421923960,
       "userAction": ""
     },
     "newsinc.com": {
@@ -3800,7 +2852,7 @@
     },
     "newyorker.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3820,6 +2872,12 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "now.eloqua.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538366209349,
       "userAction": ""
     },
     "nr-data.net": {
@@ -3846,10 +2904,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oasc10.247realmedia.com": {
+    "oath.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538268830533,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ocdn.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "office.com": {
@@ -3859,12 +2923,6 @@
       "userAction": ""
     },
     "office365.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ojrq.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3894,12 +2952,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "omnidsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "omnitagjs.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3922,12 +2974,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onetag.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538426323108,
       "userAction": ""
     },
     "onetrust.com": {
@@ -3978,12 +3024,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ophan.theguardian.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538371630281,
-      "userAction": ""
-    },
     "opinionstage.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4006,6 +3046,12 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optout.betrad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538300013262,
       "userAction": ""
     },
     "ora.tv": {
@@ -4050,22 +3096,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "p.dlx.addthis.com": {
+    "paddle.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538076392629,
-      "userAction": ""
-    },
-    "p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538159006482,
-      "userAction": ""
-    },
-    "p2.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538075969602,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pardot.com": {
@@ -4098,12 +3132,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pd.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538125278981,
-      "userAction": ""
-    },
     "performgroup.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4116,28 +3144,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "phonograph2.voxmedia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538254593492,
-      "userAction": ""
-    },
     "photobucket.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pi.pardot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538374590064,
-      "userAction": ""
-    },
-    "pic.fastapi.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538255329652,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -4170,36 +3180,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pixel.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538133315883,
-      "userAction": ""
-    },
-    "pixel.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538133366404,
-      "userAction": ""
-    },
-    "pixel.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538522752196,
-      "userAction": ""
-    },
-    "pixel.sitescout.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538192671832,
-      "userAction": ""
-    },
-    "pixel.zprk.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538486726252,
-      "userAction": ""
-    },
     "piximedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4210,18 +3190,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "platform-api.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538056097475,
-      "userAction": ""
-    },
-    "platform.linkedin.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538260131857,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -4236,28 +3204,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.performgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538214631976,
-      "userAction": ""
-    },
-    "player.vimeo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538362569129,
-      "userAction": ""
-    },
     "players.brightcove.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "playwire-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538319307097,
       "userAction": ""
     },
     "plista.com": {
@@ -4275,25 +3225,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538187345852,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "popsugar-assets.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538418412765,
-      "userAction": ""
-    },
-    "postmedia.us.janrainsso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538174985349,
       "userAction": ""
     },
     "postrelease.com": {
@@ -4309,12 +3247,6 @@
       "userAction": ""
     },
     "pressboard.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "prfct.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4356,22 +3288,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "proximus.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538427583405,
-      "userAction": ""
-    },
     "pub.network": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubads.g.doubleclick.net": {
+    "publishme.se": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538202489440,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -4394,12 +3320,6 @@
     },
     "purch.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "purechat.com": {
-      "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
@@ -4413,13 +3333,7 @@
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538206203762,
-      "userAction": ""
-    },
-    "px.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538460515426,
+      "nextUpdateTime": 1538262359887,
       "userAction": ""
     },
     "pxi.pub": {
@@ -4431,12 +3345,12 @@
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538200483882,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "qq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4444,12 +3358,6 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantcast.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538327762416,
       "userAction": ""
     },
     "quantserve.com": {
@@ -4476,12 +3384,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.turn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538114432566,
-      "userAction": ""
-    },
     "rackcdn.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4494,21 +3396,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "rakuten.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rcom.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538208445032,
-      "userAction": ""
-    },
     "reachmax.cn": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4530,7 +3432,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "republer.com": {
+    "render.githubusercontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "researchintel.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4548,15 +3456,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "reutersmedia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "revcontent.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4568,7 +3470,7 @@
     },
     "rezync.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4626,46 +3528,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rp.gwallet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294745257,
-      "userAction": ""
-    },
-    "rqtrk.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rs.gwallet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538129421105,
-      "userAction": ""
-    },
-    "rss.art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538167421505,
-      "userAction": ""
-    },
-    "rtb.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538352452690,
-      "userAction": ""
-    },
     "rtk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtve.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538202862196,
       "userAction": ""
     },
     "ru4.com": {
@@ -4680,88 +3546,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rudy.adsnative.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538152569067,
-      "userAction": ""
-    },
-    "rutarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "s-static.ak.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "s.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538369224004,
-      "userAction": ""
-    },
-    "s.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538062771361,
-      "userAction": ""
-    },
-    "s.clickability.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538478226394,
-      "userAction": ""
-    },
-    "s.effectivemeasure.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538149322611,
-      "userAction": ""
-    },
-    "s.nexac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538515216122,
-      "userAction": ""
-    },
-    "s.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538221863124,
-      "userAction": ""
-    },
-    "s.spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538331458176,
-      "userAction": ""
-    },
-    "s.thebrighttag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538183045497,
-      "userAction": ""
-    },
-    "s1061485456.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538180635780,
-      "userAction": ""
-    },
-    "s118899503.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538367243127,
-      "userAction": ""
-    },
-    "s2208.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538366295174,
       "userAction": ""
     },
     "s3-us-west-2.amazonaws.com": {
@@ -4770,10 +3558,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "s7.addthis.com": {
+    "s3xified.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538491765915,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sabavision.com": {
@@ -4806,34 +3594,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "samplicio.us": {
+    "scarabresearch.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sb-stage.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538303818062,
-      "userAction": ""
-    },
-    "sb.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538237980451,
-      "userAction": ""
-    },
-    "sbnationbidder-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538343887161,
-      "userAction": ""
-    },
-    "scdn.cxense.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538475610945,
       "userAction": ""
     },
     "scholarlyiq.com": {
@@ -4878,34 +3642,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "scribd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scripps.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538500013668,
-      "userAction": ""
-    },
-    "scripps.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538350668625,
-      "userAction": ""
-    },
     "script.ioam.de": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sdc-qczj.pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538490872689,
       "userAction": ""
     },
     "sdp-campaign.de": {
@@ -4914,100 +3654,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "search.spotxchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538422064517,
-      "userAction": ""
-    },
     "search.yahoo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "seccdn-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538546208242,
-      "userAction": ""
-    },
-    "secure-assets.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538187034130,
-      "userAction": ""
-    },
-    "secure-dcr.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538214152681,
-      "userAction": ""
-    },
-    "secure-ds.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538262143169,
-      "userAction": ""
-    },
-    "secure-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538371117898,
-      "userAction": ""
-    },
-    "secure-it.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538367254534,
-      "userAction": ""
-    },
-    "secure-us.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538062926851,
-      "userAction": ""
-    },
-    "secure.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538515294111,
-      "userAction": ""
-    },
-    "secure.livechatinc.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538269531819,
-      "userAction": ""
-    },
-    "secure.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538219869201,
-      "userAction": ""
-    },
-    "secure.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538453154129,
-      "userAction": ""
-    },
     "securedvisit.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "securepubads.g.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538165745281,
-      "userAction": ""
-    },
-    "segapi.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538077819865,
       "userAction": ""
     },
     "sekindo.com": {
@@ -5024,7 +3680,7 @@
     },
     "self.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5040,10 +3696,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servedby.flashtalking.com": {
+    "servedby-buysellads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538477934971,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "serverbid.com": {
@@ -5056,12 +3712,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "session.timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421892505,
       "userAction": ""
     },
     "sessioncam.com": {
@@ -5108,7 +3758,7 @@
     },
     "simpli.fi": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5157,7 +3807,7 @@
     "sjs.bizographics.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538374333246,
+      "nextUpdateTime": 1538321907146,
       "userAction": ""
     },
     "skimresources.com": {
@@ -5182,12 +3832,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartlock.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538354484555,
       "userAction": ""
     },
     "smashing-delivery.herokuapp.com": {
@@ -5244,22 +3888,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sohu.irs01.com": {
+    "sohu.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538175757124,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sokrati.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solarwinds.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538167927210,
       "userAction": ""
     },
     "sonobi.com": {
@@ -5274,12 +3912,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sp.analytics.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538339922746,
-      "userAction": ""
-    },
     "sphereup.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5289,6 +3921,18 @@
     "spiceworks.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spineuniverse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spingo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5330,7 +3974,7 @@
     },
     "springernature.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5346,46 +3990,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-09-26-09.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538359586941,
-      "userAction": ""
-    },
-    "srv-2018-09-26-09.pixel.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538445425688,
-      "userAction": ""
-    },
-    "srv-2018-09-26-10.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538474458903,
-      "userAction": ""
-    },
-    "srv.au.ebayrtm.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538460842793,
-      "userAction": ""
-    },
     "srx.com.sg": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sslwidget.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538250386292,
-      "userAction": ""
-    },
-    "st.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538512151649,
       "userAction": ""
     },
     "stackadapt.com": {
@@ -5394,34 +4002,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "stanza-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538238071781,
-      "userAction": ""
-    },
     "statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "static.bshare.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538407047481,
-      "userAction": ""
-    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538438476744,
-      "userAction": ""
-    },
-    "static.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538374661983,
+      "nextUpdateTime": 1538398711735,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -5433,13 +4023,7 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538123969054,
-      "userAction": ""
-    },
-    "statse.webtrendslive.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538383272999,
+      "nextUpdateTime": 1538480363136,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -5490,7 +4074,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "suning.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "suning.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sunrtb.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5502,64 +4098,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "survata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "survey.g.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538409550581,
-      "userAction": ""
-    },
     "surveymonkey.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "svcs.ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538325865068,
-      "userAction": ""
-    },
-    "sw88.go.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538045911214,
-      "userAction": ""
-    },
     "switchadhub.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "symantec.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sync.adaptv.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538159389370,
-      "userAction": ""
-    },
-    "sync.graph.bluecava.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538100879756,
-      "userAction": ""
-    },
-    "sync.search.spotxchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538407016386,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -5578,30 +4126,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tag.bounceexchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538489495789,
-      "userAction": ""
-    },
-    "tag.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538210741846,
-      "userAction": ""
-    },
-    "tag.placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538095525832,
-      "userAction": ""
-    },
-    "tags.news.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538246007029,
       "userAction": ""
     },
     "tailtarget.com": {
@@ -5634,28 +4158,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tap-secure.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538492207266,
-      "userAction": ""
-    },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tapestry.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538235641061,
-      "userAction": ""
-    },
-    "target.smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538428202945,
       "userAction": ""
     },
     "tawk.to": {
@@ -5664,7 +4170,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "taylorandfrancis.com": {
+    "teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5684,7 +4190,7 @@
     },
     "teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5712,18 +4218,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thrtle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thunder.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538123580474,
-      "userAction": ""
-    },
     "tianqi.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5748,12 +4242,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "timeinc.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538072239103,
-      "userAction": ""
-    },
     "timewarnercable.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5769,18 +4257,6 @@
     "tiqcdn.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tlx.3lift.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538202979002,
-      "userAction": ""
-    },
-    "tm-awx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5802,19 +4278,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "track.adform.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538111155067,
-      "userAction": ""
-    },
-    "track.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538073273875,
-      "userAction": ""
-    },
     "tradelab.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "traffic-media.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5862,12 +4332,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trends.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538067659492,
-      "userAction": ""
-    },
     "tribalfusion.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -5880,22 +4344,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "triblive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tripadvisor.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trk.connatix.com": {
+    "trk.mct01.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538056981974,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538388427712,
       "userAction": ""
     },
     "tronc.com": {
@@ -5922,16 +4380,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trustpilot.com": {
+    "tumblr.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tt.onthe.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538407164376,
       "userAction": ""
     },
     "turn.com": {
@@ -5949,12 +4401,6 @@
     "tvsquared.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "twimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5982,12 +4428,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "uconnect.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538086919054,
-      "userAction": ""
-    },
     "ucoz.net": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5997,19 +4437,13 @@
     "udmserve.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538457145899,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ugdturner.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unagi-eu.amazon.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538257470790,
       "userAction": ""
     },
     "undertone.com": {
@@ -6038,7 +4472,7 @@
     },
     "upsellit.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6048,13 +4482,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us-u.openx.net": {
+    "usa.gov": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538339771741,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "usa.gov": {
+    "useproof.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -6081,19 +4515,19 @@
     "utarget.pro": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538409562664,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "utarget.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538382140645,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "uuidksinc.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538344768057,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "v-biz.com.ua": {
@@ -6102,9 +4536,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "v.admaster.com.cn": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538367082123,
+      "userAction": ""
+    },
     "vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6120,10 +4560,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vendorlist.consensu.org": {
+    "verticalhealth.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538143303737,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "viafoura.co": {
@@ -6210,10 +4650,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vop.sundaysky.com": {
+    "volvelle.tech": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538418284544,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -6222,15 +4662,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "w.soundcloud.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538264689912,
-      "userAction": ""
-    },
     "w55c.net": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6240,22 +4674,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wal.wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538507015629,
-      "userAction": ""
-    },
     "wallst.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wamfactory.solution.weborama.fr": {
+    "waptime.cn": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538404424123,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "warnerbros.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wbtrk.net": {
@@ -6300,12 +4734,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "webservices.webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538420584854,
-      "userAction": ""
-    },
     "websimages.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6336,22 +4764,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "welt.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "whistleout.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "widget.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538468993614,
       "userAction": ""
     },
     "wikia-services.com": {
@@ -6384,6 +4800,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wishpond.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "wistia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6410,14 +4832,8 @@
     },
     "wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wms-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538561096392,
       "userAction": ""
     },
     "wnyc.org": {
@@ -6456,18 +4872,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ws.sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538093572796,
-      "userAction": ""
-    },
-    "ws.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538495803032,
-      "userAction": ""
-    },
     "wsj.net": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6486,58 +4890,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "www.allure.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538510946198,
-      "userAction": ""
-    },
-    "www.architecturaldigest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538087322367,
-      "userAction": ""
-    },
-    "www.beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538073326388,
-      "userAction": ""
-    },
     "www.bing.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "www.bonappetit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538446372221,
-      "userAction": ""
-    },
-    "www.brides.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538493655891,
-      "userAction": ""
-    },
-    "www.cntraveler.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538123690650,
-      "userAction": ""
-    },
-    "www.dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538195644309,
-      "userAction": ""
-    },
-    "www.epicurious.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538168960663,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -6546,100 +4902,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "www.glamour.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538116834884,
-      "userAction": ""
-    },
-    "www.golfdigest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538157891279,
-      "userAction": ""
-    },
     "www.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "www.gq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538093232146,
-      "userAction": ""
-    },
-    "www.iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538193507860,
-      "userAction": ""
-    },
-    "www.lightboxcdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538121151651,
-      "userAction": ""
-    },
-    "www.newyorker.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538278936690,
-      "userAction": ""
-    },
-    "www.proximus.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538480707132,
-      "userAction": ""
-    },
-    "www.self.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538341119642,
-      "userAction": ""
-    },
-    "www.teenvogue.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538191505978,
-      "userAction": ""
-    },
-    "www.tns-counter.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538165597564,
-      "userAction": ""
-    },
-    "www.vanityfair.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538511390052,
-      "userAction": ""
-    },
-    "www.vogue.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538445532831,
-      "userAction": ""
-    },
-    "www.wired.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538290704894,
-      "userAction": ""
-    },
-    "www.wmagazine.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538343058111,
-      "userAction": ""
-    },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538182668807,
+      "nextUpdateTime": 1538427419875,
       "userAction": ""
     },
     "wwwimages.adobe.com": {
@@ -6648,13 +4920,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "x.bidswitch.net": {
+    "xad.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538550095595,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "xad.com": {
+    "xg4ken.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xinhuanet.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -6690,6 +4968,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "xtgreat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "y3.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6714,6 +4998,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yahoosmallbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6723,7 +5013,7 @@
     "yastatic.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538421382254,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "yieldlab.net": {
@@ -6764,7 +5054,7 @@
     },
     "youvisit.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6772,18 +5062,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "z-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538367319132,
-      "userAction": ""
-    },
-    "za-cdn.effectivemeasure.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538234483947,
       "userAction": ""
     },
     "zdbb.net": {
@@ -6794,7 +5072,7 @@
     },
     "zedo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6807,6 +5085,12 @@
     "zergnet.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zhaopin.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6848,12 +5132,12 @@
     "15gifts.com": [
       "thetimes.co.uk"
     ],
+    "247-inc.net": [
+      "marriott.com"
+    ],
     "247realmedia.com": [
       "bmj.com",
       "americanbar.org"
-    ],
-    "254a.com": [
-      "tinyurl.com"
     ],
     "2o7.net": [
       "cdc.gov",
@@ -6861,19 +5145,20 @@
       "fastcompany.com"
     ],
     "33across.com": [
-      "accuweather.com"
+      "salon.com"
     ],
     "360.cn": [
       "so.com"
     ],
     "360yield.com": [
+      "telegraph.co.uk",
       "springer.com",
       "home.pl"
     ],
     "3gl.net": [
       "go.com",
       "economist.com",
-      "sfgate.com"
+      "thedailybeast.com"
     ],
     "3lift.com": [
       "msn.com",
@@ -6889,9 +5174,6 @@
     "58cdn.com.cn": [
       "ganji.com"
     ],
-    "5p4rk13.com": [
-      "sfu.ca"
-    ],
     "6sc.co": [
       "brightcove.com"
     ],
@@ -6901,10 +5183,10 @@
       "post-gazette.com"
     ],
     "aaxads.com": [
-      "forbes.com",
       "speedtest.net"
     ],
     "abmr.net": [
+      "paypal.com",
       "nike.com",
       "freetype.org"
     ],
@@ -6917,29 +5199,32 @@
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "leparisien.fr"
+      "liberation.fr"
     ],
     "acquia.com": [
       "panasonic.com",
       "osu.edu",
       "amd.com"
     ],
+    "actionnetwork.org": [
+      "dailykos.com"
+    ],
     "acuityplatform.com": [
       "medscape.com"
     ],
-    "acxiomapac.com": [
-      "businessinsider.com",
-      "npr.org"
-    ],
     "ad-hatena.com": [
       "hatena.ne.jp"
+    ],
+    "ad-plus.cn": [
+      "sohu.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com"
+      "huanqiu.com",
+      "yesky.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
@@ -6947,33 +5232,27 @@
     "adc-srv.net": [
       "autodesk.com"
     ],
-    "adclear.net": [
-      "t-online.de"
-    ],
     "addroplet.com": [
-      "tinypic.com",
+      "wallinside.com",
       "washingtonexaminer.com"
     ],
     "addthis.com": [
-      "nasa.gov",
       "who.int",
-      "npr.org"
+      "columbia.edu",
+      "uci.edu"
     ],
     "adentifi.com": [
       "metmuseum.org"
     ],
     "adform.net": [
-      "forbes.com",
-      "imdb.com",
-      "t-online.de"
+      "t-online.de",
+      "bloomberg.com",
+      "telegraph.co.uk"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
       "sputniknews.com"
-    ],
-    "adhigh.net": [
-      "rambler.ru"
     ],
     "adingo.jp": [
       "seesaa.jp"
@@ -6981,7 +5260,7 @@
     "adition.com": [
       "t-online.de",
       "dailymotion.com",
-      "lemonde.fr"
+      "spiegel.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -6992,57 +5271,63 @@
       "space.com",
       "howtogeek.com"
     ],
+    "admaster.com.cn": [
+      "sohu.com",
+      "yesky.com",
+      "bshare.cn"
+    ],
     "admission.net": [
       "edmunds.com"
     ],
     "adnxs.com": [
       "sourceforge.net",
       "nytimes.com",
-      "forbes.com"
+      "dropbox.com"
     ],
     "adobe.com": [
       "behance.net",
       "history.com",
       "nbc.com"
     ],
+    "adobecqms.net": [
+      "gopro.com"
+    ],
     "adobedtm.com": [
       "newyorker.com",
-      "symantec.com",
-      "worldbank.org"
+      "worldbank.org",
+      "nbcnews.com"
     ],
     "adotmob.com": [
-      "variety.com",
-      "standard.co.uk"
+      "dailymotion.com",
+      "nypost.com",
+      "variety.com"
     ],
     "adriver.ru": [
       "liveinternet.ru",
       "sputniknews.com",
-      "rambler.ru"
+      "ria.ru"
     ],
     "adroll.com": [
+      "nginx.org",
       "photobucket.com",
-      "cloudflare.com",
-      "ning.com"
+      "cloudflare.com"
     ],
     "adrta.com": [
       "seesaa.jp"
     ],
-    "adsafety.net": [
-      "npr.org"
-    ],
     "adscale.de": [
       "t-online.de",
-      "springer.com",
-      "home.pl"
+      "telegraph.co.uk",
+      "springer.com"
     ],
     "adsnative.com": [
+      "thehill.com",
       "squareup.com",
-      "informationweek.com",
-      "bostonherald.com"
+      "informationweek.com"
     ],
     "adsrvr.org": [
+      "adobe.com",
       "sourceforge.net",
-      "nytimes.com",
       "forbes.com"
     ],
     "adswizz.com": [
@@ -7051,20 +5336,14 @@
       "tunein.com"
     ],
     "adsymptotic.com": [
-      "forbes.com",
-      "wsj.com",
-      "etsy.com"
-    ],
-    "adtng.com": [
-      "pornhub.com"
+      "tinyurl.com",
+      "etsy.com",
+      "tripadvisor.com"
     ],
     "advertising.com": [
       "yahoo.com",
-      "nytimes.com",
-      "msn.com"
-    ],
-    "adx.com.ru": [
-      "rambler.ru"
+      "wsj.com",
+      "huffingtonpost.com"
     ],
     "adzerk.net": [
       "asp.net"
@@ -7076,9 +5355,9 @@
       "autodesk.com"
     ],
     "agkn.com": [
-      "imdb.com",
-      "bloomberg.com",
-      "cnet.com"
+      "cnet.com",
+      "businessinsider.com",
+      "dailymotion.com"
     ],
     "akamaihd.net": [
       "forbes.com",
@@ -7103,7 +5382,8 @@
       "sohu.com"
     ],
     "alipay.com": [
-      "youku.com"
+      "youku.com",
+      "taobao.com"
     ],
     "aliyun.com": [
       "alibabacloud.com",
@@ -7111,13 +5391,15 @@
     ],
     "allure.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
+    ],
+    "amap.com": [
+      "zhaopin.com"
     ],
     "amazon-adsystem.com": [
-      "forbes.com",
-      "imdb.com",
-      "washingtonpost.com"
+      "amazon.com",
+      "vimeo.com",
+      "nytimes.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -7125,8 +5407,7 @@
     "amazon.com": [
       "imdb.com",
       "amazon.co.uk",
-      "amazon.de",
-      "amazon.es"
+      "amazon.de"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -7162,14 +5443,19 @@
       "answers.com"
     ],
     "answerscloud.com": [
+      "worldbank.org",
       "acs.org",
-      "fbi.gov",
-      "uscourts.gov"
+      "fbi.gov"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
+    "aol.com": [
+      "techcrunch.com"
+    ],
     "apester.com": [
+      "inquisitr.com",
+      "searchenginewatch.com",
       "nme.com"
     ],
     "apn.co.nz": [
@@ -7187,8 +5473,7 @@
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
@@ -7207,16 +5492,22 @@
     ],
     "ati-host.net": [
       "bbc.com",
-      "straitstimes.com"
+      "straitstimes.com",
+      "thestar.com.my"
     ],
     "att.com": [
       "att.net"
     ],
-    "audtd.com": [
-      "rambler.ru"
+    "attvlt2.azurewebsites.net": [
+      "att.com"
+    ],
+    "audiencemanager.de": [
+      "macrumors.com"
     ],
     "autopilothq.com": [
-      "typeform.com"
+      "bitbucket.org",
+      "typeform.com",
+      "atlassian.com"
     ],
     "baidu.com": [
       "sina.com.cn",
@@ -7241,15 +5532,23 @@
     ],
     "beian.gov.cn": [
       "dzwww.com",
+      "ku6.com",
       "qianlong.com"
+    ],
+    "betrad.com": [
+      "gm.com"
     ],
     "bfmio.com": [
       "tinypic.com",
       "livescience.com",
       "space.com"
     ],
+    "bfmtv.com": [
+      "liberation.fr"
+    ],
     "biddingx.com": [
-      "sina.com.cn"
+      "sina.com.cn",
+      "sohu.com"
     ],
     "bidr.io": [
       "adobe.com",
@@ -7257,14 +5556,17 @@
       "dailymotion.com"
     ],
     "bidswitch.net": [
-      "forbes.com",
-      "tinyurl.com",
-      "imdb.com"
+      "dropbox.com",
+      "telegraph.co.uk",
+      "time.com"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
       "weebly.com"
+    ],
+    "bitbucket.org": [
+      "atlassian.com"
     ],
     "bizible.com": [
       "cloudflare.com",
@@ -7282,9 +5584,8 @@
       "people.com"
     ],
     "bluecava.com": [
-      "wsj.com",
       "giphy.com",
-      "active.com"
+      "walmart.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
@@ -7301,9 +5602,6 @@
       "bravenet.com",
       "jigsy.com"
     ],
-    "bobo.com": [
-      "163.com"
-    ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
@@ -7311,8 +5609,7 @@
     ],
     "bonappetit.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "boston.com": [
       "bostonglobe.com"
@@ -7330,8 +5627,7 @@
     ],
     "brides.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "brightcove.com": [
       "aarp.org",
@@ -7340,16 +5636,16 @@
     ],
     "brightcove.net": [
       "lonelyplanet.com",
-      "thetimes.co.uk",
-      "thenational.ae"
+      "techtarget.com",
+      "thetimes.co.uk"
     ],
     "bshare.cn": [
       "qianlong.com"
     ],
     "bttrack.com": [
+      "nypost.com",
       "livescience.com",
-      "variety.com",
-      "hpe.com"
+      "variety.com"
     ],
     "btttag.com": [
       "samsung.com",
@@ -7367,13 +5663,18 @@
     "cadreon.com": [
       "economist.com"
     ],
+    "capturehighered.net": [
+      "ku.edu",
+      "unm.edu"
+    ],
     "carambo.la": [
+      "salon.com",
       "accuweather.com"
     ],
     "casalemedia.com": [
-      "imdb.com",
       "washingtonpost.com",
-      "bloomberg.com"
+      "myspace.com",
+      "telegraph.co.uk"
     ],
     "cbsi.com": [
       "cnet.com",
@@ -7393,6 +5694,9 @@
     "cern.ch": [
       "home.cern"
     ],
+    "changeagain.me": [
+      "iconosquare.com"
+    ],
     "chei.com.cn": [
       "chsi.com.cn"
     ],
@@ -7410,7 +5714,8 @@
       "stltoday.com"
     ],
     "civicscience.com": [
-      "post-gazette.com"
+      "post-gazette.com",
+      "knowyourmeme.com"
     ],
     "ckies.net": [
       "abril.com.br"
@@ -7431,16 +5736,18 @@
       "sciencemag.org",
       "uci.edu"
     ],
+    "cmgdigital.com": [
+      "ajc.com"
+    ],
     "cnet.com": [
       "zdnet.com"
     ],
-    "cnn.net": [
-      "cnn.com"
-    ],
     "cntraveler.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
+    ],
+    "cnzz.com": [
+      "zol.com.cn"
     ],
     "cobaltgroup.com": [
       "edmunds.com"
@@ -7461,6 +5768,13 @@
       "ibm.com",
       "hp.com"
     ],
+    "complex.com": [
+      "knowyourmeme.com",
+      "dailydot.com"
+    ],
+    "conative.de": [
+      "focus.de"
+    ],
     "condenastdigital.com": [
       "wired.com",
       "newyorker.com",
@@ -7475,20 +5789,23 @@
       "sourceforge.net"
     ],
     "consensu.org": [
+      "buzzfeed.com",
       "pcworld.com",
-      "us.org",
-      "rollingstone.com"
+      "us.org"
     ],
     "content.ad": [
       "tinypic.com"
     ],
     "contextweb.com": [
       "sourceforge.net",
-      "forbes.com",
-      "imdb.com"
+      "myspace.com",
+      "uci.edu"
     ],
     "convertro.com": [
       "slack.com"
+    ],
+    "convio.net": [
+      "convio.com"
     ],
     "cornell.edu": [
       "arxiv.org"
@@ -7504,10 +5821,13 @@
     "creativecdn.com": [
       "ria.ru"
     ],
+    "creativecommons.org": [
+      "perl.com"
+    ],
     "criteo.com": [
-      "dropbox.com",
-      "forbes.com",
-      "reuters.com"
+      "washingtonpost.com",
+      "telegraph.co.uk",
+      "dailymail.co.uk"
     ],
     "crsspxl.com": [
       "sourceforge.net",
@@ -7518,9 +5838,9 @@
       "home.pl"
     ],
     "cxense.com": [
-      "wsj.com",
       "opera.com",
-      "talktalk.co.uk"
+      "talktalk.co.uk",
+      "gizmodo.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -7540,21 +5860,21 @@
       "metro.co.uk"
     ],
     "datamind.ru": [
-      "rambler.ru",
       "novostimira.com"
+    ],
+    "daum.net": [
+      "shutterstock.com",
+      "tistory.com"
     ],
     "dc-storm.com": [
       "nike.com",
       "alibabacloud.com",
       "coursera.org"
     ],
-    "decajo.ru": [
-      "radikal.ru"
-    ],
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "soundcloud.com"
+      "amazon.com"
     ],
     "deployads.com": [
       "tinyurl.com",
@@ -7565,16 +5885,13 @@
       "dezeen.com"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
-      "disney.com",
+      "go.com",
       "starwars.com"
     ],
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
       "zerohedge.com"
-    ],
-    "digitaltarget.ru": [
-      "rambler.ru"
     ],
     "digitru.st": [
       "britannica.com",
@@ -7592,25 +5909,25 @@
       "washingtontimes.com"
     ],
     "districtm.io": [
-      "forbes.com",
       "barnesandnoble.com",
-      "timeanddate.com"
+      "scmp.com",
+      "seattletimes.com"
     ],
     "dmxleo.com": [
       "dailymotion.com"
     ],
-    "dol.gov": [
-      "osha.gov"
+    "dnnapi.com": [
+      "zenfolio.com"
     ],
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "wsj.com"
+      "tinypic.com"
     ],
     "dotomi.com": [
-      "forbes.com",
       "samsung.com",
-      "economist.com"
+      "economist.com",
+      "barnesandnoble.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -7628,24 +5945,30 @@
       "theregister.co.uk",
       "adweek.com"
     ],
+    "dsp.com": [
+      "qq.com"
+    ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
       "cnbc.com",
-      "norton.com",
+      "nbcnews.com",
       "washingtonexaminer.com"
     ],
     "dyntrk.com": [
       "dailymotion.com"
     ],
-    "ebay.com": [
-      "ebay.co.uk",
-      "ebay.de",
+    "ebay-us.com": [
+      "ebay.com",
       "ebay.com.au"
     ],
-    "ebayrtm.com": [
+    "ebay.com": [
+      "t-online.de",
       "ebay.co.uk",
+      "ebay.de"
+    ],
+    "ebayrtm.com": [
       "ebay.de",
       "ebay.com.au"
     ],
@@ -7678,8 +6001,7 @@
     ],
     "epicurious.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -7687,12 +6009,15 @@
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "tomshardware.com"
+      "eklablog.com"
     ],
     "everesttech.net": [
       "adobe.com",
       "sourceforge.net",
-      "nytimes.com"
+      "dropbox.com"
+    ],
+    "everyaction.com": [
+      "greenpeace.org"
     ],
     "evise.com": [
       "thelancet.com",
@@ -7701,6 +6026,9 @@
     "evvnt-api.global.ssl.fastly.net": [
       "seattlepi.com"
     ],
+    "ew3.io": [
+      "liberation.fr"
+    ],
     "exactag.com": [
       "t-online.de"
     ],
@@ -7708,20 +6036,20 @@
       "exblog.jp"
     ],
     "exelator.com": [
-      "soundcloud.com",
-      "forbes.com",
-      "businessinsider.com"
+      "businessinsider.com",
+      "surveymonkey.com",
+      "talktalk.co.uk"
     ],
     "eyeota.net": [
       "sourceforge.net",
       "wsj.com",
-      "npr.org"
+      "scientificamerican.com"
     ],
     "eyereturn.com": [
       "thestar.com"
     ],
     "eyeviewads.com": [
-      "boingboing.net"
+      "nypost.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -7747,7 +6075,8 @@
     ],
     "firstimpression.io": [
       "jpost.com",
-      "haaretz.com"
+      "haaretz.com",
+      "zerohedge.com"
     ],
     "flashtalking.com": [
       "adobe.com",
@@ -7784,7 +6113,13 @@
     "fout.jp": [
       "economist.com",
       "exblog.jp",
-      "biglobe.ne.jp"
+      "seesaa.jp"
+    ],
+    "foxbusiness.com": [
+      "fox.com"
+    ],
+    "foxsports.com": [
+      "fox.com"
     ],
     "foxycart.com": [
       "brookings.edu"
@@ -7792,18 +6127,34 @@
     "freshdesk.com": [
       "podbean.com"
     ],
+    "friendbuy.com": [
+      "lulu.com"
+    ],
+    "funnyordie.com": [
+      "videojs.com"
+    ],
     "fwmrm.net": [
       "go.com",
       "discovery.com",
       "foodnetwork.com"
     ],
+    "geetest.com": [
+      "axs.com"
+    ],
     "gemius.pl": [
       "sapo.pt",
-      "ria.ru"
+      "ria.ru",
+      "onet.pl"
+    ],
+    "gentags.net": [
+      "sohu.com"
     ],
     "getclicky.com": [
       "newatlas.com",
       "cyberchimps.com"
+    ],
+    "getsmartcontent.com": [
+      "pcworld.com"
     ],
     "gigya.com": [
       "cnn.com",
@@ -7815,8 +6166,7 @@
     ],
     "glamour.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
@@ -7830,21 +6180,19 @@
     ],
     "golfdigest.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
     "google.com": [
       "youtube.com",
-      "vimeo.com",
-      "goo.gl"
+      "linkedin.com",
+      "vimeo.com"
     ],
     "gq.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "gridsumdissector.com": [
       "www.gov.cn"
@@ -7853,27 +6201,31 @@
       "groupon.com"
     ],
     "gtags.net": [
-      "ctrip.com"
+      "ctrip.com",
+      "sina.com.cn",
+      "suning.com"
     ],
     "gumgum.com": [
-      "snopes.com",
       "thehindu.com",
-      "home.pl"
+      "home.pl",
+      "zimbio.com"
     ],
     "gwallet.com": [
+      "adobe.com",
       "economist.com",
-      "ox.ac.uk",
-      "smithsonianmag.com"
+      "ox.ac.uk"
     ],
     "hatena.com": [
       "hatena.ne.jp"
     ],
     "hatena.ne.jp": [
-      "hatenablog.com",
-      "cronolog.org"
+      "hatenablog.com"
+    ],
+    "hdslb.com": [
+      "bilibili.com"
     ],
     "healte.de": [
-      "reuters.com"
+      "spiegel.de"
     ],
     "hearstnp.com": [
       "sfgate.com",
@@ -7889,13 +6241,25 @@
     "hive.co": [
       "complex.com"
     ],
+    "hiwoenrep.ru": [
+      "radikal.ru"
+    ],
     "horyzon-media.com": [
       "skyrock.com"
+    ],
+    "huanqiu.com": [
+      "sina.com.cn"
+    ],
+    "hubpd.com": [
+      "huanqiu.com"
     ],
     "hubspot.com": [
       "scoop.it",
       "500px.com",
       "thelancet.com"
+    ],
+    "huffingtonpost.com": [
+      "huffingtonpost.co.uk"
     ],
     "hugedata.com.cn": [
       "miit.gov.cn"
@@ -7906,14 +6270,12 @@
     "hwcdn.net": [
       "boingboing.net"
     ],
-    "hybrid.ai": [
-      "rambler.ru"
-    ],
     "iasds01.com": [
       "discovery.com"
     ],
     "ibclick.stream": [
-      "webmd.com"
+      "webmd.com",
+      "wikitravel.org"
     ],
     "ibillboard.com": [
       "t-online.de",
@@ -7929,9 +6291,6 @@
       "livescience.com",
       "skyrock.com"
     ],
-    "idealmedia.com": [
-      "thehill.com"
-    ],
     "ign.com": [
       "videojs.com"
     ],
@@ -7943,18 +6302,18 @@
       "variety.com"
     ],
     "im-apps.net": [
+      "economist.com",
       "exblog.jp",
-      "biglobe.ne.jp",
-      "goo.ne.jp"
+      "biglobe.ne.jp"
     ],
     "imgur.com": [
       "stackoverflow.com",
       "stackexchange.com"
     ],
     "impact-ad.jp": [
+      "economist.com",
       "yahoo.co.jp",
-      "hatena.ne.jp",
-      "goo.ne.jp"
+      "hatena.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
@@ -7968,6 +6327,9 @@
     "inq.com": [
       "ups.com"
     ],
+    "inquisitr.com": [
+      "flipboard.com"
+    ],
     "insightexpressai.com": [
       "unsplash.com",
       "philly.com"
@@ -7979,24 +6341,25 @@
     ],
     "instinctiveads.com": [
       "rollingstone.com",
-      "variety.com"
+      "variety.com",
+      "nist.gov"
     ],
     "intentiq.com": [
-      "thinkgeek.com",
-      "active.com"
+      "thinkgeek.com"
     ],
     "intentmedia.net": [
       "tripadvisor.com"
     ],
     "intercom.io": [
-      "themegrill.com",
-      "emarketer.com",
-      "diabetes.org"
+      "visual.ly",
+      "yumpu.com",
+      "emarketer.com"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
+      "inhabitat.com",
       "wikitravel.org"
     ],
     "investingchannel.com": [
@@ -8014,10 +6377,14 @@
       "virgilio.it"
     ],
     "iperceptions.com": [
+      "seagate.com",
+      "honeywell.com",
       "boeing.com"
     ],
+    "ipinyou.com": [
+      "suning.com"
+    ],
     "ipredictive.com": [
-      "imdb.com",
       "myspace.com",
       "dailymotion.com"
     ],
@@ -8038,7 +6405,6 @@
       "businessinsider.com"
     ],
     "jrs5.com": [
-      "nike.com",
       "coursera.org",
       "bostonglobe.com"
     ],
@@ -8049,7 +6415,11 @@
     ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com"
+      "zenfolio.com"
+    ],
+    "kakao.com": [
+      "daum.net",
+      "tistory.com"
     ],
     "kameleoon.eu": [
       "welt.de",
@@ -8072,9 +6442,9 @@
       "dzwww.com"
     ],
     "krxd.net": [
-      "cnn.com",
-      "theguardian.com",
-      "usatoday.com"
+      "slate.com",
+      "twitch.tv",
+      "nypost.com"
     ],
     "leadintel.io": [
       "nme.com"
@@ -8082,21 +6452,15 @@
     "leadlander.com": [
       "panasonic.com"
     ],
-    "legocdn.com": [
-      "lego.com"
-    ],
     "liadm.com": [
       "bloomberg.com",
       "time.com",
       "economist.com"
     ],
-    "licasd.com": [
-      "time.com"
-    ],
     "ligadx.com": [
+      "telegraph.co.uk",
       "springer.com",
-      "lemonde.fr",
-      "lefigaro.fr"
+      "lemonde.fr"
     ],
     "lightboxcdn.com": [
       "gizmodo.com",
@@ -8104,9 +6468,9 @@
       "fastcompany.com"
     ],
     "lijit.com": [
-      "sourceforge.net",
-      "wsj.com",
-      "bloomberg.com"
+      "deviantart.com",
+      "uci.edu",
+      "mirror.co.uk"
     ],
     "link-page.info": [
       "netvibes.com"
@@ -8117,23 +6481,22 @@
       "sourceforge.net"
     ],
     "linksynergy.com": [
+      "pcworld.com",
       "nike.com",
-      "alibabacloud.com",
-      "coursera.org"
+      "alibabacloud.com"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "microsoft.com",
       "msn.com",
-      "bing.com"
+      "bing.com",
+      "skype.com"
     ],
     "livechatinc.com": [
       "ning.com",
       "wpengine.com",
-      "sophos.com",
-      "nazwa.pl"
+      "sophos.com"
     ],
     "livejournal.net": [
       "livejournal.com"
@@ -8141,9 +6504,10 @@
     "liveperson.net": [
       "talktalk.co.uk",
       "earthlink.net",
-      "trendmicro.com"
+      "thetimes.co.uk"
     ],
     "loc.gov": [
+      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
@@ -8173,10 +6537,17 @@
       "t-online.de",
       "statista.com"
     ],
+    "madeleine.de": [
+      "t-online.de"
+    ],
     "mail.ru": [
       "vk.com",
       "yandex.ru",
       "icq.com"
+    ],
+    "mailchimp.com": [
+      "boingboing.net",
+      "colorlib.com"
     ],
     "marinsm.com": [
       "webs.com",
@@ -8185,7 +6556,6 @@
     ],
     "marketlinc.com": [
       "teamviewer.us",
-      "norton.com",
       "eset.com"
     ],
     "marketo.com": [
@@ -8199,19 +6569,22 @@
       "mercurynews.com"
     ],
     "mathtag.com": [
-      "sourceforge.net",
-      "nytimes.com",
-      "forbes.com"
+      "adobe.com",
+      "vimeo.com",
+      "sourceforge.net"
+    ],
+    "mct01.com": [
+      "zol.com.cn"
     ],
     "media.net": [
       "nytimes.com",
-      "forbes.com",
-      "reuters.com"
+      "dropbox.com",
+      "forbes.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
-      "uci.edu",
-      "autodesk.com"
+      "columbia.edu",
+      "uci.edu"
     ],
     "mediaforge.com": [
       "nike.com",
@@ -8219,12 +6592,13 @@
       "bostonglobe.com"
     ],
     "mediaplex.com": [
-      "t-online.de",
       "economist.com",
-      "dell.com"
+      "dell.com",
+      "shutterfly.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
+      "liberation.fr",
       "leparisien.fr"
     ],
     "mediav.com": [
@@ -8232,22 +6606,15 @@
       "ctrip.com",
       "toutiao.com"
     ],
-    "mediawallahscript.com": [
-      "sourceforge.net"
-    ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "thelancet.com",
       "cell.com"
     ],
     "metadsp.co.uk": [
-      "boingboing.net",
-      "standard.co.uk"
-    ],
-    "mfadsrvr.com": [
-      "forbes.com"
+      "nypost.com",
+      "variety.com"
     ],
     "mg2connext.com": [
       "philly.com",
@@ -8257,27 +6624,27 @@
       "liveleak.com"
     ],
     "miaozhen.com": [
+      "qq.com",
       "sina.com.cn",
-      "pconline.com.cn",
-      "qq.com"
+      "pconline.com.cn"
     ],
     "microad.jp": [
       "sakura.ne.jp",
       "hatena.ne.jp"
     ],
     "microsoft.com": [
+      "msn.com",
       "live.com",
-      "skype.com",
-      "office.com"
+      "skype.com"
     ],
     "microsoftonline.com": [
       "office.com",
       "microsoft.com"
     ],
     "mktoresp.com": [
-      "parallels.com",
       "zend.com",
-      "prweb.com"
+      "prweb.com",
+      "techtarget.com"
     ],
     "ml314.com": [
       "sourceforge.net",
@@ -8286,8 +6653,8 @@
     ],
     "mmstat.com": [
       "youku.com",
-      "sohu.com",
-      "taobao.com"
+      "taobao.com",
+      "alibaba.com"
     ],
     "monetate.net": [
       "nationalgeographic.com",
@@ -8296,7 +6663,7 @@
     "mookie1.com": [
       "t-online.de",
       "businessinsider.com",
-      "npr.org"
+      "photobucket.com"
     ],
     "mouseflow.com": [
       "nintendo.com"
@@ -8306,14 +6673,12 @@
       "heise.de"
     ],
     "mrpfd.com": [
-      "symantec.com",
       "hpe.com"
     ],
     "msgapp.com": [
       "post-gazette.com"
     ],
     "msn.com": [
-      "w3.org",
       "marketwatch.com"
     ],
     "mtvnservices.com": [
@@ -8323,6 +6688,9 @@
     "musthird.com": [
       "airbnb.com"
     ],
+    "myhard.com": [
+      "yesky.com"
+    ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
@@ -8331,16 +6699,13 @@
       "myspace.com"
     ],
     "myvisualiq.net": [
-      "soundcloud.com",
-      "paypal.com",
-      "surveymonkey.com"
+      "surveymonkey.com",
+      "spotify.com",
+      "economist.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
       "yellowpages.com"
-    ],
-    "narrative.io": [
-      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -8355,7 +6720,8 @@
       "t-online.de"
     ],
     "naver.com": [
-      "unity3d.com"
+      "unity3d.com",
+      "cafe24.com"
     ],
     "naver.jp": [
       "line.me"
@@ -8364,6 +6730,9 @@
       "cnbc.com",
       "nbcnews.com",
       "today.com"
+    ],
+    "netmng.com": [
+      "theknot.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -8377,10 +6746,13 @@
     ],
     "news.com.au": [
       "theaustralian.com.au",
-      "heraldsun.com.au"
+      "heraldsun.com.au",
+      "dailytelegraph.com.au"
     ],
     "newscdn.com.au": [
-      "heraldsun.com.au"
+      "theaustralian.com.au",
+      "heraldsun.com.au",
+      "dailytelegraph.com.au"
     ],
     "newscgp.com": [
       "wsj.com",
@@ -8402,8 +6774,7 @@
     ],
     "newyorker.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -8420,15 +6791,23 @@
       "huffingtonpost.com"
     ],
     "nuggad.net": [
-      "t-online.de"
+      "t-online.de",
+      "liberation.fr"
     ],
     "nxtck.com": [
-      "nike.com",
       "coursera.org",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "orange.fr"
     ],
     "o0bg.com": [
       "bostonglobe.com"
+    ],
+    "oath.com": [
+      "huffingtonpost.co.uk",
+      "techradar.com"
+    ],
+    "ocdn.eu": [
+      "onet.pl"
     ],
     "office.com": [
       "microsoftonline.com"
@@ -8436,14 +6815,10 @@
     "office365.com": [
       "microsoftonline.com"
     ],
-    "ojrq.net": [
-      "autodesk.com"
-    ],
     "ok.ru": [
       "ria.ru"
     ],
     "olark.com": [
-      "texas.gov",
       "webstarts.com"
     ],
     "olympicchannel.com": [
@@ -8452,13 +6827,10 @@
     "omkt.co": [
       "prweb.com"
     ],
-    "omnidsp.com": [
-      "rambler.ru"
-    ],
     "omnitagjs.com": [
-      "variety.com",
-      "standard.co.uk",
-      "home.pl"
+      "independent.co.uk",
+      "springer.com",
+      "variety.com"
     ],
     "omtrdc.net": [
       "adobe.com",
@@ -8485,11 +6857,10 @@
     "onthe.io": [
       "indiatimes.com",
       "express.co.uk",
-      "rbc.ru"
+      "wn.com"
     ],
     "ooyala.com": [
-      "accuweather.com",
-      "fedex.com"
+      "accuweather.com"
     ],
     "openhub.net": [
       "mariadb.org"
@@ -8498,9 +6869,9 @@
       "novostimira.com"
     ],
     "openx.net": [
-      "yahoo.com",
       "nytimes.com",
-      "forbes.com"
+      "dropbox.com",
+      "telegraph.co.uk"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -8513,14 +6884,10 @@
       "qianlong.com"
     ],
     "optimizely.com": [
-      "nytimes.com",
       "creativecommons.org",
-      "webs.com",
-      "couchsurfing.com",
-      "gitlab.com",
-      "imageshack.com",
-      "box.com",
-      "fox.com"
+      "live.com",
+      "ibm.com",
+      "blizzard.com"
     ],
     "ora.tv": [
       "cheezburger.com",
@@ -8548,10 +6915,13 @@
     "owox.com": [
       "boredpanda.com"
     ],
+    "paddle.com": [
+      "snapwidget.com"
+    ],
     "pardot.com": [
-      "tandfonline.com",
       "prezi.com",
-      "ap.org"
+      "ap.org",
+      "rebelmouse.com"
     ],
     "parsely.com": [
       "wsj.com",
@@ -8602,16 +6972,15 @@
       "express.co.uk"
     ],
     "po.st": [
-      "smithsonianmag.com",
       "nme.com"
     ],
     "popsugar-assets.com": [
       "popsugar.com"
     ],
     "postrelease.com": [
-      "wsj.com",
       "reuters.com",
-      "independent.co.uk"
+      "independent.co.uk",
+      "chicagotribune.com"
     ],
     "powerlinks.com": [
       "variety.com",
@@ -8619,10 +6988,8 @@
       "howtogeek.com"
     ],
     "pressboard.ca": [
-      "thestar.com"
-    ],
-    "prfct.co": [
-      "smugmug.com"
+      "thestar.com",
+      "observer.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
@@ -8649,9 +7016,12 @@
     "pub.network": [
       "coindesk.com"
     ],
+    "publishme.se": [
+      "blogg.se"
+    ],
     "pubmatic.com": [
-      "forbes.com",
-      "bloomberg.com",
+      "tinyurl.com",
+      "telegraph.co.uk",
       "usatoday.com"
     ],
     "pubmine.com": [
@@ -8661,12 +7031,7 @@
       "variety.com"
     ],
     "purch.com": [
-      "livescience.com",
-      "space.com",
-      "tomshardware.com"
-    ],
-    "purechat.com": [
-      "byu.edu"
+      "space.com"
     ],
     "pushanert.com": [
       "4shared.com"
@@ -8677,20 +7042,22 @@
     "pymx5.com": [
       "sfgate.com",
       "seattletimes.com",
-      "seattlepi.com"
+      "rd.com"
     ],
     "qq.com": [
-      "tencent.com"
+      "tencent.com",
+      "yesky.com",
+      "bshare.cn"
     ],
     "qualtrics.com": [
+      "techrepublic.com",
       "nintendo.com",
-      "cnet.com",
-      "mayoclinic.org"
+      "cnet.com"
     ],
     "quantserve.com": [
+      "vimeo.com",
       "wordpress.org",
-      "reddit.com",
-      "soundcloud.com"
+      "reddit.com"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -8709,13 +7076,18 @@
     "radiotime.com": [
       "tunein.com"
     ],
+    "rakuten.co.jp": [
+      "infoseek.co.jp"
+    ],
     "rambler.ru": [
       "livejournal.com",
       "novostimira.com",
       "ria.ru"
     ],
     "reachmax.cn": [
-      "qq.com"
+      "yesky.com",
+      "bshare.cn",
+      "sohu.com"
     ],
     "reddit.com": [
       "acm.org",
@@ -8727,35 +7099,34 @@
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
-    "republer.com": [
-      "rambler.ru"
+    "render.githubusercontent.com": [
+      "github.com"
+    ],
+    "researchintel.com": [
+      "intel.com"
     ],
     "reson8.com": [
-      "startribune.com",
-      "biography.com"
+      "startribune.com"
     ],
     "responsetap.com": [
       "manchester.ac.uk"
     ],
-    "reutersmedia.net": [
-      "reuters.com"
-    ],
     "revcontent.com": [
       "jpost.com",
-      "breitbart.com",
-      "bostonherald.com"
+      "breitbart.com"
     ],
     "revjet.com": [
       "bankrate.com"
     ],
     "rezync.com": [
       "economist.com",
+      "salon.com",
       "investopedia.com"
     ],
     "rfihub.com": [
-      "forbes.com",
-      "npr.org",
-      "economist.com"
+      "dropbox.com",
+      "tinyurl.com",
+      "npr.org"
     ],
     "rhombusads.com": [
       "adweek.com"
@@ -8773,8 +7144,8 @@
     ],
     "rkdms.com": [
       "wired.com",
-      "npr.org",
-      "cbsnews.com"
+      "cbsnews.com",
+      "gizmodo.com"
     ],
     "rlcdn.com": [
       "adobe.com",
@@ -8787,38 +7158,32 @@
     "rockyou.net": [
       "springer.com"
     ],
-    "rqtrk.eu": [
-      "npr.org"
-    ],
     "rtk.io": [
       "seattletimes.com",
       "startribune.com",
       "azcentral.com"
     ],
     "ru4.com": [
-      "bloomberg.com",
-      "npr.org"
+      "uci.edu"
     ],
     "rubiconproject.com": [
-      "nytimes.com",
-      "forbes.com",
-      "wsj.com"
-    ],
-    "rutarget.ru": [
-      "rambler.ru",
-      "ria.ru"
+      "yahoo.com",
+      "amazon.com",
+      "sourceforge.net"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "bell-labs.com",
-      "hwg.org"
+      "bell-labs.com"
+    ],
+    "s3xified.com": [
+      "coindesk.com"
     ],
     "sabavision.com": [
       "mihanblog.com"
     ],
     "salesforceliveagent.com": [
       "marriott.com",
-      "teamviewer.us",
-      "prweb.com"
+      "prweb.com",
+      "salesforce.com"
     ],
     "salesloft.com": [
       "wpengine.com",
@@ -8833,8 +7198,8 @@
       "lifehacker.com",
       "history.com"
     ],
-    "samplicio.us": [
-      "go.com"
+    "scarabresearch.com": [
+      "tate.org.uk"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -8855,16 +7220,13 @@
       "cell.com"
     ],
     "scorecardresearch.com": [
+      "linkedin.com",
       "yahoo.com",
-      "tumblr.com",
-      "flickr.com"
+      "tumblr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
       "startribune.com"
-    ],
-    "scribd.com": [
-      "macrumors.com"
     ],
     "sdp-campaign.de": [
       "t-online.de"
@@ -8882,8 +7244,7 @@
     ],
     "self.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "sendtonews.com": [
       "bostonherald.com"
@@ -8893,13 +7254,16 @@
       "space.com",
       "howtogeek.com"
     ],
+    "servedby-buysellads.com": [
+      "dribbble.com"
+    ],
     "serverbid.com": [
       "sciencedaily.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
       "businessinsider.com",
-      "npr.org"
+      "sciencemag.org"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -8913,24 +7277,23 @@
     ],
     "sharethis.com": [
       "uk.com",
-      "us.org",
-      "www.vic.gov.au"
+      "uci.edu",
+      "us.org"
     ],
     "sharethrough.com": [
-      "cnet.com",
-      "time.com",
-      "wired.com"
+      "springer.com",
+      "photobucket.com",
+      "cnbc.com"
     ],
     "shop.pe": [
-      "dyn.com"
+      "bluehost.com"
     ],
     "siftscience.com": [
+      "scribd.com",
       "kickstarter.com",
-      "flickr.com",
-      "shutterstock.com"
+      "flickr.com"
     ],
     "simpli.fi": [
-      "washingtontimes.com",
       "thinkgeek.com",
       "tampabay.com"
     ],
@@ -8938,7 +7301,8 @@
       "sina.com.cn"
     ],
     "sina.com.cn": [
-      "weibo.com"
+      "weibo.com",
+      "suning.com"
     ],
     "siteimprove.com": [
       "berkeley.edu",
@@ -8949,12 +7313,13 @@
       "in.gov"
     ],
     "sitelock.com": [
-      "joomla.org"
+      "joomla.org",
+      "netfirms.com"
     ],
     "sitescout.com": [
-      "forbes.com",
-      "tinyurl.com",
-      "time.com"
+      "barnesandnoble.com",
+      "tinypic.com",
+      "salon.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
@@ -8968,9 +7333,9 @@
       "slashdot.org"
     ],
     "smartadserver.com": [
+      "telegraph.co.uk",
       "springer.com",
-      "elpais.com",
-      "skyrock.com"
+      "elpais.com"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
@@ -8983,9 +7348,9 @@
       "smithsonianmag.com"
     ],
     "snapchat.com": [
-      "wsj.com",
       "giphy.com",
-      "walmart.com"
+      "walmart.com",
+      "wpengine.com"
     ],
     "so.com": [
       "360.cn"
@@ -9002,22 +7367,23 @@
       "howstuffworks.com"
     ],
     "sogou.com": [
-      "ifeng.com",
       "soso.com"
+    ],
+    "sohu.com": [
+      "bshare.cn"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
     "sonobi.com": [
-      "myspace.com",
-      "cnet.com",
-      "usatoday.com"
+      "usatoday.com",
+      "springer.com",
+      "deviantart.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
       "bmj.com",
-      "ea.com",
-      "mo.gov"
+      "ea.com"
     ],
     "sphereup.com": [
       "jpost.com"
@@ -9026,6 +7392,12 @@
       "hp.com",
       "slack.com",
       "sophos.com"
+    ],
+    "spineuniverse.com": [
+      "psychcentral.com"
+    ],
+    "spingo.com": [
+      "detroitnews.com"
     ],
     "sportz.io": [
       "gulfnews.com"
@@ -9038,17 +7410,15 @@
       "denverpost.com"
     ],
     "spotxchange.com": [
-      "imdb.com",
       "dailymotion.com",
-      "npr.org"
+      "express.co.uk",
+      "thenextweb.com"
     ],
     "spoutable.com": [
       "alternet.org",
       "dailydot.com"
     ],
     "springernature.com": [
-      "nature.com",
-      "springer.com",
       "biomedcentral.com"
     ],
     "springserve.com": [
@@ -9091,29 +7461,31 @@
     "stripe.com": [
       "smashballoon.com",
       "presscustomizr.com",
-      "themezee.com",
-      "documentcloud.org"
+      "themezee.com"
     ],
     "sumo.com": [
       "snopes.com",
-      "cdbaby.com",
-      "studiopress.com"
+      "studiopress.com",
+      "sitepoint.com"
     ],
     "sundaysky.com": [
       "fiverr.com",
       "jpost.com",
-      "dailydot.com"
+      "careerbuilder.com"
+    ],
+    "suning.cn": [
+      "suning.com"
     ],
     "suning.com": [
       "qq.com",
+      "sohu.com",
       "ifeng.com"
     ],
-    "supplyframe.com": [
-      "arduino.cc",
-      "ti.com"
+    "sunrtb.com": [
+      "yesky.com"
     ],
-    "survata.com": [
-      "tripadvisor.com"
+    "supplyframe.com": [
+      "arduino.cc"
     ],
     "surveymonkey.com": [
       "cambridge.org",
@@ -9122,31 +7494,27 @@
     ],
     "switchadhub.com": [
       "lycos.com",
-      "thehindu.com"
-    ],
-    "symantec.com": [
-      "norton.com"
+      "thehindu.com",
+      "coindesk.com"
     ],
     "taboola.com": [
       "weebly.com",
-      "msn.com",
-      "wsj.com"
+      "dropbox.com",
+      "msn.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
     ],
     "tailtarget.com": [
-      "uol.com.br",
-      "variety.com"
+      "uol.com.br"
     ],
     "tamgrt.com": [
-      "tripadvisor.com",
-      "hotels.com"
+      "tripadvisor.com"
     ],
     "tanx.com": [
+      "sina.com.cn",
       "sohu.com",
-      "ifeng.com",
-      "tmall.com"
+      "alibaba.com"
     ],
     "taobao.com": [
       "sina.com.cn",
@@ -9154,15 +7522,16 @@
       "tmall.com"
     ],
     "tapad.com": [
-      "tinyurl.com",
-      "wsj.com",
-      "paypal.com"
+      "hp.com",
+      "wired.com",
+      "spotify.com"
     ],
     "tawk.to": [
-      "cba.pl"
+      "cba.pl",
+      "affordable-papers.net"
     ],
-    "taylorandfrancis.com": [
-      "tandfonline.com"
+    "teads.tv": [
+      "telegraph.co.uk"
     ],
     "tealiumiq.com": [
       "ibm.com",
@@ -9174,8 +7543,7 @@
     ],
     "teenvogue.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "theadex.com": [
       "t-online.de",
@@ -9183,18 +7551,15 @@
       "sueddeutsche.de"
     ],
     "thebrighttag.com": [
-      "netflix.com",
       "playstation.com",
-      "washingtontimes.com"
+      "washingtontimes.com",
+      "mercurynews.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
     ],
     "theguardian.com": [
       "videojs.com"
-    ],
-    "thrtle.com": [
-      "sourceforge.net"
     ],
     "tianqi.com": [
       "qianlong.com"
@@ -9216,15 +7581,12 @@
     "tinypass.com": [
       "bloomberg.com",
       "businessinsider.com",
-      "techcrunch.com"
+      "independent.co.uk"
     ],
     "tiqcdn.com": [
       "wsj.com",
       "cisco.com",
       "marketwatch.com"
-    ],
-    "tm-awx.com": [
-      "mirror.co.uk"
     ],
     "tmall.com": [
       "taobao.com"
@@ -9238,7 +7600,11 @@
       "qualtrics.com"
     ],
     "tradelab.fr": [
-      "eklablog.com"
+      "eklablog.com",
+      "leparisien.fr"
+    ],
+    "traffic-media.co": [
+      "radikal.ru"
     ],
     "trafficjunky.net": [
       "pornhub.com"
@@ -9268,9 +7634,6 @@
       "prnewswire.com",
       "zimbra.com"
     ],
-    "triblive.com": [
-      "bleacherreport.com"
-    ],
     "tripadvisor.com": [
       "accorhotels.com"
     ],
@@ -9289,11 +7652,11 @@
     "trustarc.com": [
       "skynet.be"
     ],
-    "trustpilot.com": [
-      "jalbum.net"
+    "tumblr.com": [
+      "theweek.com"
     ],
     "turn.com": [
-      "forbes.com",
+      "tinyurl.com",
       "hp.com",
       "wired.com"
     ],
@@ -9305,19 +7668,15 @@
       "jimdo.com",
       "squarespace.com"
     ],
-    "twimg.com": [
-      "coe.int",
-      "dol.gov"
-    ],
     "twitter.com": [
+      "amazon.com",
       "wordpress.org",
-      "nytimes.com",
-      "dropbox.com"
+      "nytimes.com"
     ],
     "tynt.com": [
+      "salon.com",
       "investopedia.com",
-      "accuweather.com",
-      "washingtontimes.com"
+      "accuweather.com"
     ],
     "uc.se": [
       "jalbum.net"
@@ -9346,12 +7705,13 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "boingboing.net",
-      "bell-labs.com"
+      "hbr.org",
+      "boingboing.net"
     ],
     "upsellit.com": [
       "samsung.com",
-      "motorola.com"
+      "motorola.com",
+      "ccleaner.com"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
@@ -9359,11 +7719,15 @@
     "usa.gov": [
       "transportation.gov"
     ],
+    "useproof.com": [
+      "iconosquare.com"
+    ],
     "usergram.info": [
       "ocn.ne.jp"
     ],
     "uservoice.com": [
-      "scoop.it"
+      "scoop.it",
+      "theknot.com"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -9382,14 +7746,16 @@
     ],
     "vanityfair.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "veinteractive.com": [
       "prweb.com"
     ],
     "velaro.com": [
       "lg.com"
+    ],
+    "verticalhealth.net": [
+      "psychcentral.com"
     ],
     "viafoura.co": [
       "cbc.ca",
@@ -9404,7 +7770,7 @@
     ],
     "videohub.tv": [
       "wsj.com",
-      "bloomberg.com"
+      "uci.edu"
     ],
     "vidible.tv": [
       "huffingtonpost.com",
@@ -9412,9 +7778,9 @@
       "autoblog.com"
     ],
     "viglink.com": [
-      "cnet.com",
       "zdnet.com",
-      "thedailybeast.com"
+      "thedailybeast.com",
+      "softonic.com"
     ],
     "vilynx.com": [
       "cbsnews.com",
@@ -9424,8 +7790,7 @@
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "wufoo.com",
-      "oclc.org"
+      "wufoo.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
@@ -9441,28 +7806,33 @@
     "vk.com": [
       "yandex.ru",
       "rt.com",
-      "ria.ru"
+      "liveinternet.ru"
     ],
     "vogue.com": [
-      "wired.com",
-      "pitchfork.com"
+      "wired.com"
+    ],
+    "volvelle.tech": [
+      "prweb.com"
     ],
     "voxmedia.com": [
       "theverge.com",
       "vox.com",
-      "recode.net",
-      "polygon.com"
+      "recode.net"
     ],
     "w55c.net": [
-      "forbes.com",
-      "hp.com",
-      "businessinsider.com"
+      "hpe.com"
     ],
     "wal.co": [
       "walmart.com"
     ],
     "wallst.com": [
       "reuters.com"
+    ],
+    "waptime.cn": [
+      "tianqi.com"
+    ],
+    "warnerbros.com": [
+      "tmz.com"
     ],
     "wbtrk.net": [
       "bild.de",
@@ -9477,8 +7847,7 @@
       "wunderground.com"
     ],
     "webmd.com": [
-      "medscape.com",
-      "medicinenet.com"
+      "medscape.com"
     ],
     "weborama.fr": [
       "lemonde.fr",
@@ -9511,9 +7880,6 @@
     "weibo.com": [
       "sina.com.cn"
     ],
-    "welt.de": [
-      "bild.de"
-    ],
     "whistleout.com": [
       "earthlink.net"
     ],
@@ -9526,16 +7892,17 @@
       "wikisource.org"
     ],
     "wired.com": [
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
-      "globalnews.ca",
-      "vancouversun.com"
+      "globalnews.ca"
     ],
     "wishpond.com": [
+      "discovermagazine.com"
+    ],
+    "wishpond.net": [
       "discovermagazine.com"
     ],
     "wistia.com": [
@@ -9550,13 +7917,11 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "redbubble.com",
-      "upwork.com"
+      "zappos.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "wnyc.org": [
       "newyorker.com"
@@ -9593,6 +7958,13 @@
     "xad.com": [
       "vt.edu"
     ],
+    "xg4ken.com": [
+      "bluehost.com",
+      "kaspersky.com"
+    ],
+    "xinhuanet.com": [
+      "news.cn"
+    ],
     "xiti.com": [
       "lemonde.fr",
       "skyrock.com",
@@ -9603,12 +7975,16 @@
       "ocn.ne.jp"
     ],
     "xplosion.de": [
+      "t-online.de",
       "spiegel.de",
-      "sueddeutsche.de",
-      "zeit.de"
+      "sueddeutsche.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
+    ],
+    "xtgreat.com": [
+      "qq.com",
+      "sohu.com"
     ],
     "yadro.ru": [
       "vk.com",
@@ -9625,6 +8001,9 @@
       "tumblr.com",
       "flickr.com"
     ],
+    "yahoosmallbusiness.com": [
+      "yahoo.com"
+    ],
     "yandex.ru": [
       "opera.com",
       "livejournal.com",
@@ -9633,21 +8012,20 @@
     "yastatic.net": [
       "liveinternet.ru",
       "sputniknews.com",
-      "ria.ru"
+      "qip.ru"
     ],
     "yieldlab.net": [
       "t-online.de",
-      "springer.com",
-      "spiegel.de"
+      "telegraph.co.uk",
+      "springer.com"
     ],
     "yieldoptimizer.com": [
-      "philly.com",
-      "groupon.com"
+      "fourseasons.com"
     ],
     "yimg.com": [
+      "yahoo.com",
       "flickr.com",
-      "nytimes.com",
-      "dropbox.com"
+      "nytimes.com"
     ],
     "yldbt.com": [
       "biography.com",
@@ -9663,11 +8041,12 @@
       "google.com",
       "mozilla.org",
       "nih.gov",
-      "honeywell.com"
+      "unt.edu"
     ],
     "youvisit.com": [
       "osu.edu",
-      "fsu.edu"
+      "fsu.edu",
+      "unh.edu"
     ],
     "ypcdn.com": [
       "yellowpages.com"
@@ -9679,17 +8058,21 @@
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com"
+      "thehindu.com",
+      "infoplease.com"
     ],
     "zemanta.com": [
       "variety.com",
       "lemonde.fr",
-      "standard.co.uk"
+      "farfetch.com"
     ],
     "zergnet.com": [
       "imdb.com",
       "marketwatch.com",
       "weather.com"
+    ],
+    "zhaopin.cn": [
+      "zhaopin.com"
     ],
     "zidtech.com": [
       "coindesk.com"
@@ -9709,5 +8092,5 @@
       "parallels.com"
     ]
   },
-  "version": "2018.9.26"
+  "version": "2018.9.27"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,13 +3,13 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535295667139,
+      "nextUpdateTime": 1535131518617,
       "userAction": ""
     },
     "112-tzm-766.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535189289123,
+      "nextUpdateTime": 1535149513388,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -24,45 +24,111 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "126.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "127.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "15gifts.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535312804098,
+      "nextUpdateTime": 1535203312039,
       "userAction": ""
     },
-    "20798148p.rfihub.com": {
+    "1dmp.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535134607453,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "2771890.fls.doubleclick.net": {
+    "1rx.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535331723304,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "23video.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "247-inc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535040469247,
+      "nextUpdateTime": 1535391580217,
       "userAction": ""
     },
-    "2ecd5.v.fwmrm.net": {
+    "2mdnsys.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535364762306,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "2o7.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "33across.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360buyimg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360yield.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "3gl.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -75,145 +141,223 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535356269183,
+      "nextUpdateTime": 1535288564686,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535074621092,
-      "userAction": ""
-    },
-    "4303900.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535426959834,
+      "nextUpdateTime": 1535556755499,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535137738544,
+      "nextUpdateTime": 1535616677370,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535183264209,
+      "nextUpdateTime": 1535547398351,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535280524361,
+      "nextUpdateTime": 1535592234323,
+      "userAction": ""
+    },
+    "4924464.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535440457062,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535472616612,
+      "nextUpdateTime": 1535276170445,
+      "userAction": ""
+    },
+    "4dsply.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "50bang.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535031682414,
+      "nextUpdateTime": 1535593380762,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535215572202,
+      "nextUpdateTime": 1535321145910,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535177286890,
+      "nextUpdateTime": 1535482911467,
+      "userAction": ""
+    },
+    "58.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "58cdn.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "5p4rk13.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535018916902,
+      "nextUpdateTime": 1535371657297,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535274302650,
+      "nextUpdateTime": 1535167279610,
       "userAction": ""
     },
-    "6954342.fls.doubleclick.net": {
+    "6sc.co": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535389775911,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "7eer.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "7grid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445598247,
+      "nextUpdateTime": 1535524131585,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535518717819,
+      "nextUpdateTime": 1535340362267,
+      "userAction": ""
+    },
+    "8329645.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535353449192,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535325869162,
+      "nextUpdateTime": 1535615993684,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535522409644,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535133497126,
+      "userAction": ""
+    },
+    "a.quora.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535405357388,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535199928678,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535490342215,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535405476367,
+      "nextUpdateTime": 1535378457839,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535121490945,
+      "nextUpdateTime": 1535161779696,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535247839389,
+      "nextUpdateTime": 1535211637737,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535208406610,
+      "nextUpdateTime": 1535563194232,
       "userAction": ""
     },
-    "aa.agkn.com": {
+    "aamcftag.aamsitecertifier.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535518074755,
+      "userAction": ""
+    },
+    "aamsitecertifier.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535357668253,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535409461357,
+      "nextUpdateTime": 1535119827399,
+      "userAction": ""
+    },
+    "aaxads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "abmr.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "accessatlanta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -222,16 +366,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.us1.gigya.com": {
+    "accuweather.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535156435397,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535108086040,
+      "nextUpdateTime": 1535429731669,
+      "userAction": ""
+    },
+    "acint.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acpm.fr": {
@@ -240,39 +390,123 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "action.media6degrees.com": {
+    "acquia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535233559120,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "actionnetwork.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1534640190001,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445319044,
+      "nextUpdateTime": 1535338170348,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535108800392,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535559735121,
       "userAction": ""
     },
-    "ad-score.com": {
+    "acuityplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "acxiomapac.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-stir.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-survey.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad.adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535280536254,
+      "userAction": ""
+    },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535102726609,
+      "nextUpdateTime": 1535264413152,
+      "userAction": ""
+    },
+    "ad.yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535443152680,
+      "userAction": ""
+    },
+    "adapf.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adaraanalytics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adc-srv.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adclear.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "addtoany.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adentifi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -282,9 +516,57 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adfox.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adfront.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adidas.fi": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adingo.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adition.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adjust-net.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adlmerge.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -294,16 +576,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "admaster.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "admiral.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535437438641,
+      "userAction": ""
+    },
+    "admission.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "admixer.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ado.pro-market.net": {
+    "adobe.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535519674298,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adotmob.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adroll.com": {
@@ -312,52 +636,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ads.adfox.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535192940943,
+      "userAction": ""
+    },
+    "ads.pro-market.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535166695414,
+      "userAction": ""
+    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535398864857,
+      "nextUpdateTime": 1535492314435,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535306789983,
+      "nextUpdateTime": 1535135614621,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535092678429,
-      "userAction": ""
-    },
-    "ads.twitter.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535426799358,
-      "userAction": ""
-    },
-    "ads.yahoo.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535030171231,
+      "nextUpdateTime": 1535549461468,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535335292087,
+      "nextUpdateTime": 1535393595473,
+      "userAction": ""
+    },
+    "adscale.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535060659368,
+      "nextUpdateTime": 1535585040406,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535399234345,
+      "nextUpdateTime": 1535485571758,
       "userAction": ""
     },
     "adsnative.com": {
@@ -366,7 +696,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adsrvr.org": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -378,9 +720,63 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adtags.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adtdp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "advertur.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adwstats.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx.com.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adzerk.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aetnd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "afilio.com.br": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -390,10 +786,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aimfar.solution.weborama.fr": {
+    "aid-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aidata.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aili.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aimfr.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535397031257,
+      "nextUpdateTime": 1535494521452,
+      "userAction": ""
+    },
+    "ajx130.online": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "akamaihd.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "akamaized.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "albacross.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alibaba.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alicdn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alipay.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aliyun.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "allure.com": {
@@ -402,9 +864,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "am15.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "amazon.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -420,40 +894,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazonwebservices.d2.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535475655145,
+      "userAction": ""
+    },
+    "amazonwebservicesinc.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535384144806,
+      "userAction": ""
+    },
+    "ameba.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535221452777,
+      "nextUpdateTime": 1535542954455,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535417025823,
+      "nextUpdateTime": 1535381037838,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535346469077,
+      "nextUpdateTime": 1535613174595,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535137200226,
+      "nextUpdateTime": 1535108485791,
       "userAction": ""
     },
-    "an.yandex.ru": {
+    "and.co.uk": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535052792707,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "analytics.twitter.com": {
+    "answcdn.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535128575286,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -462,70 +954,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "antdsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aol.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aol.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ap.lijit.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535275471737,
+      "userAction": ""
+    },
+    "ap.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "apester.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535122809239,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535528849979,
+      "nextUpdateTime": 1535336991540,
       "userAction": ""
     },
-    "api-iam.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478349814,
-      "userAction": ""
-    },
-    "api-public.addthis.com": {
+    "api-cache.adsnative.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535028419051,
+      "nextUpdateTime": 1535575652992,
       "userAction": ""
     },
-    "api-v3.tinypass.com": {
+    "api.circularhub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535072558804,
+      "nextUpdateTime": 1535169145890,
       "userAction": ""
     },
-    "api.autopilothq.com": {
+    "api.company-target.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535149168850,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535317179596,
       "userAction": ""
     },
-    "api.bounceexchange.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535356553700,
-      "userAction": ""
-    },
-    "api.flyertown.ca": {
+    "api.ooyala.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535476779656,
-      "userAction": ""
-    },
-    "api.nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535271136144,
-      "userAction": ""
-    },
-    "api.pymx5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535191722826,
-      "userAction": ""
-    },
-    "api.viglink.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535274925730,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apis.google.com": {
@@ -534,10 +1026,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "apn.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535159823561,
+      "nextUpdateTime": 1535218695801,
+      "userAction": ""
+    },
+    "appdynamics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "apple.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aqtracker.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "arcgis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -546,10 +1068,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "areyouahuman.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "arrivalist.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "art19.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535209374580,
+      "nextUpdateTime": 1535501468829,
+      "userAction": ""
+    },
+    "as.casalemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535229691374,
+      "userAction": ""
+    },
+    "asos-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "assets.adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535391921965,
+      "userAction": ""
+    },
+    "assets.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535530764372,
+      "userAction": ""
+    },
+    "atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atemda.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atgsvcs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ati-host.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "att.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -561,7 +1155,25 @@
     "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535345318345,
+      "nextUpdateTime": 1535164070585,
+      "userAction": ""
+    },
+    "audtd.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "auth.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "autoimg.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "autopilothq.com": {
@@ -573,43 +1185,133 @@
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535329606520,
+      "nextUpdateTime": 1535355659377,
+      "userAction": ""
+    },
+    "b.nativendo.de": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535538712482,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535101895013,
+      "nextUpdateTime": 1535483331527,
+      "userAction": ""
+    },
+    "b1img.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535115362722,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535505370686,
       "userAction": ""
     },
-    "ba.demdex.net": {
+    "b92.yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535152380703,
+      "nextUpdateTime": 1535148881205,
+      "userAction": ""
+    },
+    "baidu.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bam-x.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535143260433,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529473453,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535136901003,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535541829645,
+      "userAction": ""
+    },
+    "bazaarvoice.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbb.org": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbbpromos.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbc.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbelements.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535032191274,
+      "nextUpdateTime": 1535487258088,
+      "userAction": ""
+    },
+    "beacon.sojern.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529821305,
+      "userAction": ""
+    },
+    "beatport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "beemray.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "benchtag2.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "betweendigital.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bfmio.com": {
@@ -618,28 +1320,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bfmtv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535492243358,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535526427623,
       "userAction": ""
     },
     "bid.contextweb.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535179689143,
+      "nextUpdateTime": 1535484981338,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535233305767,
+      "nextUpdateTime": 1535558241739,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535143686901,
+      "nextUpdateTime": 1535327480100,
+      "userAction": ""
+    },
+    "biddingx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bidr.io": {
@@ -654,15 +1368,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bigmining.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bigmir.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bing.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bitbucket.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizibly.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizrate.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "blogos.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bloomberg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluecava.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluemix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluetoad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bnidx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -684,16 +1476,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bounceexchange.com": {
+    "boston.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boxinc.sc.omtrdc.net": {
+    "botradar.tech": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535385321750,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "boudja.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bounceexchange.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535062904378,
+      "userAction": ""
+    },
+    "brandcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "brides.com": {
@@ -702,58 +1512,112 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bs.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535067213156,
-      "userAction": ""
-    },
-    "bs.yandex.ru": {
+    "brightcove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535529949166,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "britishairways.d3.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535552042196,
+      "userAction": ""
+    },
+    "bs.serving-sys.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535430149297,
+      "userAction": ""
+    },
+    "btlr.sharethrough.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535546439609,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535054886709,
+      "nextUpdateTime": 1535375679856,
+      "userAction": ""
+    },
+    "btttag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bumlam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c-ctrip.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535137900056,
+      "nextUpdateTime": 1535505105536,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535357523797,
+      "nextUpdateTime": 1535571444799,
       "userAction": ""
     },
-    "c.liadm.com": {
+    "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535145618083,
+      "nextUpdateTime": 1535584627640,
       "userAction": ""
     },
-    "c.statcounter.com": {
+    "c.jsrdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535528454733,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535253163372,
+      "userAction": ""
+    },
+    "c.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315021536,
+      "nextUpdateTime": 1535565223252,
       "userAction": ""
     },
-    "cache.vindicosuite.com": {
+    "c212.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535244807153,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c3tag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cadreon.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -762,22 +1626,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "caltat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "candlewoodsuites.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535234001824,
+      "nextUpdateTime": 1535596662850,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535045856033,
+      "nextUpdateTime": 1535590260745,
       "userAction": ""
     },
-    "casale-match.dotomi.com": {
+    "capturehighered.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535126325622,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "carambo.la": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -786,34 +1668,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cbsi.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cbsistatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ccgateway.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cdn-apple.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535438164044,
+      "nextUpdateTime": 1535214837676,
+      "userAction": ""
+    },
+    "cdn-hotels.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cdn-net.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535185919291,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535608709373,
+      "userAction": ""
+    },
+    "cdn.blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535256296804,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535051441601,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535493360512,
+      "userAction": ""
+    },
+    "cdn.districtm.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535490700346,
+      "userAction": ""
+    },
+    "cdn.dynamicyield.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535411948604,
+      "userAction": ""
+    },
+    "cdn.engine.addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535446078859,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535128940934,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535382379876,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535215121020,
+      "nextUpdateTime": 1535601702055,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -822,40 +1764,82 @@
       "nextUpdateTime": 1529084908284,
       "userAction": ""
     },
-    "cdn.oas-c18.adnxs.com": {
+    "cdn.onthe.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535290993902,
+      "nextUpdateTime": 1535353300697,
+      "userAction": ""
+    },
+    "cdn.pardot.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535617791411,
+      "userAction": ""
+    },
+    "cdn.static.zdbb.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535400873241,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535233843557,
+      "nextUpdateTime": 1535121167406,
       "userAction": ""
     },
-    "cdn.tt.omtrdc.net": {
+    "cdn.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535041458150,
+      "nextUpdateTime": 1535467316593,
       "userAction": ""
     },
     "cdn.viglink.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535427235391,
+      "nextUpdateTime": 1535566437816,
+      "userAction": ""
+    },
+    "cdn.yldbt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535334881641,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535106027323,
+      "nextUpdateTime": 1535143354964,
       "userAction": ""
     },
-    "cdns.gigya.com": {
+    "cdn2.lockerdome.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535141757175,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529533114,
+      "userAction": ""
+    },
+    "cdnwidget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cern.ch": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "changeagain.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "charitynavigator.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -867,7 +1851,79 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535242569428,
+      "nextUpdateTime": 1535134554501,
+      "userAction": ""
+    },
+    "chei.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chicagotribune.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinajob.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinaso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinavivaki.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "choozle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "circularhub.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "civicscience.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ckies.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clickability.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clicktale.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clicktripz.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -882,16 +1938,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "clmbtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cloudflare.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cm.e.qq.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535362642071,
+      "userAction": ""
+    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315162739,
+      "nextUpdateTime": 1535429314447,
+      "userAction": ""
+    },
+    "cm.l.qq.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535280560755,
+      "userAction": ""
+    },
+    "cms.tanx.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535240105058,
+      "userAction": ""
+    },
+    "cnet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535414582808,
+      "nextUpdateTime": 1535142903454,
+      "userAction": ""
+    },
+    "cnn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -900,10 +1998,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "collecte.audience.acpm.fr": {
+    "cnzz.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cobaltgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "coherentpath.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cohesionapps.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483507215,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "collector-963.tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535346254938,
+      "userAction": ""
+    },
+    "collegenet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "comm100.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "commander1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "company-target.com": {
@@ -912,10 +2052,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "condenast.demdex.net": {
+    "complex.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535403196330,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "conative.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -924,10 +2070,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "conductrics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "configusa.veinteractive.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535543444411,
+      "userAction": ""
+    },
+    "connatix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535381483975,
+      "nextUpdateTime": 1535174547715,
+      "userAction": ""
+    },
+    "connexity.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "consensu.org": {
@@ -936,22 +2106,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "consent.cmp.oath.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535501732621,
+      "userAction": ""
+    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumer.krxd.net": {
+    "consumable.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535345800844,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "contextual.media.net": {
+    "contentabc.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535058410852,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "contextweb.com": {
@@ -963,19 +2139,61 @@
     "conv-blizzard-emea.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535068114235,
+      "nextUpdateTime": 1535326160739,
       "userAction": ""
     },
     "conv-blizzard-na.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434015564,
+      "nextUpdateTime": 1535228455740,
+      "userAction": ""
+    },
+    "convertful.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "convertro.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "convio.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cornell.edu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535232747387,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535193184634,
+      "userAction": ""
+    },
+    "cox.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "coxbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cpex.cz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cpx.to": {
@@ -984,7 +2202,49 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cquotient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cr-nielsen.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecommons.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "criteo.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "croissed.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "crowneplaza.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "crsspxl.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -996,69 +2256,207 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cssrvsync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cstatic.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535218329476,
+      "userAction": ""
+    },
+    "ct.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535231836071,
+      "userAction": ""
+    },
+    "ctv.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "curse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "custhelp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cx.atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535375224707,
+      "userAction": ""
+    },
     "cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "d.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535381374242,
-      "userAction": ""
-    },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535298770056,
-      "userAction": ""
-    },
-    "d.la1-c2-dfw.salesforceliveagent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535372426642,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535510911863,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535024017932,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535402065299,
       "userAction": ""
     },
-    "data.ad-score.com": {
+    "d1af033869koo7.cloudfront.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535525960694,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "data.dianomi.com": {
+    "d1rv23qj5kas56.cloudfront.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535390484851,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datacloud-us-east-1.tealiumiq.com": {
+    "d2-apps.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535073773964,
+      "nextUpdateTime": 1535313149602,
+      "userAction": ""
+    },
+    "d41.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "da-ads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dailymail.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dailymotion.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535167766489,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535127779521,
       "userAction": ""
     },
-    "dc.ads.linkedin.com": {
+    "datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "datasteam.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "daum.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "daumcdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "daumdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dc-storm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "de.ioam.de": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535494300698,
+      "nextUpdateTime": 1535553465126,
+      "userAction": ""
+    },
+    "deep.bi": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "delivery.h.switchadhub.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535249908051,
+      "userAction": ""
+    },
+    "dell.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "departapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "deployads.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "deqwas.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "developermedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1068,7 +2466,49 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dezeenjobs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dhs.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "di-dtaectolog-us-prod-1.appspot.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dictionary.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digikulture-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535473213147,
+      "userAction": ""
+    },
+    "digitaladsystems.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaltarget.ru": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1080,16 +2520,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dis.us.criteo.com": {
+    "disney.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535051700652,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535248736855,
+      "nextUpdateTime": 1535514492739,
+      "userAction": ""
+    },
+    "disqus.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "distiltag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "districtm.io": {
@@ -1098,15 +2550,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "djv99sxoqpv11.cloudfront.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535207581785,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535278571573,
+      "userAction": ""
+    },
+    "dmxleo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dnnapi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dol.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "domdex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1116,16 +2598,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dotsub.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "doublemax.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "doublepimpssl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "doubleverify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dpm.demdex.net": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535220813510,
+      "userAction": ""
+    },
+    "dpmsrv.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535141129266,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1134,10 +2646,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dsum-sec.casalemedia.com": {
+    "dx.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535450697822,
+      "nextUpdateTime": 1535284046783,
+      "userAction": ""
+    },
+    "dynad.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1146,10 +2664,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eb2.3lift.com": {
+    "dynatrace-managed.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535466272567,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dyntrk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebay-us.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebay.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1158,7 +2700,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ebaystatic.com": {
+    "ebdr3.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebis.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ecdn.firstimpression.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535480744702,
+      "userAction": ""
+    },
+    "econda-monitor.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ecustomeropinions.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "edge-cdn.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1167,7 +2739,13 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503094601,
+      "nextUpdateTime": 1535109055535,
+      "userAction": ""
+    },
+    "edmunds.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1182,10 +2760,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "em.licasd.com": {
+    "elsevier.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "elsevierhealth.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535483929811,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "emc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "emlgrid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "emxdgt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "engage.commander1.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535417679010,
+      "userAction": ""
+    },
+    "envato.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "epicurious.com": {
@@ -1194,22 +2808,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "equalstyle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "eset.marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535324409999,
+      "userAction": ""
+    },
     "eset.tt.omtrdc.net": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535172647379,
+      "userAction": ""
+    },
+    "espn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "estara.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "estat.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535323726127,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "etracker.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "etsystudio.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510670417,
+      "nextUpdateTime": 1535233686356,
       "userAction": ""
     },
-    "events.mediarithmics.com": {
+    "evenhotels.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535114411199,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "eventsabout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1218,10 +2880,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "everyaction.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535054385053,
+      "nextUpdateTime": 1535412667318,
+      "userAction": ""
+    },
+    "evise.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "evolok.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "evyy.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ew3.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ewscripps.hb.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535440360689,
+      "userAction": ""
+    },
+    "exactag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "excite.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "exe.bid": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "exelator.com": {
@@ -1230,10 +2946,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "exosrv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "expedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535128843717,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535550982016,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1242,28 +2970,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "eyereturn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ezoic.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 1535067712368,
+      "userAction": ""
+    },
+    "facetz.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fairfax.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fastcompany.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535385394512,
+      "nextUpdateTime": 1535532544281,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535108377514,
+      "nextUpdateTime": 1535476086076,
+      "userAction": ""
+    },
+    "fdlstatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "feathr.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1278,34 +3048,172 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ffx.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fidelity-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "filepicker.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "firstimpression.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flashtalking.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flickr.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flipboard.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flyercity.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "fo-api.omnitagjs.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535110977981,
+      "userAction": ""
+    },
+    "fontawesome.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foresee.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "forms.hubspot.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535114875943,
+      "userAction": ""
+    },
+    "formstack.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fout.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fox.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535512337961,
+      "nextUpdateTime": 1535397455637,
+      "userAction": ""
+    },
+    "foxnews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxsports.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxycart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "freeskreen.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436668569,
+      "nextUpdateTime": 1535263330795,
+      "userAction": ""
+    },
+    "freshdesk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "friendbuy.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "funcaptcha.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "funnyordie.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "fusiontables.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "futurenet-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535071225476,
       "userAction": ""
     },
     "fwmrm.net": {
@@ -1316,62 +3224,104 @@
     },
     "g.cn.miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535399901695,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535463525932,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535240351512,
+      "userAction": ""
+    },
+    "g2crowd.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535330828661,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535259298411,
+      "nextUpdateTime": 1535282616525,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535101364820,
+      "nextUpdateTime": 1535324356929,
+      "userAction": ""
+    },
+    "gamer-network.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535176199996,
+      "nextUpdateTime": 1535406151780,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535402637759,
-      "userAction": ""
-    },
-    "gannett.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535343921291,
+      "nextUpdateTime": 1535595384247,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529600416,
+      "userAction": ""
+    },
+    "gemius.pl": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535452798906,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gentags.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535333296953,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535470476213,
       "userAction": ""
     },
-    "geosync.solution.weborama.fr": {
+    "getclicky.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535160445716,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getdrip.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getpocket.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getsmartcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gfycat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gigya.com": {
@@ -1380,9 +3330,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "giphy.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "github.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "globalwebindex.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gmossp-sp.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1398,6 +3372,18 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "goo.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "google.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "google.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1407,7 +3393,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535491836597,
+      "nextUpdateTime": 1535299738930,
       "userAction": ""
     },
     "gq.com": {
@@ -1419,7 +3405,19 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535227663022,
+      "nextUpdateTime": 1535232994108,
+      "userAction": ""
+    },
+    "gridsumdissector.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "groupondata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1428,27 +3426,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gscounters.us1.gigya.com": {
+    "gsimedia.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535212137627,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gslbeacon.lijit.com": {
+    "gssprt.jp": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535485285651,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gum.criteo.com": {
+    "gtags.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535290294755,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "guoshipartners.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1458,88 +3462,298 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hatena.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "hb-api.omnitagjs.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535189695673,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535149948702,
       "userAction": ""
     },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535078071521,
+      "nextUpdateTime": 1535528458660,
       "userAction": ""
     },
-    "i.liadm.com": {
+    "healte.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hearstnp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535529602945,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "help.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hiexpress.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "highwire.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hitslink.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hive.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hlserve.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hm.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535592367417,
+      "userAction": ""
+    },
+    "holidayinn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "holidayinnresorts.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "horyzon-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hotelindigo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hotelsapi.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "htmedia.in": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hubspot.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huffingtonpost.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huffingtonpost.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huihui.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hwcdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hypemarks.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "i.gridsumdissector.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535258286357,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535170174461,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535560008032,
       "userAction": ""
     },
-    "ib.3lift.com": {
+    "i.ua": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535403265784,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "i1img.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ib-ibi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535288809150,
+      "nextUpdateTime": 1535558901666,
       "userAction": ""
     },
-    "ic.tynt.com": {
+    "ibclick.stream": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535495293493,
+      "nextUpdateTime": 1535168630812,
       "userAction": ""
     },
-    "id.cxense.com": {
+    "ibillboard.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535496907922,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ibt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535476999744,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535611501989,
       "userAction": ""
     },
     "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535383207086,
+      "nextUpdateTime": 1535224773713,
       "userAction": ""
     },
-    "idsync.rlcdn.com": {
+    "idealmedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535075793702,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "image2.pubmatic.com": {
+    "ign.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535291313527,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "image6.pubmatic.com": {
+    "igodigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535365119943,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "img.youtube.com": {
+    "iheart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "im-apps.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imagetopng.club": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imedia.cz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "img.ak.impact-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535376841775,
+      "userAction": ""
+    },
+    "img.purch.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535505276490,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imgfarm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imgur.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "impact-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1548,19 +3762,85 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "infinity-tracking.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "infinityid.condenastdigital.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535609251930,
+      "userAction": ""
+    },
+    "infolinks.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "innovid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "inq.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535249104973,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "inside-graph.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535325186526,
+      "nextUpdateTime": 1535259006632,
       "userAction": ""
     },
     "insightexpressai.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "instagram.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "insticator-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535313547846,
+      "userAction": ""
+    },
+    "instinctiveads.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentmedia.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1572,10 +3852,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "intergient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "internetbrands.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535164044525,
+      "nextUpdateTime": 1535212585331,
+      "userAction": ""
+    },
+    "investingchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "investis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "invoc.us": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ioam.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "iperceptions.com": {
@@ -1584,22 +3906,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ips-invite.iperceptions.com": {
+    "ipinyou.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535325289627,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ipredictive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "irs01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "izooto.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535319029672,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535302445154,
       "userAction": ""
     },
-    "js.adsrvr.org": {
+    "janrainsso.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535465747682,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jd.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jquery.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jrs5.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1614,9 +3972,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "justpremium.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jword.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jyxo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kakao.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kameleoon.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1662,9 +4050,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "kinja.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kiwiirc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "l.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1674,16 +4080,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lcidc.liadm.com": {
+    "ladsp.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535169102934,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "li.pxl.ace.advertising.com": {
+    "leadintel.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535477346565,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "leaf.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "legocdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lejwaengv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "liadm.com": {
@@ -1692,9 +4116,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "libero.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "licasd.com": {
       "dnt": false,
       "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "licdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ligadx.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1710,7 +4152,43 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "lincoln.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "link-page.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "linkedin.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "linksynergy.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "list-manage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "listrakbi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "live.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1722,40 +4200,166 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load77.exelator.com": {
+    "livedoor.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "livejournal.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lkqd.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "load.instinctiveads.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535166623245,
+      "nextUpdateTime": 1535156309565,
+      "userAction": ""
+    },
+    "load.sumo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535193129482,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535068047141,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535330758728,
       "userAction": ""
     },
-    "log.outbrain.com": {
+    "loc.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lockerdome.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535602667578,
+      "userAction": ""
+    },
+    "log.mmstat.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535473321187,
+      "nextUpdateTime": 1535614693593,
+      "userAction": ""
+    },
+    "logc187.xiti.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535533148953,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535491014034,
+      "nextUpdateTime": 1535423452721,
+      "userAction": ""
+    },
+    "logly.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535260738970,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535260246626,
       "userAction": ""
     },
-    "m.addthis.com": {
+    "logs1136.xiti.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399926820,
+      "nextUpdateTime": 1535620450441,
+      "userAction": ""
+    },
+    "lptag.liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535381494449,
+      "userAction": ""
+    },
+    "lqm.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lrcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lucklayed.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lwcal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lytics.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "m.reachmax.cn": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535177699423,
+      "userAction": ""
+    },
+    "m6r.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "madeleine.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mail.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mailchimp.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mantisadnetwork.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1776,16 +4380,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "match.adsrvr.org": {
+    "marinsm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535234844708,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketo.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "match.adsrvr.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535382731107,
       "userAction": ""
     },
     "match.prod.bidr.io": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535338080427,
+      "userAction": ""
+    },
+    "matheranalytics.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535264504925,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1794,10 +4422,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mc.yandex.ru": {
+    "me-ssl.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535318601438,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535545627821,
       "userAction": ""
     },
     "media.net": {
@@ -1815,12 +4443,90 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535489306691,
+      "nextUpdateTime": 1535562992042,
+      "userAction": ""
+    },
+    "mediaforge.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medialand.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediaplex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediav.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediawallahscript.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medscape.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medtargetsystem.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mendeley.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "messenger.live.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "metadsp.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mg2connext.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mgid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "miamiherald.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1830,10 +4536,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mid.rkdms.com": {
+    "microad.jp": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535201966174,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoft.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoftonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mid.rkdms.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535261768429,
+      "userAction": ""
+    },
+    "mirtesen.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1845,7 +4575,91 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535082082006,
+      "nextUpdateTime": 1535088403217,
+      "userAction": ""
+    },
+    "mlb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mlive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mmstat.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mmtro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "molefefiseranis.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "monetate.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "monster.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mookie1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mouseflow.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mpnrs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mrpfd.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msgapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mssl.fwmrm.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535132799668,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1860,10 +4674,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mthsense.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mtrx.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535142954690,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535349304856,
       "userAction": ""
     },
     "mts0.google.com": {
@@ -1878,7 +4698,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mtty.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mtvnservices.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "musthird.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "muumuu-domain.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1898,8 +4742,44 @@
     },
     "mx.technolutions.net": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535512750016,
+      "userAction": ""
+    },
+    "mybuys.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myhard.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mynativeplatform.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myregistry.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myspacecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myvisualiq.net": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535404018448,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "nanigans.com": {
@@ -1908,9 +4788,117 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nasdaq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nationalgeographic.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "native.ai": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "native.sharethrough.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535458022322,
+      "userAction": ""
+    },
+    "nativendo.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nbcnews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nbcu.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535351358779,
+      "userAction": ""
+    },
+    "nbcuni.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "netdna-ssl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newatlas.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "neweggimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newscdn.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1923,7 +4911,31 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535018230678,
+      "nextUpdateTime": 1535270929625,
+      "userAction": ""
+    },
+    "newsinc.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsmemory.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsvine.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsweekgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1932,16 +4944,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-a.intercom.io": {
+    "nexac.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535498883050,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-b.intercom.io": {
+    "ngpvan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nih.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nineto5mac-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535229374587,
+      "nextUpdateTime": 1535458910130,
+      "userAction": ""
+    },
+    "nokia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "norton.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1950,16 +4986,124 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oclc.112.2o7.net": {
+    "nsaudience.pl": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535425842674,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "odb.outbrain.com": {
+    "nscontext.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nuggad.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535016850629,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nxtck.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nymag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nzaza.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "o0bg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oasc10.247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535205066735,
+      "userAction": ""
+    },
+    "oath.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ocdn.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oclc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ofapes.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "office.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "office365.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ojrq.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ok.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olark.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olympicchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omkt.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnidsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "omnitagjs.com": {
@@ -1974,9 +5118,75 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "onclickmega.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onecount.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onet.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onetag.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535417103733,
+      "userAction": ""
+    },
     "onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onevision.com.tw": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "online-metrix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onsugar.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onthe.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openhub.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openstat.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1986,15 +5196,75 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "optimize-stats.voxmedia.com": {
+    "opf.ooyala.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535525515019,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "opinionstage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optaim.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optimix.asia": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optimove.events": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ora.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oracleimg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "orangeads.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oreilly.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "otm-r.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "otto.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2004,52 +5274,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ovh.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "owox.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "p.adsymptotic.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535203430840,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535365238469,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535414888339,
+      "nextUpdateTime": 1535168480502,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535206307068,
-      "userAction": ""
-    },
-    "p.liadm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535075363187,
-      "userAction": ""
-    },
-    "p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535358438619,
-      "userAction": ""
-    },
-    "p.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535256790030,
+      "nextUpdateTime": 1535348749572,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535087119968,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535338824891,
+      "userAction": ""
+    },
+    "paddle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pardot.com": {
@@ -2064,39 +5334,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pba.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535115013415,
-      "userAction": ""
-    },
-    "pbbl.co": {
+    "paypal.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pbid.pro-market.net": {
+    "paypalobjects.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535136510150,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pd.sharethis.com": {
+    "payroll.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pba.lijit.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535543859020,
+      "userAction": ""
+    },
+    "pbskids.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pcmag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pdmp.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "performgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "perimeterx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535153992015,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pewresearch.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "phonograph2.voxmedia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535325549253,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535441500485,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535354151599,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pingan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2109,79 +5433,79 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535221836104,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pixel-geo.prfct.co": {
+    "pixanalytics.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535035427244,
-      "userAction": ""
-    },
-    "pixel-sync.sitescout.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535122200195,
-      "userAction": ""
-    },
-    "pixel-us-east.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535379825285,
-      "userAction": ""
-    },
-    "pixel.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535237799393,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535126888506,
+      "nextUpdateTime": 1535444780876,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535139385386,
-      "userAction": ""
-    },
-    "pixel.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535292610867,
+      "nextUpdateTime": 1535344368148,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535355794721,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535558880509,
       "userAction": ""
     },
-    "pixel.rubiconproject.com": {
+    "pixel.s3xified.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535486117158,
+      "nextUpdateTime": 1535454023503,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535164323168,
+      "nextUpdateTime": 1535559337523,
       "userAction": ""
     },
-    "pixeltrack.eyeviewads.com": {
+    "pixel.zprk.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535144814767,
+      "userAction": ""
+    },
+    "piximedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535195842399,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pixnet.cc": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "placed.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "placelocal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535484478744,
+      "nextUpdateTime": 1535124167487,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2196,16 +5520,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "player.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535105086109,
+      "nextUpdateTime": 1535505151187,
+      "userAction": ""
+    },
+    "players.brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535030196338,
+      "nextUpdateTime": 1535388410492,
+      "userAction": ""
+    },
+    "playwire.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "plista.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2217,13 +5565,37 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535441634636,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "polymorphicads.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "popin.cc": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "popsugar-assets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pos.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535294459416,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535168204261,
+      "nextUpdateTime": 1535469659560,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2232,15 +5604,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pr-bh.ybp.yahoo.com": {
+    "powerlinks.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535271792808,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pressboard.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "prfct.co": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2250,28 +5628,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "profile.justuno.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535039428012,
-      "userAction": ""
-    },
-    "ps.eyeota.net": {
+    "prod-mng-proxy-connext.azurewebsites.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535044042579,
+      "nextUpdateTime": 1535243906722,
+      "userAction": ""
+    },
+    "proparm.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "provenpixel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "providesupport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "proximus.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535564390419,
+      "userAction": ""
+    },
+    "proximustv.be": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pscp.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pub.network": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535111836244,
+      "nextUpdateTime": 1535611640025,
       "userAction": ""
     },
-    "pubmatic-match.dotomi.com": {
+    "publishme.se": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535502071689,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2280,69 +5694,141 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubmatic2waycm-atl.netmng.com": {
+    "pubmine.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535177396397,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "purch-match.dotomi.com": {
+    "pulpix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535459595542,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purechat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "px.adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535176013543,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535250433294,
-      "userAction": ""
-    },
-    "px.dynamicyield.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535405852313,
+      "nextUpdateTime": 1535131329876,
       "userAction": ""
     },
-    "px.owneriq.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535291856491,
-      "userAction": ""
-    },
-    "px.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535296720309,
-      "userAction": ""
-    },
-    "px0.pbbl.co": {
+    "pxf.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535076873350,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pxtres.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pxuno.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pxzwei.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535420663273,
+      "nextUpdateTime": 1535033233942,
       "userAction": ""
     },
-    "q.quora.com": {
+    "qantas.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535401599359,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535490587938,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535242881020,
+      "nextUpdateTime": 1535345306051,
+      "userAction": ""
+    },
+    "qnsr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qq.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qsstats.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qtmojo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qualtrics.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quantcast.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535217833076,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quantummetric.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooks.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooksonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2352,10 +5838,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.skimresources.com": {
+    "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535170004392,
+      "nextUpdateTime": 1535217930912,
+      "userAction": ""
+    },
+    "rackcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "radiotime.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rakuten.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2364,39 +5868,135 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rand.d1.sc.omtrdc.net": {
+    "rbnt.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535263109404,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rcom.dynamicyield.com": {
+    "rcsmetrics.it": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535384795636,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reachmax.cn": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535535765113,
+      "nextUpdateTime": 1535304923654,
       "userAction": ""
     },
-    "registercom.sc.omtrdc.net": {
+    "reddit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535462594322,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "registercom.tt.omtrdc.net": {
+    "redlink.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535189737074,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reference.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "regmedia.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "relap.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "republer.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "researchintel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reson8.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "responsetap.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reutersmedia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revjet.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rezync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ria.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richmetrics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richrelevance.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rightnowtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2412,28 +6012,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rp.gwallet.com": {
+    "rnengage.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535380552995,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rs.gwallet.com": {
+    "rockyou.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535231527445,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "roomkey.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "roymorgan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rtax.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535104158026,
+      "nextUpdateTime": 1535222519189,
       "userAction": ""
     },
-    "rtb.districtm.io": {
+    "rtb.com.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535035055571,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rtk.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ru4.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -2444,8 +6068,20 @@
     },
     "rudy.adsnative.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535223087702,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535347337543,
+      "userAction": ""
+    },
+    "rundsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rutarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "s-static.ak.facebook.com": {
@@ -2457,79 +6093,85 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535410059142,
+      "nextUpdateTime": 1535352076386,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535439279491,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535561577916,
       "userAction": ""
     },
-    "s.cpx.to": {
+    "s.clickability.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535479648873,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535224844708,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535058060751,
-      "userAction": ""
-    },
-    "s.jsrdn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535459842092,
-      "userAction": ""
-    },
-    "s.po.st": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535253080228,
+      "nextUpdateTime": 1535201225344,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535135587742,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535214890098,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535507972811,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535434341417,
       "userAction": ""
     },
     "s.yimg.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535314953789,
+      "nextUpdateTime": 1535216141835,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535242557490,
+      "nextUpdateTime": 1535580705625,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535479363146,
+      "nextUpdateTime": 1535131999264,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535493968964,
+      "userAction": ""
+    },
+    "s3-us-west-2.amazonaws.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "s3xified.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535039569298,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535523380151,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535477270241,
+      "userAction": ""
+    },
+    "sabavision.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2538,34 +6180,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "salesloft.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "salesmanago.pl": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "samba.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535072165940,
+      "nextUpdateTime": 1535121885101,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535215807271,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535435991656,
       "userAction": ""
     },
-    "sbnationbidder-d.openx.net": {
+    "sbal4kp.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535218882947,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scarabresearch.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535515673197,
+      "nextUpdateTime": 1535441459044,
       "userAction": ""
     },
-    "scomcluster.cxense.com": {
+    "scholarlyiq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535069100437,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirect.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirectassets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciverse.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scoop.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scopus.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2574,16 +6270,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "scribblelive.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535020426187,
+      "nextUpdateTime": 1535244758147,
+      "userAction": ""
+    },
+    "scripps.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535227106148,
+      "userAction": ""
+    },
+    "script.ioam.de": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sddan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "se.monetate.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535391241554,
+      "userAction": ""
+    },
+    "seadform.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535485865391,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535453750224,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2592,87 +6324,135 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "searchmarketing.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535061912370,
-      "userAction": ""
-    },
-    "secfld.vmmpxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535411085544,
+      "nextUpdateTime": 1535243571282,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418977196,
+      "nextUpdateTime": 1535119927597,
+      "userAction": ""
+    },
+    "secure-cf-c.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "secure-dcr.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535335494368,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535188699282,
+      "nextUpdateTime": 1535584481337,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535356996177,
+      "nextUpdateTime": 1535177741800,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535326763580,
+      "nextUpdateTime": 1535107082511,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535483067072,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535292364343,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535133299962,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535562920063,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535402768464,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535398828987,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535195438164,
+      "nextUpdateTime": 1535351110245,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535504287312,
+      "nextUpdateTime": 1535579341049,
+      "userAction": ""
+    },
+    "secure.statcounter.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535254601040,
+      "userAction": ""
+    },
+    "securedvisit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535282607731,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535591583698,
       "userAction": ""
     },
-    "segments.company-target.com": {
+    "seekingalpha.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535259895831,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sekindo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "selectablemedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "semasio.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sendtonews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2682,9 +6462,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "servedby-buysellads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "serverbid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sessioncam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "shareaholic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2694,27 +6498,87 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sharethrough.adnxs.com": {
+    "sharethrough.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535439209850,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simage2.pubmatic.com": {
+    "sheego.de": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535373129653,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simage4.pubmatic.com": {
+    "shop.pe": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535066804433,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1534791910138,
+      "userAction": ""
+    },
+    "shopify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "simplereach.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "simpli.fi": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.com.cn": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sinoptik.ua": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitehelix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "siteimproveanalytics.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitelabweb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitelock.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2730,9 +6594,69 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sjs.bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535196852776,
+      "userAction": ""
+    },
     "skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sky.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "slashdotmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartadserver.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartclip.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smashing-delivery.herokuapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smi2.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smi2.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smithsonian.museum": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smyte.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2742,9 +6666,99 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "snapwidget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "snplow.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "so.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "socdm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sociomantic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "soflopxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "softonic-analytics.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sogou.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sohu.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sojern.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sokrati.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "solarwinds.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535180937040,
+      "userAction": ""
+    },
+    "soliditet.se": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "solocpm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sonyentertainmentnetwork.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2754,21 +6768,87 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sourceforge.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418102706,
+      "nextUpdateTime": 1535161310463,
       "userAction": ""
     },
-    "sp1cluster.cxense.com": {
+    "sp.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spectate.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sphereup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spiceworks.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535265282354,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spineuniverse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spingo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sportz.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spot.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spotify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spots.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2778,52 +6858,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "springernature.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "springserve.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-22-08.config.parsely.com": {
+    "sprinklr.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535226346743,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-22-09.config.parsely.com": {
+    "srv-2018-08-23-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535482395839,
+      "nextUpdateTime": 1535292359742,
+      "userAction": ""
+    },
+    "srv-2018-08-23-10.config.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535475527218,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535222239514,
+      "nextUpdateTime": 1535550468582,
       "userAction": ""
     },
-    "ssl.siteimprove.com": {
+    "srx.com.sg": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535484066342,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ss3.zedo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535129275153,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535486723866,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535229607025,
       "userAction": ""
     },
-    "ssum-sec.casalemedia.com": {
+    "ssp.adriver.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535090326798,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535203697827,
       "userAction": ""
     },
-    "st.dynamicyield.com": {
+    "st.hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535164370467,
+      "userAction": ""
+    },
+    "stackadapt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535143155903,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "staples-sparx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "staples-static.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "starfieldtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2838,22 +6960,40 @@
       "nextUpdateTime": 1529315030088,
       "userAction": ""
     },
+    "static.apester.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535270017993,
+      "userAction": ""
+    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535046610826,
+      "nextUpdateTime": 1535289627794,
+      "userAction": ""
+    },
+    "static.getclicky.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535459656103,
+      "userAction": ""
+    },
+    "static.mediarithmics.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535318289140,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535212699887,
+      "nextUpdateTime": 1535229325922,
       "userAction": ""
     },
-    "static.quantcast.mgr.consensu.org": {
+    "staticimgfarm.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535515390425,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2865,18 +7005,72 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535271064884,
+      "nextUpdateTime": 1535508331167,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535237146011,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535190455456,
+      "userAction": ""
+    },
+    "staybridge.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "steepto.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stg-sp.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stg8.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stickyadstv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storage.googleapis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storygize.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "streem.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "streetscout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2889,7 +7083,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535269383338,
+      "nextUpdateTime": 1535231190644,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2898,58 +7092,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "suning.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sunrtb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "supplyframe.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "survata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535018613611,
+      "nextUpdateTime": 1535421948525,
+      "userAction": ""
+    },
+    "surveymonkey.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535172174965,
+      "nextUpdateTime": 1535311993890,
       "userAction": ""
     },
-    "sync-tm.everesttech.net": {
+    "switchadhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535283029520,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sync.adaptv.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535249046647,
-      "userAction": ""
-    },
-    "sync.adkernel.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535071305588,
-      "userAction": ""
-    },
-    "sync.bfmio.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535427669787,
-      "userAction": ""
-    },
-    "sync.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535093224646,
-      "userAction": ""
-    },
-    "sync.multiview.com": {
+    "symantec.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535154068185,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "synacor.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sync.1rx.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436844877,
+      "userAction": ""
+    },
+    "sync.audtd.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535423682583,
+      "userAction": ""
+    },
+    "sync.datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535591448993,
+      "userAction": ""
+    },
+    "sync.republer.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535227536756,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535057971306,
+      "nextUpdateTime": 1535404928871,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2958,21 +7188,135 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "t.go.sohu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535161788370,
+      "userAction": ""
+    },
     "taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tacdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tag-st.contextweb.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535575760736,
+      "userAction": ""
+    },
+    "tag.1rx.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535224096496,
+      "userAction": ""
+    },
+    "tag.audience.acpm.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535587928642,
+      "userAction": ""
+    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535198760139,
+      "nextUpdateTime": 1535172809545,
+      "userAction": ""
+    },
+    "tag.marinsm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535169314524,
+      "userAction": ""
+    },
+    "tag.mtrcs.samba.tv": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535482405835,
+      "userAction": ""
+    },
+    "tag.sp.advertising.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535108288134,
+      "userAction": ""
+    },
+    "tag4arm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tagdelivery.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tailtarget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "talkgadget.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tamgrt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tanx.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "taobao.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tapad.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "targetimg1.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tawk.to": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tcell.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "teads.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2988,9 +7332,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "techweb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "telegraph.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "telekom.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tenmax.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "theadex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "theatlas.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3000,28 +7380,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thrtle.com": {
+    "theglobeandmail.ca": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535305777635,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thumbs.ebaystatic.com": {
+    "theguardian.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535105272905,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "thesaurus.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "thomsonreuters.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535432484423,
+      "nextUpdateTime": 1535536640170,
+      "userAction": ""
+    },
+    "tidaltv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tidelinedata.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "timecommerce.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535420021607,
+      "nextUpdateTime": 1535335023989,
+      "userAction": ""
+    },
+    "timewarnercable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tinypass.com": {
@@ -3030,10 +7446,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tiqcdn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tl813.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535026689669,
+      "nextUpdateTime": 1535210811276,
+      "userAction": ""
+    },
+    "tm-awx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tmall.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3044,32 +7484,92 @@
     },
     "token.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535233393938,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535573160300,
       "userAction": ""
     },
-    "top100.rambler.ru": {
+    "toutapp.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535125035641,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535406490099,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535515643596,
+      "userAction": ""
+    },
+    "tracc.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535061545317,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535424312057,
       "userAction": ""
     },
-    "track.eyeviewads.com": {
+    "track.hubspot.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535155370781,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535264130780,
+      "userAction": ""
+    },
+    "trackad.cz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trackalyzer.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tracking.g2crowd.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535237778325,
+      "userAction": ""
+    },
+    "tradedoubler.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tradelab.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "traffic-media.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficgate.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficjam.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficjunky.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3078,10 +7578,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trc.taboola.com": {
+    "travelzoo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trb.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "treasuredata.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535140806281,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tremorhub.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "trends.google.com": {
@@ -3090,9 +7608,99 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "trends.revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535603923908,
+      "userAction": ""
+    },
+    "tribalfusion.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tribl.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535233893141,
+      "userAction": ""
+    },
+    "tripadvisor.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tronc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trumba.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "truoptik.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustarc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustev.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustpilot.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trvl-px.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tumblr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tutorialize.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "twimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3108,40 +7716,178 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "u.openx.net": {
+    "ubi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uciservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uconnect.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535092934568,
+      "nextUpdateTime": 1535393886670,
+      "userAction": ""
+    },
+    "ucoz.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "udmserve.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535539694388,
+      "userAction": ""
+    },
+    "udnfunlife.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uefa.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ufpcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ugdturner.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "unagi-eu.amazon.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535382929843,
+      "nextUpdateTime": 1535196808939,
       "userAction": ""
     },
-    "us-u.openx.net": {
+    "undertone.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unicc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unity.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "universal.iperceptions.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535165883589,
+      "nextUpdateTime": 1535325388047,
       "userAction": ""
     },
-    "us.pixel.newscgp.com": {
+    "unrulymedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535390643472,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us4.siteimprove.com": {
+    "upravel.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535170950487,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us5.siteimprove.com": {
+    "ups.xplosion.de": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535407396093,
+      "userAction": ""
+    },
+    "upsellit.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uptolike.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "urbandictionary.store": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "usa.gov": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535361402673,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "useproof.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "usergram.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "userreport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ustream.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "utarget.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "utarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uuidksinc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "v12group.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -3150,10 +7896,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vid.springserve.com": {
+    "veinteractive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535169227544,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "velaro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "velemh.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vendorlist.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535354855735,
+      "userAction": ""
+    },
+    "verticalhealth.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "veruta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "video.google.com": {
@@ -3162,7 +7950,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "videoamp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "videohub.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vidible.tv": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vilynx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3180,22 +7992,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "visitor-service-us-east-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535199238726,
-      "userAction": ""
-    },
-    "vmmpxl.com": {
+    "virgilio.it": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vmss.boldchat.com": {
+    "visitor-service.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535207908950,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535281447453,
+      "userAction": ""
+    },
+    "visualstudio.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vizury.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vk.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535214742233,
       "userAction": ""
     },
     "vogue.com": {
@@ -3204,10 +8028,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vop.sundaysky.com": {
+    "volvelle.tech": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535027449792,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3216,31 +8040,97 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "w.soundcloud.com": {
+    "vtracy.de": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535180305355,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wam-yahoo.solution.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535313044985,
-      "userAction": ""
-    },
-    "wamfactory.solution.weborama.fr": {
+    "w55c.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535283879516,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wallst.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "waptime.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "warnerbros.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wbtrk.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wcfbc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "weather.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315460235,
+      "nextUpdateTime": 1535205349790,
+      "userAction": ""
+    },
+    "webmd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webpush.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "websimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webspectator.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webtrekk.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3252,15 +8142,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "widgets.outbrain.com": {
+    "weibo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "welt.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "whistleout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "widget.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535484411512,
+      "nextUpdateTime": 1535613320681,
+      "userAction": ""
+    },
+    "wikia-services.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wikimedia.org": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wired.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wise.space": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3270,7 +8196,79 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wishpond.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wishpond.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wkxppshj-qx.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1534814085104,
+      "userAction": ""
+    },
     "wmagazine.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wnyc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wolfram.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woobi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woopic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wordpress.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wrating.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3279,25 +8277,49 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535220842816,
+      "nextUpdateTime": 1535133343141,
       "userAction": ""
     },
-    "ww.steelhousemedia.com": {
+    "wsj.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535108380967,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wsj.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wsod.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wt-eu02.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wurfl.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535451698656,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535160363763,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478914675,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535121108712,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3308,44 +8330,44 @@
     },
     "www.bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535198678997,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535515298218,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535335746123,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535253088334,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535523057317,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535377541215,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535385380509,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535332528512,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535341462375,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535086092034,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535373992834,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535118488381,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535478659047,
       "userAction": ""
     },
     "www.google.com": {
@@ -3356,103 +8378,145 @@
     },
     "www.gq.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535056845706,
-      "userAction": ""
-    },
-    "www.justuno.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535134268596,
+      "nextUpdateTime": 1535109212248,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535412347346,
-      "userAction": ""
-    },
-    "www.linkedin.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503327200,
+      "nextUpdateTime": 1535353938304,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535191271791,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535324760182,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478932878,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535412184727,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535236669569,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535371018711,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535386103543,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535524961484,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535446262570,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535401655245,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535037751236,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535364193938,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535528753563,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535307422760,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535365974182,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535212366928,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535532430753,
-      "userAction": ""
-    },
-    "www.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535024452155,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535257180613,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535040980033,
+      "nextUpdateTime": 1535432091170,
+      "userAction": ""
+    },
+    "wwwimages.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wywyuserservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535454366224,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535372826747,
+      "userAction": ""
+    },
+    "xad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xg4ken.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xinhuanet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xlisting.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xplosion.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xs4all.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xsdownload.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xxxlutz.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3463,6 +8527,12 @@
       "userAction": ""
     },
     "yadro.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3480,13 +8550,67 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yandex.ua": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yastatic.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535352911929,
+      "nextUpdateTime": 1535288290126,
+      "userAction": ""
+    },
+    "yieldify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yieldoptimizer.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yldbt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ymetrica1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535543854128,
+      "userAction": ""
+    },
+    "yoox.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yotpo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "youtube-nocookie.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
@@ -3498,25 +8622,109 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "youvisit.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ypcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yudu.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535507962998,
+      "nextUpdateTime": 1535312844355,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535038311647,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535168425931,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535217382463,
+      "nextUpdateTime": 1535346541264,
+      "userAction": ""
+    },
+    "zedo.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "zemanta.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zendesk.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zergnet.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zhaopin.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zhiziyun.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zidtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ziffdavis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zoho.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zohopublic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zoomph.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3560,12 +8768,7 @@
     "2o7.net": [
       "mysql.com",
       "cdc.gov",
-      "theatlantic.com",
-      "prnewswire.com",
-      "fastcompany.com",
-      "earthlink.net",
-      "qz.com",
-      "oclc.org"
+      "theatlantic.com"
     ],
     "33across.com": [
       "accuweather.com"
@@ -3588,11 +8791,7 @@
     "3lift.com": [
       "nature.com",
       "springer.com",
-      "theverge.com",
-      "usatoday.com",
-      "weather.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "theverge.com"
     ],
     "4dsply.com": [
       "wnd.com"
@@ -3650,8 +8849,7 @@
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr",
-      "leparisien.fr"
+      "liberation.fr"
     ],
     "acquia.com": [
       "panasonic.com",
@@ -3669,9 +8867,6 @@
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
-    ],
-    "ad-score.com": [
-      "wnd.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
@@ -3702,10 +8897,7 @@
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
-      "yahoo.com",
-      "who.int",
-      "columbia.edu",
-      "gulfnews.com"
+      "yahoo.com"
     ],
     "addtoany.com": [
       "irs.gov"
@@ -3717,9 +8909,7 @@
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com",
-      "shutterstock.com",
-      "helsinki.fi"
+      "springer.com"
     ],
     "adfox.ru": [
       "livejournal.com",
@@ -3743,8 +8933,7 @@
     "adition.com": [
       "bloomberg.com",
       "dailymotion.com",
-      "spiegel.de",
-      "lemonde.fr"
+      "spiegel.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -3753,8 +8942,7 @@
     "adkernel.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com",
-      "xda-developers.com"
+      "space.com"
     ],
     "adlmerge.com": [
       "tomsk.ru"
@@ -3773,22 +8961,18 @@
     "adnxs.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net",
-      "nytimes.com",
-      "cisco.com",
-      "jsonline.com",
-      "rfi.fr"
+      "sourceforge.net"
     ],
     "adobe.com": [
       "wikipedia.org",
+      "apache.org",
       "behance.net",
-      "history.com"
+      "msnbc.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
       "bbb.org",
-      "bizjournals.com",
-      "worldbank.org"
+      "bizjournals.com"
     ],
     "adotmob.com": [
       "standard.co.uk",
@@ -3802,22 +8986,17 @@
     "adroll.com": [
       "stumbleupon.com",
       "nature.com",
-      "nginx.org",
-      "cloudflare.com",
-      "ning.com",
-      "case.edu"
+      "nginx.org"
     ],
     "adscale.de": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com",
-      "statista.com"
+      "springer.com"
     ],
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "informationweek.com",
-      "bostonherald.com"
+      "informationweek.com"
     ],
     "adsniper.ru": [
       "rambler.ru"
@@ -3825,11 +9004,7 @@
     "adsrvr.org": [
       "adobe.com",
       "yahoo.com",
-      "googletagmanager.com",
-      "sourceforge.net",
-      "cisco.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "googletagmanager.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -3839,10 +9014,7 @@
     "adsymptotic.com": [
       "tinyurl.com",
       "etsy.com",
-      "tripadvisor.com",
-      "foursquare.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "tripadvisor.com"
     ],
     "adtags.pro": [
       "tomsk.ru"
@@ -3853,10 +9025,7 @@
     "advertising.com": [
       "amazon.com",
       "sourceforge.net",
-      "dropbox.com",
-      "wsj.com",
-      "theverge.com",
-      "walgreens.com"
+      "dropbox.com"
     ],
     "advertur.ru": [
       "radikal.ru"
@@ -3885,10 +9054,7 @@
     "agkn.com": [
       "amazon.com",
       "t-online.de",
-      "bloomberg.com",
-      "cnet.com",
-      "zdnet.com",
-      "zerohedge.com"
+      "bloomberg.com"
     ],
     "aid-ad.jp": [
       "shinobi.jp"
@@ -3904,14 +9070,10 @@
     "ajx130.online": [
       "radikal.ru"
     ],
-    "akamai.net": [
-      "newscientist.com"
-    ],
     "akamaihd.net": [
       "voanews.com",
       "repubblica.it",
-      "iyfubh.com",
-      "forbes.com"
+      "iyfubh.com"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -3931,7 +9093,7 @@
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
-      "sohu.com"
+      "aliexpress.com"
     ],
     "alipay.com": [
       "alibaba.com",
@@ -3943,8 +9105,7 @@
     "allure.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "am15.net": [
       "radikal.ru"
@@ -3952,10 +9113,7 @@
     "amazon-adsystem.com": [
       "amazon.com",
       "nytimes.com",
-      "reddit.com",
-      "cnn.com",
-      "goodreads.com",
-      "bostonherald.com"
+      "reddit.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -3980,8 +9138,7 @@
     "answerscloud.com": [
       "worldbank.org",
       "acs.org",
-      "fbi.gov",
-      "realtor.com"
+      "fbi.gov"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -4008,8 +9165,7 @@
     "app.link": [
       "foursquare.com",
       "history.com",
-      "nbc.com",
-      "strava.com"
+      "nbc.com"
     ],
     "appdynamics.com": [
       "nfl.com"
@@ -4022,17 +9178,13 @@
     "aqtracker.com": [
       "nikkei.com"
     ],
-    "aralego.com": [
-      "accuweather.com"
-    ],
     "arcgis.com": [
       "chron.com"
     ],
     "architecturaldigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
@@ -4054,8 +9206,7 @@
     "atdmt.com": [
       "facebook.com",
       "yahoo.com",
-      "msn.com",
-      "t-online.de"
+      "msn.com"
     ],
     "atemda.com": [
       "springer.com",
@@ -4082,8 +9233,7 @@
     "autopilothq.com": [
       "bitbucket.org",
       "rfc-editor.org",
-      "typeform.com",
-      "quantcast.com"
+      "typeform.com"
     ],
     "b1img.com": [
       "threadless.com"
@@ -4091,15 +9241,10 @@
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com",
-      "sohu.com",
-      "51.la"
+      "ifeng.com"
     ],
     "bam-x.com": [
       "gq.com"
-    ],
-    "barnebys.com": [
-      "lemonde.fr"
     ],
     "bazaarvoice.com": [
       "target.com",
@@ -4141,9 +9286,7 @@
     "bfmio.com": [
       "symantec.com",
       "tinypic.com",
-      "venturebeat.com",
-      "livescience.com",
-      "xda-developers.com"
+      "venturebeat.com"
     ],
     "bfmtv.com": [
       "liberation.fr",
@@ -4155,18 +9298,12 @@
     "bidr.io": [
       "adobe.com",
       "dailymotion.com",
-      "hootsuite.com",
-      "symantec.com",
-      "box.com"
+      "hootsuite.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
-      "amazon.com",
-      "dropbox.com",
-      "theverge.com",
-      "jsonline.com",
-      "walgreens.com"
+      "amazon.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -4179,9 +9316,7 @@
       "vimeo.com",
       "cnn.com",
       "weebly.com",
-      "msn.com",
-      "parallels.com",
-      "pingdom.com"
+      "msn.com"
     ],
     "bitbucket.org": [
       "atlassian.com"
@@ -4189,9 +9324,7 @@
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com",
-      "ibm.com",
-      "gitlab.com"
+      "zendesk.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
@@ -4199,16 +9332,12 @@
     "bizographics.com": [
       "zend.com",
       "nginx.com",
-      "oreilly.com",
-      "jimdo.com",
-      "ox.ac.uk"
+      "oreilly.com"
     ],
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com",
-      "slashdot.org"
+      "ew.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -4223,8 +9352,7 @@
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
-      "sfgate.com",
-      "chron.com"
+      "sfgate.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -4236,23 +9364,21 @@
       "jigsy.com",
       "bravenet.com"
     ],
+    "bobo.com": [
+      "163.com"
+    ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org",
-      "networksolutions.com"
+      "cancer.org"
     ],
     "bonappetit.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "boston.com": [
       "bostonglobe.com"
-    ],
-    "bostonglobemedia.com": [
-      "boston.com"
     ],
     "botradar.tech": [
       "radikal.ru"
@@ -4263,11 +9389,7 @@
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com",
-      "usatoday.com",
-      "fortune.com",
-      "jsonline.com",
-      "pitchfork.com"
+      "wired.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
@@ -4275,14 +9397,14 @@
     "brides.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "brightcove.com": [
       "scholastic.com",
       "si.com",
       "federalreserve.gov",
-      "informationweek.com"
+      "informationweek.com",
+      "straitstimes.com"
     ],
     "brightcove.net": [
       "lefigaro.fr",
@@ -4292,9 +9414,7 @@
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
-      "zendesk.com",
-      "livescience.com",
-      "dailydot.com"
+      "zendesk.com"
     ],
     "btttag.com": [
       "samsung.com",
@@ -4334,18 +9454,12 @@
     "casalemedia.com": [
       "amazon.com",
       "dropbox.com",
-      "myspace.com",
-      "washingtonpost.com",
-      "theverge.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "myspace.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
-      "gamespot.com",
-      "cnet.com",
-      "cbsnews.com"
+      "gamespot.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -4408,6 +9522,10 @@
     "ckies.net": [
       "abril.com.br"
     ],
+    "cleveland.com": [
+      "nola.com",
+      "al.com"
+    ],
     "clickability.com": [
       "prnewswire.com",
       "philly.com",
@@ -4429,7 +9547,6 @@
       "uci.edu",
       "nbcnews.com",
       "sciencemag.org",
-      "symantec.com",
       "allaboutcookies.org"
     ],
     "cnet.com": [
@@ -4441,8 +9558,7 @@
     "cntraveler.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "cnzz.com": [
       "zol.com.cn"
@@ -4473,10 +9589,7 @@
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com",
-      "theverge.com",
-      "jsonline.com",
-      "box.com"
+      "redhat.com"
     ],
     "complex.com": [
       "knowyourmeme.com",
@@ -4489,9 +9602,7 @@
     "condenastdigital.com": [
       "wired.com",
       "arstechnica.com",
-      "nj.com",
-      "newyorker.com",
-      "pitchfork.com"
+      "nj.com"
     ],
     "conductrics.com": [
       "nginx.com"
@@ -4506,10 +9617,7 @@
     "consensu.org": [
       "rollingstone.com",
       "variety.com",
-      "adweek.com",
-      "buzzfeed.com",
-      "thetimes.co.uk",
-      "nme.com"
+      "adweek.com"
     ],
     "consumable.com": [
       "xfinity.com"
@@ -4520,10 +9628,7 @@
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "bloomberg.com",
-      "forbes.com",
-      "uci.edu",
-      "walgreens.com"
+      "bloomberg.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -4551,9 +9656,7 @@
     "cpx.to": [
       "express.co.uk",
       "digitaltrends.com",
-      "techradar.com",
-      "independent.co.uk",
-      "rfi.fr"
+      "techradar.com"
     ],
     "cquotient.com": [
       "gopro.com"
@@ -4571,10 +9674,7 @@
     "criteo.com": [
       "tinyurl.com",
       "washingtonpost.com",
-      "dailymail.co.uk",
-      "dropbox.com",
-      "webmd.com",
-      "sedo.com"
+      "dailymail.co.uk"
     ],
     "croissed.info": [
       "4shared.com"
@@ -4586,6 +9686,9 @@
       "sourceforge.net",
       "slashdot.org",
       "bartleby.com"
+    ],
+    "crwdcntrl.net": [
+      "bloomberg.com"
     ],
     "cssrvsync.com": [
       "springer.com",
@@ -4603,10 +9706,7 @@
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
-      "gizmodo.com",
-      "wsj.com",
-      "cbc.ca",
-      "allafrica.com"
+      "gizmodo.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -4664,11 +9764,7 @@
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "amazon.com",
-      "soundcloud.com",
-      "webmd.com",
-      "jsonline.com",
-      "britishairways.com"
+      "amazon.com"
     ],
     "departapp.com": [
       "liveuamap.com"
@@ -4697,8 +9793,7 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com",
-      "zerohedge.com"
+      "entrepreneur.com"
     ],
     "dictionary.com": [
       "thesaurus.com"
@@ -4714,8 +9809,7 @@
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk",
-      "bostonherald.com"
+      "express.co.uk"
     ],
     "disney.com": [
       "starwars.com"
@@ -4724,19 +9818,15 @@
       "pnas.org",
       "dyn.com",
       "mercurynews.com",
-      "dw.com",
       "rollingstone.com"
     ],
     "distiltag.com": [
-      "reuters.com",
-      "merriam-webster.com"
+      "reuters.com"
     ],
     "districtm.io": [
       "barnesandnoble.com",
       "urbandictionary.com",
-      "axs.com",
-      "timeanddate.com",
-      "newatlas.com"
+      "axs.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
       "4shared.com"
@@ -4759,11 +9849,7 @@
     "dotomi.com": [
       "tinyurl.com",
       "samsung.com",
-      "webmd.com",
-      "forbes.com",
-      "illinois.edu",
-      "jsonline.com",
-      "xda-developers.com"
+      "webmd.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -4771,11 +9857,7 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com",
-      "sourceforge.net",
-      "zend.com",
-      "jsonline.com",
-      "britishairways.com"
+      "linkedin.com"
     ],
     "doublemax.net": [
       "udn.com"
@@ -4790,8 +9872,7 @@
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com",
-      "adweek.com"
+      "techtarget.com"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4799,8 +9880,7 @@
     "dynamicyield.com": [
       "t-online.de",
       "cnbc.com",
-      "nbcnews.com",
-      "washingtonexaminer.com"
+      "nbcnews.com"
     ],
     "dynatrace-managed.com": [
       "delta.com"
@@ -4827,9 +9907,6 @@
       "ebay.com",
       "ebay.com.au"
     ],
-    "ebaystatic.com": [
-      "ebay.com.au"
-    ],
     "ebdr3.com": [
       "springer.com"
     ],
@@ -4852,15 +9929,12 @@
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com",
-      "goal.com"
+      "gulfnews.com"
     ],
     "eloqua.com": [
       "intel.com",
       "cisco.com",
-      "prnewswire.com",
-      "siemens.com",
-      "eset.com"
+      "prnewswire.com"
     ],
     "elsevier.com": [
       "sciencedirect.com",
@@ -4887,8 +9961,7 @@
     "epicurious.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -4919,11 +9992,7 @@
     "everesttech.net": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net",
-      "dailymotion.com",
-      "webmd.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "everyaction.com": [
       "greenpeace.org"
@@ -4954,10 +10023,7 @@
     "exelator.com": [
       "soundcloud.com",
       "forbes.com",
-      "bloomberg.com",
-      "businessinsider.com",
-      "mirror.co.uk",
-      "zerohedge.com"
+      "bloomberg.com"
     ],
     "exosrv.com": [
       "pornhub.com"
@@ -4968,18 +10034,14 @@
     "eyeota.net": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com",
-      "gizmodo.com",
-      "xda-developers.com"
+      "bloomberg.com"
     ],
     "eyereturn.com": [
       "thestar.com",
       "queensu.ca"
     ],
     "eyeviewads.com": [
-      "staples.com",
-      "xda-developers.com",
-      "walgreens.com"
+      "staples.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -4988,11 +10050,7 @@
     "facebook.com": [
       "instagram.com",
       "wordpress.org",
-      "adobe.com",
-      "nytimes.com",
-      "goodreads.com",
-      "jsonline.com",
-      "helsinki.fi"
+      "adobe.com"
     ],
     "facetz.net": [
       "novostimira.com",
@@ -5032,8 +10090,7 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu",
-      "bmj.com"
+      "msu.edu"
     ],
     "flickr.com": [
       "state.gov",
@@ -5051,21 +10108,19 @@
     "flyertown.ca": [
       "canada.com",
       "globalnews.ca",
-      "nationalpost.com",
-      "vancouversun.com"
+      "nationalpost.com"
     ],
     "fontawesome.com": [
       "socarrao.com.br",
       "clinicaltrials.gov",
       "moonfruit.com",
-      "webex.com"
+      "webex.com",
+      "sitepoint.com"
     ],
     "foresee.com": [
       "epa.gov",
       "si.edu",
-      "theglobeandmail.com",
-      "sec.gov",
-      "marthastewart.com"
+      "theglobeandmail.com"
     ],
     "formstack.com": [
       "in.gov"
@@ -5112,9 +10167,7 @@
     "fwmrm.net": [
       "yahoo.com",
       "mlb.com",
-      "xfinity.com",
-      "discovery.com",
-      "hgtv.com"
+      "xfinity.com"
     ],
     "g2crowd.com": [
       "prezi.com",
@@ -5157,9 +10210,7 @@
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au",
-      "sfgate.com",
-      "hgtv.com"
+      "abc.net.au"
     ],
     "giphy.com": [
       "urbandictionary.com",
@@ -5172,8 +10223,7 @@
     "glamour.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
@@ -5193,8 +10243,7 @@
     "golfdigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
@@ -5206,18 +10255,14 @@
       "youtube.com",
       "linkedin.com",
       "google.de",
-      "godaddy.com",
-      "goodreads.com",
       "scmp.com",
       "chromium.org",
-      "jsonline.com",
-      "britishairways.com"
+      "google.be"
     ],
     "gq.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "gridsumdissector.com": [
       "qq.com",
@@ -5226,6 +10271,9 @@
     ],
     "groupondata.com": [
       "groupon.com"
+    ],
+    "grubstreet.com": [
+      "nymag.com"
     ],
     "gsimedia.net": [
       "acehardware.com"
@@ -5241,8 +10289,7 @@
     "gumgum.com": [
       "liveuamap.com",
       "colourlovers.com",
-      "infoplease.com",
-      "coindesk.com"
+      "infoplease.com"
     ],
     "guoshipartners.com": [
       "udn.com"
@@ -5250,9 +10297,10 @@
     "gwallet.com": [
       "adobe.com",
       "ox.ac.uk",
-      "ihg.com",
-      "economist.com",
-      "business2community.com"
+      "ihg.com"
+    ],
+    "gwmtracking.com": [
+      "proofpoint.com"
     ],
     "hadcs.de": [
       "t-online.de"
@@ -5315,8 +10363,7 @@
     "hubspot.com": [
       "wpengine.com",
       "shopify.com",
-      "technologyreview.com",
-      "scoop.it"
+      "technologyreview.com"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
@@ -5367,9 +10414,7 @@
     "id5-sync.com": [
       "bloomberg.com",
       "venturebeat.com",
-      "dailymotion.com",
-      "livescience.com",
-      "xda-developers.com"
+      "dailymotion.com"
     ],
     "idealmedia.com": [
       "alternet.org",
@@ -5413,14 +10458,7 @@
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com",
-      "wsj.com",
-      "altervista.org",
-      "marthastewart.com",
-      "hgtv.com"
-    ],
-    "ineity.pro": [
-      "4shared.com"
+      "bbc.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
@@ -5446,22 +10484,18 @@
     "insightexpressai.com": [
       "unsplash.com",
       "standard.co.uk",
-      "motorola.com",
-      "reddit.com",
-      "gopro.com"
+      "motorola.com"
     ],
     "instagram.com": [
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu",
-      "tmz.com"
+      "arizona.edu"
     ],
     "instinctiveads.com": [
       "variety.com",
       "dp.ua",
-      "blackberry.com",
-      "rollingstone.com"
+      "blackberry.com"
     ],
     "intentiq.com": [
       "sourceforge.net",
@@ -5475,8 +10509,7 @@
     "intercom.io": [
       "themeforest.net",
       "ft.com",
-      "elegantthemes.com",
-      "iconfinder.com"
+      "elegantthemes.com"
     ],
     "intergient.com": [
       "infoplease.com"
@@ -5505,8 +10538,7 @@
     "iperceptions.com": [
       "ford.com",
       "seagate.com",
-      "honeywell.com",
-      "boeing.com"
+      "honeywell.com"
     ],
     "ipinyou.com": [
       "autohome.com.cn"
@@ -5543,8 +10575,7 @@
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com",
-      "vancouversun.com"
+      "dallasnews.com"
     ],
     "justpremium.com": [
       "tvtropes.org"
@@ -5552,8 +10583,7 @@
     "justuno.com": [
       "gartner.com",
       "searchengineland.com",
-      "zenfolio.com",
-      "gopro.com"
+      "zenfolio.com"
     ],
     "jword.jp": [
       "excite.co.jp"
@@ -5572,10 +10602,7 @@
     "keywee.co": [
       "latimes.com",
       "nationalgeographic.com",
-      "chicagotribune.com",
-      "nytimes.com",
-      "rollingstone.com",
-      "apartmenttherapy.com"
+      "chicagotribune.com"
     ],
     "kinja.com": [
       "gizmodo.com",
@@ -5588,11 +10615,7 @@
     "krxd.net": [
       "inhabitat.com",
       "bgr.com",
-      "jalopnik.com",
-      "cnn.com",
-      "gizmodo.com",
-      "jsonline.com",
-      "realtor.com"
+      "jalopnik.com"
     ],
     "ladsp.com": [
       "exblog.jp",
@@ -5615,16 +10638,13 @@
     "liadm.com": [
       "webmd.com",
       "nj.com",
-      "patch.com",
-      "bloomberg.com",
-      "usmagazine.com"
+      "patch.com"
     ],
     "libero.it": [
       "virgilio.it"
     ],
     "licasd.com": [
-      "nj.com",
-      "usmagazine.com"
+      "nj.com"
     ],
     "licdn.com": [
       "linkedin.com"
@@ -5637,16 +10657,12 @@
     "lightboxcdn.com": [
       "zdnet.com",
       "fastcompany.com",
-      "adweek.com",
-      "lifehacker.com",
-      "usmagazine.com"
+      "adweek.com"
     ],
     "lijit.com": [
       "sourceforge.net",
       "bloomberg.com",
-      "deviantart.com",
-      "howstuffworks.com",
-      "infoplease.com"
+      "deviantart.com"
     ],
     "lincoln.com": [
       "ford.com"
@@ -5658,11 +10674,7 @@
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net",
-      "dropbox.com",
-      "cisco.com",
-      "unity3d.com",
-      "helsinki.fi"
+      "sourceforge.net"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
@@ -5697,8 +10709,7 @@
     "liveperson.net": [
       "apache.org",
       "prnewswire.com",
-      "ibm.com",
-      "earthlink.net"
+      "ibm.com"
     ],
     "lkqd.net": [
       "allafrica.com"
@@ -5732,8 +10743,7 @@
     "lytics.io": [
       "adweek.com",
       "digitaltrends.com",
-      "fool.com",
-      "economist.com"
+      "fool.com"
     ],
     "m6r.eu": [
       "t-online.de",
@@ -5745,15 +10755,12 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com",
-      "yandex.ru",
-      "ok.ru"
+      "google.com"
     ],
     "mailchimp.com": [
       "colorlib.com",
       "fas.org",
-      "tias.com",
-      "nap.edu"
+      "tias.com"
     ],
     "mantisadnetwork.com": [
       "tvtropes.org"
@@ -5761,20 +10768,18 @@
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "hootsuite.com",
-      "smugmug.com"
+      "hootsuite.com"
     ],
     "marketlinc.com": [
       "kaspersky.com",
       "norton.com",
-      "eset.com",
-      "teamviewer.us"
+      "eset.com"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
       "dyn.com",
-      "ubuntu.com"
+      "domaintools.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
@@ -5784,25 +10789,17 @@
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net",
-      "forbes.com",
-      "prnewswire.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
-      "forbes.com",
-      "reuters.com",
-      "webmd.com",
-      "cracked.com"
+      "forbes.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
       "uci.edu",
-      "autodesk.com",
-      "box.com"
+      "autodesk.com"
     ],
     "mediaforge.com": [
       "nike.com",
@@ -5820,8 +10817,7 @@
     "mediarithmics.com": [
       "orange.fr",
       "lynda.com",
-      "liberation.fr",
-      "leparisien.fr"
+      "liberation.fr"
     ],
     "mediav.com": [
       "ctrip.com",
@@ -5848,9 +10844,6 @@
       "nypost.com",
       "standard.co.uk"
     ],
-    "mfadsrvr.com": [
-      "jsonline.com"
-    ],
     "mg2connext.com": [
       "mercurynews.com",
       "philly.com",
@@ -5867,9 +10860,7 @@
     "miaozhen.com": [
       "sina.com.cn",
       "163.com",
-      "dzwww.com",
-      "sohu.com",
-      "autohome.com.cn"
+      "dzwww.com"
     ],
     "microad.jp": [
       "rakuten.co.jp",
@@ -5896,18 +10887,12 @@
     "mktoresp.com": [
       "parallels.com",
       "prnewswire.com",
-      "zend.com",
-      "nginx.com",
-      "oreilly.com",
-      "pingdom.com"
+      "zend.com"
     ],
     "ml314.com": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com",
-      "wsj.com",
-      "zdnet.com",
-      "xda-developers.com"
+      "bloomberg.com"
     ],
     "mlb.com": [
       "nhl.com"
@@ -5918,9 +10903,7 @@
     "mmstat.com": [
       "alibaba.com",
       "youku.com",
-      "taobao.com",
-      "sohu.com",
-      "51.la"
+      "taobao.com"
     ],
     "mmtro.com": [
       "upwork.com"
@@ -5939,8 +10922,7 @@
     "mookie1.com": [
       "t-online.de",
       "nbcnews.com",
-      "theglobeandmail.com",
-      "thetimes.co.uk"
+      "theglobeandmail.com"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -5975,8 +10957,7 @@
       "cc.com"
     ],
     "multiview.com": [
-      "symantec.com",
-      "nutrition.org"
+      "symantec.com"
     ],
     "musthird.com": [
       "airbnb.com"
@@ -6003,15 +10984,12 @@
     "myvisualiq.net": [
       "soundcloud.com",
       "surveymonkey.com",
-      "spotify.com",
-      "paypal.com",
-      "dell.com"
+      "spotify.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
       "overstock.com",
-      "squareup.com",
-      "zappos.com"
+      "squareup.com"
     ],
     "narrative.io": [
       "sourceforge.net"
@@ -6047,8 +11025,7 @@
     "nbcuni.com": [
       "cnbc.com",
       "msnbc.com",
-      "nbc.com",
-      "nbcnews.com"
+      "nbc.com"
     ],
     "netdna-ssl.com": [
       "alternet.org"
@@ -6056,9 +11033,7 @@
     "netmng.com": [
       "lenovo.com",
       "theknot.com",
-      "shopko.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "shopko.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -6083,10 +11058,7 @@
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
-      "thesun.co.uk",
-      "wsj.com",
-      "news.com.au",
-      "realtor.com"
+      "thesun.co.uk"
     ],
     "newsinc.com": [
       "latimes.com",
@@ -6107,8 +11079,7 @@
     "newyorker.com": [
       "wired.com",
       "vanityfair.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -6121,7 +11092,7 @@
       "clinicaltrials.gov"
     ],
     "nj.com": [
-      "nola.com"
+      "bleacherreport.com"
     ],
     "nokia.com": [
       "bell-labs.com"
@@ -6132,11 +11103,7 @@
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com",
-      "washingtonpost.com",
-      "domainmarket.com",
-      "jsonline.com",
-      "helsinki.fi"
+      "oracle.com"
     ],
     "nsaudience.pl": [
       "interia.pl"
@@ -6207,15 +11174,12 @@
     "omnitagjs.com": [
       "springer.com",
       "standard.co.uk",
-      "home.pl",
-      "newatlas.com"
+      "home.pl"
     ],
     "omtrdc.net": [
       "adobe.com",
       "amazon.com",
-      "telegraph.co.uk",
-      "dell.com",
-      "eset.com"
+      "telegraph.co.uk"
     ],
     "onclickmega.com": [
       "brothersoft.com"
@@ -6229,9 +11193,7 @@
     "onetrust.com": [
       "themeisle.com",
       "bitbucket.org",
-      "namecheap.com",
-      "thesun.co.uk",
-      "active.com"
+      "namecheap.com"
     ],
     "onevision.com.tw": [
       "udn.com"
@@ -6262,11 +11224,7 @@
     "openx.net": [
       "yahoo.com",
       "amazon.com",
-      "nytimes.com",
-      "dropbox.com",
-      "theverge.com",
-      "jsonline.com",
-      "active.com"
+      "nytimes.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -6281,18 +11239,17 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
+      "nytimes.com",
       "bbc.com",
       "live.com",
       "ibm.com",
-      "wiley.com",
+      "hp.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
-      "constantcontact.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
-      "scientificamerican.com",
       "evernote.com",
       "box.com",
       "prezi.com",
@@ -6302,7 +11259,6 @@
       "accorhotels.com",
       "uber.com",
       "xbox.com",
-      "history.com",
       "bestbuy.com",
       "jamanetwork.com",
       "imageshack.com",
@@ -6311,12 +11267,12 @@
       "metmuseum.org",
       "intuit.com",
       "blizzard.com",
+      "office.com",
       "squareup.com",
       "starbucks.com",
       "ajc.com",
       "justgiving.com",
       "dreamhost.com",
-      "microsoft.com",
       "edx.org",
       "bartleby.com",
       "malwarebytes.com",
@@ -6355,10 +11311,7 @@
     "outbrain.com": [
       "nature.com",
       "scribd.com",
-      "foxnews.com",
-      "cnn.com",
-      "news.com.au",
-      "rfi.fr"
+      "foxnews.com"
     ],
     "ovh.com": [
       "ovh.co.uk"
@@ -6366,8 +11319,7 @@
     "owneriq.net": [
       "lycos.com",
       "lg.com",
-      "washingtontimes.com",
-      "walgreens.com"
+      "washingtontimes.com"
     ],
     "owox.com": [
       "simplesite.com"
@@ -6378,16 +11330,12 @@
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org",
-      "propublica.org"
+      "ap.org"
     ],
     "parsely.com": [
       "time.com",
       "wired.com",
-      "wikia.com",
-      "wsj.com",
-      "fortune.com",
-      "rfi.fr"
+      "wikia.com"
     ],
     "paypal.com": [
       "paypal.me"
@@ -6399,9 +11347,6 @@
     ],
     "payroll.com": [
       "intuit.com"
-    ],
-    "pbbl.co": [
-      "zappos.com"
     ],
     "pbskids.org": [
       "pbs.org"
@@ -6430,16 +11375,12 @@
     "pinterest.com": [
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "nytimes.com",
-      "themeforest.net",
-      "booking.com",
-      "marthastewart.com"
+      "nytimes.com"
     ],
     "pitchfork.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "epicurious.com"
+      "vanityfair.com"
     ],
     "pixanalytics.com": [
       "pixnet.net"
@@ -6466,8 +11407,7 @@
     "po.st": [
       "smithsonianmag.com",
       "wnd.com",
-      "business2community.com",
-      "nme.com"
+      "business2community.com"
     ],
     "polymorphicads.jp": [
       "shinobi.jp"
@@ -6481,10 +11421,7 @@
     "postrelease.com": [
       "reuters.com",
       "independent.co.uk",
-      "chicagotribune.com",
-      "wsj.com",
-      "marketwatch.com",
-      "bostonherald.com"
+      "chicagotribune.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
@@ -6496,14 +11433,12 @@
     ],
     "prfct.co": [
       "smugmug.com",
-      "marthastewart.com",
-      "business2community.com"
+      "marthastewart.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
       "symantec.com",
-      "slashdot.org",
-      "business2community.com"
+      "slashdot.org"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
@@ -6537,11 +11472,7 @@
     "pubmatic.com": [
       "dropbox.com",
       "tinyurl.com",
-      "bloomberg.com",
-      "usatoday.com",
-      "webmd.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "bloomberg.com"
     ],
     "pubmine.com": [
       "foreignpolicy.com",
@@ -6574,8 +11505,7 @@
     "pymx5.com": [
       "seattletimes.com",
       "seattlepi.com",
-      "sfgate.com",
-      "cracked.com"
+      "sfgate.com"
     ],
     "qnsr.com": [
       "serverwatch.com"
@@ -6595,16 +11525,13 @@
     "qualtrics.com": [
       "adidas.com",
       "cnet.com",
-      "babycenter.com"
+      "babycenter.com",
+      "mayoclinic.org"
     ],
     "quantserve.com": [
       "wordpress.org",
       "vimeo.com",
-      "reddit.com",
-      "soundcloud.com",
-      "goodreads.com",
-      "jsonline.com",
-      "rfi.fr"
+      "reddit.com"
     ],
     "quantummetric.com": [
       "macys.com"
@@ -6618,9 +11545,7 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com",
-      "nypost.com",
-      "eset.com"
+      "ning.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -6635,8 +11560,7 @@
       "livejournal.com",
       "washingtonpost.com",
       "novostimira.com",
-      "ria.ru",
-      "kharkov.ua"
+      "ria.ru"
     ],
     "rbnt.org": [
       "radikal.ru"
@@ -6652,9 +11576,6 @@
     "reddit.com": [
       "acm.org",
       "perl.com"
-    ],
-    "redditmedia.com": [
-      "reddit.com"
     ],
     "redlink.com": [
       "jamanetwork.com",
@@ -6698,16 +11619,12 @@
       "bankrate.com"
     ],
     "rezync.com": [
-      "economist.com",
-      "accuweather.com"
+      "economist.com"
     ],
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
-      "npr.org",
-      "forbes.com",
-      "foursquare.com",
-      "gopro.com"
+      "npr.org"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6727,18 +11644,12 @@
     "rkdms.com": [
       "time.com",
       "wired.com",
-      "cbsnews.com",
-      "zdnet.com",
-      "pitchfork.com"
+      "cbsnews.com"
     ],
     "rlcdn.com": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net",
-      "reddit.com",
-      "uci.edu",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "rnengage.com": [
       "oracle.com",
@@ -6765,17 +11676,12 @@
     ],
     "ru4.com": [
       "dropbox.com",
-      "bloomberg.com",
-      "uci.edu"
+      "bloomberg.com"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net",
-      "nytimes.com",
-      "gizmodo.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "rundsp.com": [
       "hpe.com",
@@ -6800,8 +11706,7 @@
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
-      "salesforce.com",
-      "eset.com"
+      "salesforce.com"
     ],
     "salesloft.com": [
       "techtarget.com",
@@ -6848,11 +11753,7 @@
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
-      "tumblr.com",
-      "nytimes.com",
-      "goodreads.com",
-      "jsonline.com",
-      "drugs.com"
+      "tumblr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
@@ -6881,15 +11782,12 @@
     "selectablemedia.com": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com",
-      "marthastewart.com"
+      "ew.com"
     ],
     "self.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "semasio.net": [
       "bloomberg.com"
@@ -6901,8 +11799,7 @@
     "servebom.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com",
-      "xda-developers.com"
+      "space.com"
     ],
     "servedby-buysellads.com": [
       "dribbble.com"
@@ -6913,9 +11810,7 @@
     "serving-sys.com": [
       "dropbox.com",
       "t-online.de",
-      "nbcnews.com",
-      "news.com.au",
-      "hgtv.com"
+      "nbcnews.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -6928,16 +11823,12 @@
     "sharethis.com": [
       "www.uk.com",
       "whatsapp.com",
-      "lycos.com",
-      "uci.edu",
-      "dailycaller.com"
+      "lycos.com"
     ],
     "sharethrough.com": [
       "yahoo.com",
       "cnn.com",
-      "time.com",
-      "cnet.com",
-      "fortune.com"
+      "time.com"
     ],
     "sheego.de": [
       "t-online.de"
@@ -6977,11 +11868,7 @@
     "siteimprove.com": [
       "usda.gov",
       "verisign.com",
-      "udel.edu",
-      "berkeley.edu",
-      "helsinki.fi",
-      "case.edu",
-      "oclc.org"
+      "udel.edu"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
@@ -6997,16 +11884,12 @@
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "seattletimes.com",
-      "accuweather.com",
-      "newatlas.com"
+      "seattletimes.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com",
-      "arstechnica.com",
-      "coindesk.com"
+      "gizmodo.com"
     ],
     "sky.com": [
       "skygroup.sky",
@@ -7043,10 +11926,7 @@
     "snapchat.com": [
       "jimdo.com",
       "overstock.com",
-      "complex.com",
-      "wsj.com",
-      "giphy.com",
-      "zappos.com"
+      "complex.com"
     ],
     "snapwidget.com": [
       "udel.edu"
@@ -7097,11 +11977,7 @@
     "sonobi.com": [
       "photobucket.com",
       "deviantart.com",
-      "springer.com",
-      "forbes.com",
-      "theverge.com",
-      "jsonline.com",
-      "couchsurfing.com"
+      "springer.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -7110,7 +11986,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "mo.gov"
+      "irishtimes.com"
     ],
     "sourceforge.net": [
       "libpng.org"
@@ -7151,9 +12027,7 @@
     "spotxchange.com": [
       "amazon.com",
       "dropbox.com",
-      "dailymotion.com",
-      "thenextweb.com",
-      "bostonherald.com"
+      "dailymotion.com"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -7167,8 +12041,7 @@
     "springserve.com": [
       "tinypic.com",
       "liveuamap.com",
-      "magento.com",
-      "dailydot.com"
+      "magento.com"
     ],
     "sprinklr.com": [
       "autodesk.com"
@@ -7193,9 +12066,7 @@
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org",
-      "cbslocal.com",
-      "zerohedge.com"
+      "man7.org"
     ],
     "staticimgfarm.com": [
       "excite.com"
@@ -7206,8 +12077,7 @@
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "istockphoto.com",
-      "careerbuilder.com"
+      "istockphoto.com"
     ],
     "steepto.com": [
       "liveleak.com"
@@ -7248,14 +12118,12 @@
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com",
-      "makezine.com"
+      "studiopress.com"
     ],
     "sundaysky.com": [
       "overstock.com",
       "alternet.org",
-      "infoplease.com",
-      "dailydot.com"
+      "infoplease.com"
     ],
     "suning.com": [
       "qq.com",
@@ -7279,8 +12147,7 @@
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
-      "indianexpress.com",
-      "springer.com"
+      "indianexpress.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -7292,11 +12159,7 @@
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
-      "t-online.de",
-      "msn.com",
-      "zdnet.com",
-      "jsonline.com",
-      "edmunds.com"
+      "t-online.de"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -7323,14 +12186,12 @@
       "sina.com.cn",
       "1688.com",
       "tmall.com",
-      "51.la"
+      "alibaba.com"
     ],
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
-      "soundcloud.com",
-      "dropbox.com",
-      "newyorker.com"
+      "soundcloud.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -7347,20 +12208,12 @@
     "tealiumiq.com": [
       "ibm.com",
       "cbsnews.com",
-      "evernote.com",
-      "cnet.com",
-      "politico.com",
-      "usmagazine.com"
+      "evernote.com"
     ],
     "technolutions.net": [
       "illinois.edu",
       "upenn.edu",
-      "uci.edu",
-      "udel.edu",
-      "case.edu"
-    ],
-    "technoratimedia.com": [
-      "accuweather.com"
+      "uci.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -7368,8 +12221,7 @@
     "teenvogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "telegraph.co.uk": [
       "wordpress.com"
@@ -7391,8 +12243,7 @@
     "thebrighttag.com": [
       "netflix.com",
       "wufoo.com",
-      "playstation.com",
-      "zappos.com"
+      "playstation.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -7406,9 +12257,6 @@
     "thomsonreuters.com": [
       "reuters.com"
     ],
-    "thrtle.com": [
-      "xda-developers.com"
-    ],
     "tidaltv.com": [
       "dailymotion.com",
       "nationalgeographic.com",
@@ -7420,9 +12268,7 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com",
-      "marthastewart.com"
+      "ew.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -7430,19 +12276,14 @@
     "tinypass.com": [
       "businessinsider.com",
       "techcrunch.com",
-      "kickstarter.com",
-      "bloomberg.com",
-      "gizmodo.com",
-      "vancouversun.com"
+      "kickstarter.com"
     ],
     "tiqcdn.com": [
       "cisco.com",
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
-      "marketwatch.com",
-      "hpe.com",
-      "orange.fr"
+      "hpe.com"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -7457,10 +12298,7 @@
     "tns-counter.ru": [
       "livejournal.com",
       "vk.com",
-      "yandex.ru",
-      "mail.ru",
-      "ok.ru",
-      "radikal.ru"
+      "yandex.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
@@ -7516,8 +12354,7 @@
     "tribalfusion.com": [
       "dailymotion.com",
       "pastebin.com",
-      "liveleak.com",
-      "marriott.com"
+      "liveleak.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -7562,10 +12399,7 @@
     "turn.com": [
       "bloomberg.com",
       "wired.com",
-      "webmd.com",
-      "economist.com",
-      "booking.com",
-      "pitchfork.com"
+      "webmd.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
@@ -7573,9 +12407,7 @@
     "tvsquared.com": [
       "telegraph.co.uk",
       "jimdo.com",
-      "squarespace.com",
-      "economist.com",
-      "booking.com"
+      "squarespace.com"
     ],
     "twimg.com": [
       "coe.int",
@@ -7586,21 +12418,13 @@
       "wordpress.org",
       "yahoo.com",
       "chicagotribune.com",
-      "nytimes.com",
       "cnn.com",
-      "msn.com",
-      "ca.gov",
-      "parallels.com",
-      "sfgate.com",
-      "marthastewart.com",
-      "helsinki.fi",
-      "edmunds.com"
+      "cnet.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com",
-      "dailycaller.com"
+      "washingtontimes.com"
     ],
     "ubi.com": [
       "ubisoft.com"
@@ -7663,8 +12487,7 @@
     "usa.gov": [
       "transportation.gov",
       "dhs.gov",
-      "usembassy.gov",
-      "osha.gov"
+      "usembassy.gov"
     ],
     "useproof.com": [
       "iconosquare.com"
@@ -7696,8 +12519,7 @@
     "vanityfair.com": [
       "wired.com",
       "newyorker.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "veinteractive.com": [
       "prweb.com",
@@ -7729,23 +12551,17 @@
       "hpe.com"
     ],
     "videohub.tv": [
-      "liveuamap.com",
-      "wsj.com",
-      "uci.edu"
+      "liveuamap.com"
     ],
     "vidible.tv": [
       "aol.com",
       "nydailynews.com",
-      "autoblog.com",
-      "huffingtonpost.com"
+      "autoblog.com"
     ],
     "viglink.com": [
       "zdnet.com",
       "softonic.com",
-      "techrepublic.com",
-      "cnet.com",
-      "thedailybeast.com",
-      "xda-developers.com"
+      "techrepublic.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
@@ -7758,16 +12574,12 @@
       "livestream.com",
       "wufoo.com",
       "heroku.com",
-      "emarketer.com",
-      "oclc.org"
+      "designboom.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
       "fortune.com",
-      "people.com",
-      "time.com",
-      "marthastewart.com",
-      "zappos.com"
+      "people.com"
     ],
     "virgilio.it": [
       "libero.it"
@@ -7781,17 +12593,12 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru",
-      "yandex.ru"
-    ],
-    "vmmpxl.com": [
-      "networksolutions.com"
+      "ria.ru"
     ],
     "vogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "volvelle.tech": [
       "prweb.com",
@@ -7807,11 +12614,13 @@
     "vtracy.de": [
       "bloomberg.com"
     ],
+    "vulture.com": [
+      "nymag.com"
+    ],
     "w55c.net": [
       "hpe.com",
       "ebay.com",
-      "sourceforge.net",
-      "pbs.org"
+      "sourceforge.net"
     ],
     "wallst.com": [
       "reuters.com"
@@ -7840,8 +12649,7 @@
     "weborama.fr": [
       "lemonde.fr",
       "rbc.ru",
-      "lexpress.fr",
-      "leparisien.fr"
+      "lexpress.fr"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -7865,8 +12673,7 @@
     "webtrendslive.com": [
       "nature.com",
       "abc.net.au",
-      "oup.com",
-      "dhl.com"
+      "oup.com"
     ],
     "weibo.com": [
       "sina.com.cn"
@@ -7890,8 +12697,7 @@
     "wired.com": [
       "newyorker.com",
       "vanityfair.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "wise.space": [
       "purevolume.com"
@@ -7901,7 +12707,7 @@
       "suntimes.com",
       "canada.com",
       "globalnews.ca",
-      "bostonherald.com"
+      "vancouversun.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
@@ -7928,8 +12734,7 @@
     "wmagazine.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "wnyc.org": [
       "newyorker.com",
@@ -7997,9 +12802,7 @@
     "xiti.com": [
       "lemonde.fr",
       "unblog.fr",
-      "uefa.com",
-      "skyrock.com",
-      "leparisien.fr"
+      "uefa.com"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
@@ -8020,25 +12823,17 @@
     "yadro.ru": [
       "vk.com",
       "novostimira.com",
-      "mail.ru",
-      "rt.com",
-      "ok.ru",
-      "radikal.ru"
+      "mail.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
-      "rakuten.co.jp",
-      "economist.com",
-      "biglobe.ne.jp"
+      "rakuten.co.jp"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
-      "flickr.com",
-      "sourceforge.net",
-      "theverge.com",
-      "xda-developers.com"
+      "flickr.com"
     ],
     "yahoosmallbusiness.com": [
       "yahoo.com"
@@ -8048,12 +12843,7 @@
       "opera.com",
       "stanford.edu",
       "ning.com",
-      "rt.com",
-      "fourseasons.com",
-      "radikal.ru",
-      "yandex.com",
-      "kharkov.ua",
-      "rambler.ru"
+      "fourseasons.com"
     ],
     "yandex.ua": [
       "kharkov.ua",
@@ -8062,8 +12852,7 @@
     "yastatic.net": [
       "qip.ru",
       "tass.ru",
-      "radikal.ru",
-      "yandex.com"
+      "radikal.ru"
     ],
     "yieldify.com": [
       "logitech.com"
@@ -8071,8 +12860,7 @@
     "yieldlab.net": [
       "spiegel.de",
       "heise.de",
-      "faz.net",
-      "statista.com"
+      "faz.net"
     ],
     "yieldoptimizer.com": [
       "ihg.com",
@@ -8084,15 +12872,12 @@
       "flickr.com",
       "nytimes.com",
       "dropbox.com",
-      "aol.com",
-      "qualtrics.com",
       "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
-      "newyorker.com",
-      "pcworld.com"
+      "newyorker.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -8117,12 +12902,9 @@
       "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
-      "redhat.com",
-      "skyrock.com",
       "caltech.edu",
-      "dailykos.com",
-      "honeywell.com",
-      "amazon.com"
+      "acm.org",
+      "honeywell.com"
     ],
     "youvisit.com": [
       "osu.edu",
@@ -8138,8 +12920,7 @@
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com",
-      "everydayhealth.com"
+      "ign.com"
     ],
     "zedo.com": [
       "tinypic.com",
@@ -8149,10 +12930,7 @@
     "zemanta.com": [
       "independent.co.uk",
       "thehill.com",
-      "farfetch.com",
-      "paypal.com",
-      "lemonde.fr",
-      "infoplease.com"
+      "farfetch.com"
     ],
     "zendesk.com": [
       "jugem.jp",
@@ -8163,7 +12941,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "marketwatch.com"
+      "wunderground.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -8189,14 +12967,11 @@
       "biglobe.ne.jp",
       "uga.edu"
     ],
-    "zopim.com": [
-      "lulu.com"
-    ],
     "zprk.io": [
       "news.com.au",
       "theaustralian.com.au",
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.22"
+  "version": "2018.8.23"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,7 +3,13 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537523787722,
+      "nextUpdateTime": 1535295667139,
+      "userAction": ""
+    },
+    "112-tzm-766.mktoresp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535189289123,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,43 +33,31 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537882843856,
-      "userAction": ""
-    },
-    "1dmp.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535312804098,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537605774759,
-      "userAction": ""
-    },
-    "247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535134607453,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537672087946,
+      "nextUpdateTime": 1535331723304,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537759773496,
+      "nextUpdateTime": 1535040469247,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537525630119,
+      "nextUpdateTime": 1535364762306,
       "userAction": ""
     },
     "2o7.net": {
@@ -78,220 +72,148 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "4139589.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537489663543,
-      "userAction": ""
-    },
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537839020503,
+      "nextUpdateTime": 1535356269183,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537806789164,
+      "nextUpdateTime": 1535074621092,
+      "userAction": ""
+    },
+    "4303900.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535426959834,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550836808,
-      "userAction": ""
-    },
-    "4488211.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537634827185,
+      "nextUpdateTime": 1535137738544,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537660954849,
+      "nextUpdateTime": 1535183264209,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537616474930,
+      "nextUpdateTime": 1535280524361,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537903679851,
-      "userAction": ""
-    },
-    "5035317.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537641921682,
-      "userAction": ""
-    },
-    "516-dgm-318.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537562933555,
+      "nextUpdateTime": 1535472616612,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537758474854,
+      "nextUpdateTime": 1535031682414,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537647432807,
+      "nextUpdateTime": 1535215572202,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537658367928,
+      "nextUpdateTime": 1535177286890,
       "userAction": ""
     },
     "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537467654547,
+      "nextUpdateTime": 1535018916902,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537755076104,
+      "nextUpdateTime": 1535274302650,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537709469941,
+      "nextUpdateTime": 1535389775911,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537696294907,
-      "userAction": ""
-    },
-    "8136595.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537582726061,
+      "nextUpdateTime": 1535445598247,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537660816632,
-      "userAction": ""
-    },
-    "8329645.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537554078620,
+      "nextUpdateTime": 1535518717819,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537684895391,
+      "nextUpdateTime": 1535325869162,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537837354591,
-      "userAction": ""
-    },
-    "a.postrelease.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537515526187,
+      "nextUpdateTime": 1535522409644,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537636809064,
-      "userAction": ""
-    },
-    "a.tribalfusion.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537958298176,
-      "userAction": ""
-    },
-    "a.volvelle.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537841163145,
+      "nextUpdateTime": 1535199928678,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537476962673,
-      "userAction": ""
-    },
-    "a2.zassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537619523629,
-      "userAction": ""
-    },
-    "a2352870194.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537899708209,
+      "nextUpdateTime": 1535405476367,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537759103890,
+      "nextUpdateTime": 1535121490945,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537776388617,
+      "nextUpdateTime": 1535247839389,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537630083868,
+      "nextUpdateTime": 1535208406610,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537555408578,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535357668253,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537905178162,
-      "userAction": ""
-    },
-    "aax-us-east.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537913502506,
-      "userAction": ""
-    },
-    "aax.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537906291842,
+      "nextUpdateTime": 1535409461357,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -302,14 +224,14 @@
     },
     "accounts.us1.gigya.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537601074233,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535156435397,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537557514250,
+      "nextUpdateTime": 1535108086040,
       "userAction": ""
     },
     "acpm.fr": {
@@ -318,34 +240,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "action.media6degrees.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535233559120,
+      "userAction": ""
+    },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537770198983,
+      "nextUpdateTime": 1535445319044,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537767132056,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535108800392,
+      "userAction": ""
+    },
+    "ad-score.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537485350920,
-      "userAction": ""
-    },
-    "ad.wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537516510407,
-      "userAction": ""
-    },
-    "addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535102726609,
       "userAction": ""
     },
     "addthis.com": {
@@ -372,22 +294,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admission.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adobedtm.com": {
+    "ado.pro-market.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535519674298,
       "userAction": ""
     },
     "adroll.com": {
@@ -396,46 +312,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537516218769,
-      "userAction": ""
-    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537626134365,
+      "nextUpdateTime": 1535398864857,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537724241784,
+      "nextUpdateTime": 1535306789983,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537486989192,
+      "nextUpdateTime": 1535092678429,
+      "userAction": ""
+    },
+    "ads.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535426799358,
+      "userAction": ""
+    },
+    "ads.yahoo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535030171231,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537708083756,
+      "nextUpdateTime": 1535335292087,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537655918135,
+      "nextUpdateTime": 1535060659368,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537843092747,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535399234345,
       "userAction": ""
     },
     "adsnative.com": {
@@ -462,40 +384,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adzerk.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aidata.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "aimfar.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537722347207,
-      "userAction": ""
-    },
-    "aimfr.solution.weborama.fr": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537807566362,
-      "userAction": ""
-    },
-    "akamaihd.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535397031257,
       "userAction": ""
     },
     "allure.com": {
@@ -510,6 +408,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazon.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "amazoncustomerservice.d2.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -519,25 +423,37 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537524155167,
+      "nextUpdateTime": 1535221452777,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537553863674,
+      "nextUpdateTime": 1535417025823,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537697793123,
+      "nextUpdateTime": 1535346469077,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537579018050,
+      "nextUpdateTime": 1535137200226,
+      "userAction": ""
+    },
+    "an.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535052792707,
+      "userAction": ""
+    },
+    "analytics.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535128575286,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -549,61 +465,67 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537594235413,
+      "nextUpdateTime": 1535122809239,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537632246708,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535528849979,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537678263693,
+      "nextUpdateTime": 1535478349814,
+      "userAction": ""
+    },
+    "api-public.addthis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535028419051,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537568296851,
+      "nextUpdateTime": 1535072558804,
       "userAction": ""
     },
-    "api.adsnative.com": {
+    "api.autopilothq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537621901239,
+      "nextUpdateTime": 1535149168850,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537740805532,
-      "userAction": ""
-    },
-    "api.circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537919792740,
+      "nextUpdateTime": 1535356553700,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537467277113,
+      "nextUpdateTime": 1535476779656,
+      "userAction": ""
+    },
+    "api.nanigans.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535271136144,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537525258759,
+      "nextUpdateTime": 1535191722826,
       "userAction": ""
     },
     "api.viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537628885397,
+      "nextUpdateTime": 1535274925730,
       "userAction": ""
     },
     "apis.google.com": {
@@ -615,7 +537,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537815247633,
+      "nextUpdateTime": 1535159823561,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -624,40 +546,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537452967901,
-      "userAction": ""
-    },
-    "as.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537604250626,
-      "userAction": ""
-    },
-    "assets-gulfnews.sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537535218026,
-      "userAction": ""
-    },
-    "assets.adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537685560379,
-      "userAction": ""
-    },
-    "atlasobscura-travel.t.domdex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537769347318,
+      "nextUpdateTime": 1535209374580,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -666,76 +558,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.pixel.newscgp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537470177567,
-      "userAction": ""
-    },
     "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537753859069,
+      "nextUpdateTime": 1535345318345,
       "userAction": ""
     },
-    "avn.innity.com": {
+    "autopilothq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537492777061,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537781953417,
+      "nextUpdateTime": 1535329606520,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537708713404,
+      "nextUpdateTime": 1535101895013,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537850537520,
+      "nextUpdateTime": 1535115362722,
       "userAction": ""
     },
-    "baidu.com": {
+    "ba.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535152380703,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537861157001,
+      "nextUpdateTime": 1535143260433,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537750898790,
+      "nextUpdateTime": 1535136901003,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537689859400,
-      "userAction": ""
-    },
-    "beacon.sojern.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537672342487,
-      "userAction": ""
-    },
-    "beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535032191274,
       "userAction": ""
     },
     "bfmio.com": {
@@ -746,26 +620,26 @@
     },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537876030242,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535492243358,
       "userAction": ""
     },
     "bid.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537727034118,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535179689143,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537674443840,
+      "nextUpdateTime": 1535233305767,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537764450557,
+      "nextUpdateTime": 1535143686901,
       "userAction": ""
     },
     "bidr.io": {
@@ -792,18 +666,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bizrate.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "block.lp1block.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537539284902,
-      "userAction": ""
-    },
     "boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -828,6 +690,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "boxinc.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535385321750,
+      "userAction": ""
+    },
     "brides.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -837,61 +705,55 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537847715087,
+      "nextUpdateTime": 1535067213156,
+      "userAction": ""
+    },
+    "bs.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535529949166,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537560032812,
+      "nextUpdateTime": 1535054886709,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537515889831,
+      "nextUpdateTime": 1535137900056,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537837415606,
-      "userAction": ""
-    },
-    "c.deployads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537858571539,
+      "nextUpdateTime": 1535357523797,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537866121849,
-      "userAction": ""
-    },
-    "c.pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537906295980,
+      "nextUpdateTime": 1535145618083,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537569480916,
-      "userAction": ""
-    },
-    "c1.neweggimages.com": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537830208904,
+      "nextUpdateTime": 1535528454733,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537459132298,
+      "nextUpdateTime": 1535315021536,
+      "userAction": ""
+    },
+    "cache.vindicosuite.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535244807153,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -900,10 +762,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "canwestglobal.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535234001824,
+      "userAction": ""
+    },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537860188041,
+      "nextUpdateTime": 1535045856033,
+      "userAction": ""
+    },
+    "casale-match.dotomi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535126325622,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -915,115 +789,73 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537952708382,
+      "nextUpdateTime": 1535438164044,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537894424784,
-      "userAction": ""
-    },
-    "cdn.conversant.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537839731513,
+      "nextUpdateTime": 1535185919291,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537882453116,
+      "nextUpdateTime": 1535051441601,
       "userAction": ""
     },
-    "cdn.districtm.io": {
+    "cdn.justuno.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537652824451,
-      "userAction": ""
-    },
-    "cdn.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537702491205,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535128940934,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537558524129,
+      "nextUpdateTime": 1535215121020,
+      "userAction": ""
+    },
+    "cdn.native.ai": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1529084908284,
       "userAction": ""
     },
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537636079695,
-      "userAction": ""
-    },
-    "cdn.onthe.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537786940871,
-      "userAction": ""
-    },
-    "cdn.selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537631039742,
-      "userAction": ""
-    },
-    "cdn.siftscience.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537918282363,
-      "userAction": ""
-    },
-    "cdn.static.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537690344667,
+      "nextUpdateTime": 1535290993902,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537519408272,
+      "nextUpdateTime": 1535233843557,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537558429193,
-      "userAction": ""
-    },
-    "cdn.tynt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537664574694,
-      "userAction": ""
-    },
-    "cdn.useproof.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537581699904,
+      "nextUpdateTime": 1535041458150,
       "userAction": ""
     },
     "cdn.viglink.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537893245832,
+      "nextUpdateTime": 1535427235391,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537510786988,
+      "nextUpdateTime": 1535106027323,
       "userAction": ""
     },
-    "changeagain.me": {
+    "cdns.gigya.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537608291316,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535141757175,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -1035,37 +867,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537543528064,
-      "userAction": ""
-    },
-    "chirp.bizrate.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537767361677,
-      "userAction": ""
-    },
-    "circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ck.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537813214078,
-      "userAction": ""
-    },
-    "ckies.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537727954791,
-      "userAction": ""
-    },
-    "clickability.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535242569428,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -1083,31 +885,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537874053443,
-      "userAction": ""
-    },
-    "cm.ipinyou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537867900784,
-      "userAction": ""
-    },
-    "cm.pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537608629045,
-      "userAction": ""
-    },
-    "cmp.smartadserver.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537552077164,
+      "nextUpdateTime": 1535315162739,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537834017634,
+      "nextUpdateTime": 1535414582808,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -1116,34 +900,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collect-eu-west-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537881878643,
-      "userAction": ""
-    },
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537839202775,
-      "userAction": ""
-    },
-    "collector-pxbecn7fqx.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537708477519,
-      "userAction": ""
-    },
-    "commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535483507215,
       "userAction": ""
     },
     "company-target.com": {
@@ -1155,7 +915,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537532540484,
+      "nextUpdateTime": 1535403196330,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -1164,40 +924,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "config.lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537725971184,
-      "userAction": ""
-    },
-    "configusa.veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537500033910,
-      "userAction": ""
-    },
-    "connatix.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537748225044,
+      "nextUpdateTime": 1535381483975,
       "userAction": ""
     },
     "consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "consent-pref.trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537709448258,
       "userAction": ""
     },
     "consent.google.com": {
@@ -1209,13 +945,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537501606547,
+      "nextUpdateTime": 1535345800844,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537773991938,
+      "nextUpdateTime": 1535058410852,
       "userAction": ""
     },
     "contextweb.com": {
@@ -1227,43 +963,25 @@
     "conv-blizzard-emea.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537925186078,
+      "nextUpdateTime": 1535068114235,
       "userAction": ""
     },
     "conv-blizzard-na.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537555515485,
-      "userAction": ""
-    },
-    "core.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537786354696,
+      "nextUpdateTime": 1535434015564,
       "userAction": ""
     },
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537671549081,
+      "nextUpdateTime": 1535232747387,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cquotient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cr.frontend.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537492445133,
       "userAction": ""
     },
     "criteo.com": {
@@ -1275,19 +993,7 @@
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537613129543,
-      "userAction": ""
-    },
-    "csi.gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537727420108,
-      "userAction": ""
-    },
-    "cstatic.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537815897116,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cxense.com": {
@@ -1299,76 +1005,58 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537760155029,
-      "userAction": ""
-    },
-    "d.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537624262906,
+      "nextUpdateTime": 1535381374242,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537517182021,
+      "nextUpdateTime": 1535298770056,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537841732692,
+      "nextUpdateTime": 1535372426642,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537846817170,
+      "nextUpdateTime": 1535024017932,
       "userAction": ""
     },
-    "d3kkw-y716t.ads.tremorhub.com": {
+    "data.ad-score.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537748341344,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535525960694,
       "userAction": ""
     },
     "data.dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537599056552,
+      "nextUpdateTime": 1535390484851,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537601944767,
+      "nextUpdateTime": 1535073773964,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537599995118,
+      "nextUpdateTime": 1535167766489,
       "userAction": ""
     },
-    "daum.net": {
+    "dc.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "delivery.zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537523645440,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535494300698,
       "userAction": ""
     },
     "demdex.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1380,27 +1068,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "digikulture-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537523129525,
-      "userAction": ""
-    },
-    "digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1410,16 +1080,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dis.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537527991706,
-      "userAction": ""
-    },
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537834942901,
+      "nextUpdateTime": 1535051700652,
+      "userAction": ""
+    },
+    "display.bfmio.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535248736855,
       "userAction": ""
     },
     "districtm.io": {
@@ -1428,27 +1098,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dmg.digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537599597142,
-      "userAction": ""
-    },
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537456298791,
+      "nextUpdateTime": 1535207581785,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "domdex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1467,7 +1125,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537753424164,
+      "nextUpdateTime": 1535141129266,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1476,22 +1134,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dt.admission.net": {
+    "dsum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537648146014,
-      "userAction": ""
-    },
-    "dt.cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537780764105,
-      "userAction": ""
-    },
-    "dudintrec.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537533439543,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535450697822,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1500,28 +1146,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "e-2072.adzerk.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537905006966,
-      "userAction": ""
-    },
     "eb2.3lift.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537507933433,
-      "userAction": ""
-    },
-    "ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535466272567,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1530,16 +1158,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "echo.intergient.com": {
+    "ebaystatic.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537592599902,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537936892363,
+      "nextUpdateTime": 1535503094601,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1557,25 +1185,7 @@
     "em.licasd.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537958553018,
-      "userAction": ""
-    },
-    "embed.sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537911579947,
-      "userAction": ""
-    },
-    "engage.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537768821556,
-      "userAction": ""
-    },
-    "engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537919419023,
+      "nextUpdateTime": 1535483929811,
       "userAction": ""
     },
     "epicurious.com": {
@@ -1584,22 +1194,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eset.marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537501049394,
-      "userAction": ""
-    },
     "eset.tt.omtrdc.net": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535323726127,
+      "userAction": ""
+    },
+    "eus.rubiconproject.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537948559383,
+      "nextUpdateTime": 1535510670417,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537902234192,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535114411199,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1611,7 +1221,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537909681312,
+      "nextUpdateTime": 1535054385053,
       "userAction": ""
     },
     "exelator.com": {
@@ -1623,7 +1233,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537914393364,
+      "nextUpdateTime": 1535128843717,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1634,7 +1244,7 @@
     },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1647,13 +1257,13 @@
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537575820847,
+      "nextUpdateTime": 1535385394512,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537545195020,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535108377514,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1668,18 +1278,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fls-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537946679180,
-      "userAction": ""
-    },
-    "fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537876172595,
-      "userAction": ""
-    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1689,7 +1287,13 @@
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537689231760,
+      "nextUpdateTime": 1535512337961,
+      "userAction": ""
+    },
+    "freestar-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436668569,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1698,76 +1302,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "futurenet-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535071225476,
+      "userAction": ""
+    },
     "fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.ign.com": {
+    "g.cn.miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537541650706,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535399901695,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537627486048,
+      "nextUpdateTime": 1535330828661,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537665925657,
+      "nextUpdateTime": 1535259298411,
+      "userAction": ""
+    },
+    "gakogedifoda.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535101364820,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537702487137,
+      "nextUpdateTime": 1535176199996,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537759846881,
+      "nextUpdateTime": 1535402637759,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537478628987,
+      "nextUpdateTime": 1535343921291,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537711670087,
-      "userAction": ""
-    },
-    "geocoding.internetbrands.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537874591769,
+      "nextUpdateTime": 1535452798906,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537510348476,
+      "nextUpdateTime": 1535333296953,
       "userAction": ""
     },
     "geosync.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537682619526,
-      "userAction": ""
-    },
-    "getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535160445716,
       "userAction": ""
     },
     "gigya.com": {
@@ -1777,12 +1381,6 @@
       "userAction": ""
     },
     "glamour.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "globalwebindex.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1809,7 +1407,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537812333564,
+      "nextUpdateTime": 1535491836597,
       "userAction": ""
     },
     "gq.com": {
@@ -1821,7 +1419,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537913818401,
+      "nextUpdateTime": 1535227663022,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1833,25 +1431,19 @@
     "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537826644903,
+      "nextUpdateTime": 1535212137627,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537616533756,
-      "userAction": ""
-    },
-    "gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535485285651,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537604908756,
+      "nextUpdateTime": 1535290294755,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1866,130 +1458,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gwiq-v3.globalwebindex.net": {
+    "hb-api.omnitagjs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537903525761,
+      "nextUpdateTime": 1535189695673,
       "userAction": ""
     },
-    "hdslb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hm.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537567498875,
-      "userAction": ""
-    },
-    "hmcdn.baidu.com": {
+    "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537776901148,
-      "userAction": ""
-    },
-    "i.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537762278852,
+      "nextUpdateTime": 1535078071521,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537847658666,
+      "nextUpdateTime": 1535529602945,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537816173449,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535170174461,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537663039777,
+      "nextUpdateTime": 1535403265784,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537686738742,
+      "nextUpdateTime": 1535288809150,
       "userAction": ""
     },
     "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537737731849,
+      "nextUpdateTime": 1535495293493,
+      "userAction": ""
+    },
+    "id.cxense.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535496907922,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537451086715,
+      "nextUpdateTime": 1535476999744,
       "userAction": ""
     },
-    "identityssl.newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537809654954,
-      "userAction": ""
-    },
-    "idpix.media6degrees.com": {
+    "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537739576272,
+      "nextUpdateTime": 1535383207086,
       "userAction": ""
     },
     "idsync.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537842333111,
-      "userAction": ""
-    },
-    "ign.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535075793702,
       "userAction": ""
     },
     "image2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537592083467,
-      "userAction": ""
-    },
-    "image4.pubmatic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537704450079,
+      "nextUpdateTime": 1535291313527,
       "userAction": ""
     },
     "image6.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537653168221,
-      "userAction": ""
-    },
-    "images.taboola.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537513469490,
-      "userAction": ""
-    },
-    "img.purch.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535365119943,
       "userAction": ""
     },
     "img.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537501222395,
+      "nextUpdateTime": 1535505276490,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1998,43 +1548,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "in.getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537565558881,
-      "userAction": ""
-    },
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537568428156,
-      "userAction": ""
-    },
-    "innity.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535249104973,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537950838582,
+      "nextUpdateTime": 1535325186526,
       "userAction": ""
     },
     "insightexpressai.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "insticator-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537956619651,
-      "userAction": ""
-    },
-    "instinctiveads.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2046,91 +1572,49 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "intergient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "internetbrands.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537528784057,
-      "userAction": ""
-    },
-    "investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535164044525,
       "userAction": ""
     },
     "iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ipinyou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "ips-invite.iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537869247546,
-      "userAction": ""
-    },
-    "ir-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537912596310,
-      "userAction": ""
-    },
-    "italiaonline01.wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537811450996,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535325289627,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537570038384,
+      "nextUpdateTime": 1535319029672,
       "userAction": ""
     },
     "js.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537524595439,
-      "userAction": ""
-    },
-    "js.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537709002002,
+      "nextUpdateTime": 1535465747682,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1537453750117,
+      "nextUpdateTime": 1529472262192,
       "userAction": ""
     },
     "jsrdn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2193,19 +1677,13 @@
     "lcidc.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537480178306,
-      "userAction": ""
-    },
-    "leadintel.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537526964354,
+      "nextUpdateTime": 1535169102934,
       "userAction": ""
     },
     "li.pxl.ace.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537690362083,
+      "nextUpdateTime": 1535477346565,
       "userAction": ""
     },
     "liadm.com": {
@@ -2238,94 +1716,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "live.sekindo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537661966910,
-      "userAction": ""
-    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "load.instinctiveads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537887139462,
-      "userAction": ""
-    },
     "load77.exelator.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537607433156,
-      "userAction": ""
-    },
-    "loadm.exelator.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537695354708,
+      "nextUpdateTime": 1535166623245,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535068047141,
+      "userAction": ""
+    },
+    "log.outbrain.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537858987653,
-      "userAction": ""
-    },
-    "lockerdome.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537628767640,
-      "userAction": ""
-    },
-    "loggingapi.spingo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537519313806,
+      "nextUpdateTime": 1535473321187,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537938495129,
+      "nextUpdateTime": 1535491014034,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537529381640,
-      "userAction": ""
-    },
-    "lp1block.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lptag.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537673205510,
-      "userAction": ""
-    },
-    "lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535260738970,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537931773797,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535399926820,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -2340,40 +1770,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "maps.gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537817500851,
-      "userAction": ""
-    },
     "mapsengine.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537611772016,
+      "nextUpdateTime": 1535234844708,
       "userAction": ""
     },
     "match.prod.bidr.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537695592254,
+      "nextUpdateTime": 1535264504925,
       "userAction": ""
     },
     "mathtag.com": {
@@ -2385,19 +1797,13 @@
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537781513983,
+      "nextUpdateTime": 1535318601438,
       "userAction": ""
     },
     "media.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "media.workandmoney.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537772218821,
       "userAction": ""
     },
     "media6degrees.com": {
@@ -2409,37 +1815,25 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537450926060,
+      "nextUpdateTime": 1535489306691,
       "userAction": ""
     },
     "mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mediawallahscript.com": {
+    "miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediawiki.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mfadsrvr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537740252391,
+      "nextUpdateTime": 1535201966174,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -2451,19 +1845,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537595374693,
-      "userAction": ""
-    },
-    "mps.nbcuni.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537756493707,
-      "userAction": ""
-    },
-    "mssl.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537765088056,
+      "nextUpdateTime": 1535082082006,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -2478,6 +1860,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mtrx.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535142954690,
+      "userAction": ""
+    },
     "mts0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -2487,6 +1875,12 @@
     "mts1.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2502,33 +1896,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nbcu.demdex.net": {
+    "mx.technolutions.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537675565343,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535404018448,
       "userAction": ""
     },
-    "nbcuni.com": {
+    "nanigans.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.com.au": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2541,7 +1923,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550690745,
+      "nextUpdateTime": 1535018230678,
       "userAction": ""
     },
     "newyorker.com": {
@@ -2550,22 +1932,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537899672597,
+      "nextUpdateTime": 1535498883050,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537802452858,
+      "nextUpdateTime": 1535229374587,
       "userAction": ""
     },
     "nr-data.net": {
@@ -2574,22 +1950,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oasc10.247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537927451218,
-      "userAction": ""
-    },
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537516141999,
+      "nextUpdateTime": 1535425842674,
       "userAction": ""
     },
     "odb.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537837698830,
+      "nextUpdateTime": 1535016850629,
+      "userAction": ""
+    },
+    "omnitagjs.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -2604,39 +1980,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "onthe.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "openx.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ophan.theguardian.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537645962946,
-      "userAction": ""
-    },
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537751703960,
+      "nextUpdateTime": 1535525515019,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ora.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2655,49 +2013,43 @@
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537706817051,
+      "nextUpdateTime": 1535203430840,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537845404551,
-      "userAction": ""
-    },
-    "p.cquotient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537936279314,
+      "nextUpdateTime": 1535414888339,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537493433158,
+      "nextUpdateTime": 1535206307068,
+      "userAction": ""
+    },
+    "p.liadm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535075363187,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537487063788,
+      "nextUpdateTime": 1535358438619,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537505785246,
-      "userAction": ""
-    },
-    "p.yotpo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537699522129,
+      "nextUpdateTime": 1535256790030,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537845781986,
+      "nextUpdateTime": 1535087119968,
       "userAction": ""
     },
     "pardot.com": {
@@ -2712,45 +2064,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "partner.mediawallahscript.com": {
+    "pba.lijit.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535115013415,
+      "userAction": ""
+    },
+    "pbbl.co": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537679554534,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pbid.pro-market.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535136510150,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537675608382,
-      "userAction": ""
-    },
-    "performgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535153992015,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537856276772,
+      "nextUpdateTime": 1535441500485,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2760,106 +2106,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pixel-sc2.adsymptotic.com": {
+    "pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537605179109,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535221836104,
+      "userAction": ""
+    },
+    "pixel-geo.prfct.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535035427244,
       "userAction": ""
     },
     "pixel-sync.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537687745697,
+      "nextUpdateTime": 1535122200195,
+      "userAction": ""
+    },
+    "pixel-us-east.rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535379825285,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537661479633,
+      "nextUpdateTime": 1535237799393,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537936618740,
+      "nextUpdateTime": 1535126888506,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537885552749,
+      "nextUpdateTime": 1535139385386,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537802852606,
-      "userAction": ""
-    },
-    "pixel.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537539611639,
+      "nextUpdateTime": 1535292610867,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537793705979,
+      "nextUpdateTime": 1535355794721,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537853122548,
-      "userAction": ""
-    },
-    "pixel.servebom.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537887790446,
+      "nextUpdateTime": 1535486117158,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537516043381,
-      "userAction": ""
-    },
-    "pixel.zprk.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537669815103,
+      "nextUpdateTime": 1535164323168,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537574398798,
-      "userAction": ""
-    },
-    "placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "platform-api.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537618692470,
+      "nextUpdateTime": 1535195842399,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537458677035,
+      "nextUpdateTime": 1535484478744,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537800409757,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "play.google.com": {
@@ -2868,22 +2196,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.performgroup.com": {
+    "player.vimeo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537896826240,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535105086109,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537773917321,
-      "userAction": ""
-    },
-    "plugin.tianqijun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537748776986,
+      "nextUpdateTime": 1535030196338,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2894,8 +2216,14 @@
     },
     "po.st": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537500258193,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535441634636,
+      "userAction": ""
+    },
+    "postmedia.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535168204261,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2904,46 +2232,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "privacy.purch.com": {
+    "pr-bh.ybp.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537879271663,
+      "nextUpdateTime": 1535271792808,
       "userAction": ""
     },
-    "proximus.be": {
+    "prfct.co": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "proximus.demdex.net": {
+    "pro-market.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "profile.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537649779975,
+      "nextUpdateTime": 1535039428012,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537770609852,
-      "userAction": ""
-    },
-    "pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535044042579,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537688216070,
+      "nextUpdateTime": 1535111836244,
       "userAction": ""
     },
     "pubmatic-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537799110233,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535502071689,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2955,73 +2283,61 @@
     "pubmatic2waycm-atl.netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537511161551,
+      "nextUpdateTime": 1535177396397,
       "userAction": ""
     },
     "purch-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537491674953,
-      "userAction": ""
-    },
-    "purch-sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537615213593,
-      "userAction": ""
-    },
-    "purch.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535459595542,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537796909603,
+      "nextUpdateTime": 1535250433294,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537576171296,
+      "nextUpdateTime": 1535405852313,
       "userAction": ""
     },
     "px.owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537837144843,
+      "nextUpdateTime": 1535291856491,
       "userAction": ""
     },
     "px.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537627831473,
+      "nextUpdateTime": 1535296720309,
       "userAction": ""
     },
-    "pxlsfvwe-a.akamaihd.net": {
+    "px0.pbbl.co": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537456582086,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535076873350,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537534907217,
+      "nextUpdateTime": 1535420663273,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537631387420,
+      "nextUpdateTime": 1535401599359,
       "userAction": ""
     },
-    "quantcast.mgr.consensu.org": {
+    "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550668996,
+      "nextUpdateTime": 1535242881020,
       "userAction": ""
     },
     "quantserve.com": {
@@ -3036,58 +2352,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.dmp.sina.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537556220411,
-      "userAction": ""
-    },
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537777511413,
+      "nextUpdateTime": 1535170004392,
       "userAction": ""
     },
-    "r.turn.com": {
+    "rambler.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537632510659,
+      "nextUpdateTime": 1535263109404,
       "userAction": ""
     },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537739633160,
+      "nextUpdateTime": 1535384795636,
       "userAction": ""
     },
-    "rd.frontend.weborama.fr": {
+    "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537866844315,
+      "nextUpdateTime": 1535535765113,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537950836227,
+      "nextUpdateTime": 1535462594322,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537482418879,
-      "userAction": ""
-    },
-    "res.suning.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537813301024,
-      "userAction": ""
-    },
-    "revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535189737074,
       "userAction": ""
     },
     "rfihub.com": {
@@ -3110,44 +2414,26 @@
     },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537908971962,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535380552995,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537804281708,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535231527445,
       "userAction": ""
     },
-    "rss.art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537506168486,
-      "userAction": ""
-    },
-    "rtb.connatix.com": {
+    "rtax.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537662261105,
+      "nextUpdateTime": 1535104158026,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537891050192,
-      "userAction": ""
-    },
-    "rtb.mfadsrvr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537514930749,
-      "userAction": ""
-    },
-    "rtve.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537766130426,
+      "nextUpdateTime": 1535035055571,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -3158,8 +2444,8 @@
     },
     "rudy.adsnative.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537806612737,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535223087702,
       "userAction": ""
     },
     "s-static.ak.facebook.com": {
@@ -3168,100 +2454,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "s-v6exp1-ds.metric.gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537824622166,
-      "userAction": ""
-    },
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537718290259,
+      "nextUpdateTime": 1535410059142,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537774137149,
-      "userAction": ""
-    },
-    "s.clickability.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537615272003,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535439279491,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537650324477,
+      "nextUpdateTime": 1535479648873,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537704922531,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535058060751,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537846016887,
+      "nextUpdateTime": 1535459842092,
       "userAction": ""
     },
-    "s.nexac.com": {
+    "s.po.st": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537448578396,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535253080228,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537510193603,
-      "userAction": ""
-    },
-    "s.spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537567561362,
+      "nextUpdateTime": 1535135587742,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537637515918,
+      "nextUpdateTime": 1535507972811,
       "userAction": ""
     },
-    "s1.hdslb.com": {
+    "s.yimg.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537678226590,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535314953789,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537894278733,
+      "nextUpdateTime": 1535242557490,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537945122061,
+      "nextUpdateTime": 1535479363146,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537781342146,
+      "nextUpdateTime": 1535039569298,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537811788622,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535523380151,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -3270,34 +2538,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "samba.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537578272771,
+      "nextUpdateTime": 1535072165940,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537823324902,
+      "nextUpdateTime": 1535215807271,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537733366525,
+      "nextUpdateTime": 1535218882947,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537618963583,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535515673197,
+      "userAction": ""
+    },
+    "scomcluster.cxense.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535069100437,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -3309,19 +2577,13 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537533436741,
-      "userAction": ""
-    },
-    "sdc-qczj.pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537450956832,
+      "nextUpdateTime": 1535020426187,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537656187416,
+      "nextUpdateTime": 1535485865391,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -3333,114 +2595,84 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537671345425,
+      "nextUpdateTime": 1535061912370,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537786730710,
+      "nextUpdateTime": 1535411085544,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537738916180,
-      "userAction": ""
-    },
-    "secure-dcr.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537699103277,
+      "nextUpdateTime": 1535418977196,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537597100597,
+      "nextUpdateTime": 1535188699282,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537856608472,
+      "nextUpdateTime": 1535356996177,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537818295597,
+      "nextUpdateTime": 1535326763580,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537766934140,
+      "nextUpdateTime": 1535483067072,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537525528622,
+      "nextUpdateTime": 1535133299962,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537738077212,
+      "nextUpdateTime": 1535402768464,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537715006767,
+      "nextUpdateTime": 1535195438164,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537949451895,
+      "nextUpdateTime": 1535504287312,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537771009211,
-      "userAction": ""
-    },
-    "segapi.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799252076,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535282607731,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537705585446,
-      "userAction": ""
-    },
-    "sekindo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535259895831,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3450,27 +2682,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servicer.traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537770562636,
-      "userAction": ""
-    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "session.timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537902227193,
-      "userAction": ""
-    },
-    "sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3483,25 +2697,19 @@
     "sharethrough.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537848455982,
-      "userAction": ""
-    },
-    "siftscience.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535439209850,
       "userAction": ""
     },
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537498910884,
+      "nextUpdateTime": 1535373129653,
       "userAction": ""
     },
-    "sina.com.cn": {
+    "simage4.pubmatic.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535066804433,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -3528,27 +2736,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "smartlock.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537590634754,
-      "userAction": ""
-    },
-    "smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sojern.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3566,31 +2756,19 @@
     },
     "sp.analytics.yahoo.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535418102706,
+      "userAction": ""
+    },
+    "sp1cluster.cxense.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537785069352,
-      "userAction": ""
-    },
-    "spingo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535265282354,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3600,64 +2778,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "src.ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537556536901,
-      "userAction": ""
-    },
-    "srv-2018-09-19-11.config.parsely.com": {
+    "springserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537798885889,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-09-19-11.pixel.parsely.com": {
+    "srv-2018-08-22-08.config.parsely.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537840754975,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535226346743,
       "userAction": ""
     },
-    "srv-2018-09-19-12.config.parsely.com": {
+    "srv-2018-08-22-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537742571634,
+      "nextUpdateTime": 1535482395839,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537457643347,
+      "nextUpdateTime": 1535222239514,
       "userAction": ""
     },
-    "ssl.gstatic.com": {
+    "ssl.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537647056340,
+      "nextUpdateTime": 1535484066342,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537451072989,
+      "nextUpdateTime": 1535486723866,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537693049279,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535090326798,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537823064117,
-      "userAction": ""
-    },
-    "stanza-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537829817249,
+      "nextUpdateTime": 1535143155903,
       "userAction": ""
     },
     "statcounter.com": {
@@ -3666,22 +2832,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "static.addtoany.com": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1529315030088,
+      "userAction": ""
+    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537800009124,
+      "nextUpdateTime": 1535046610826,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537792793168,
+      "nextUpdateTime": 1535212699887,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537692165307,
+      "nextUpdateTime": 1535515390425,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -3693,13 +2865,13 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537699249146,
+      "nextUpdateTime": 1535271064884,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537944166201,
+      "nextUpdateTime": 1535237146011,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -3717,7 +2889,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537816897557,
+      "nextUpdateTime": 1535269383338,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -3726,88 +2898,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "suning.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537489764549,
+      "nextUpdateTime": 1535018613611,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537910804572,
+      "nextUpdateTime": 1535172174965,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537852480724,
-      "userAction": ""
-    },
-    "sync.1dmp.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537632266172,
+      "nextUpdateTime": 1535283029520,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537655833858,
+      "nextUpdateTime": 1535249046647,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537809960844,
+      "nextUpdateTime": 1535071305588,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537547540738,
-      "userAction": ""
-    },
-    "sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537713247533,
+      "nextUpdateTime": 1535427669787,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537572759329,
+      "nextUpdateTime": 1535093224646,
+      "userAction": ""
+    },
+    "sync.multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535154068185,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537835499899,
-      "userAction": ""
-    },
-    "sync.teads.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537624685346,
+      "nextUpdateTime": 1535057971306,
       "userAction": ""
     },
     "syndication.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "t.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537621436426,
       "userAction": ""
     },
     "taboola.com": {
@@ -3819,25 +2967,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537914093330,
-      "userAction": ""
-    },
-    "tag.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537709296119,
-      "userAction": ""
-    },
-    "tag.placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537534262582,
-      "userAction": ""
-    },
-    "tags.news.com.au": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537538118661,
+      "nextUpdateTime": 1535198760139,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -3846,31 +2976,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tap-secure.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537538702540,
-      "userAction": ""
-    },
-    "target.smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537577942085,
-      "userAction": ""
-    },
-    "tawk.to": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "teads.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tealiumiq.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "technolutions.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3888,34 +3000,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "theguardian.com": {
+    "thrtle.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535305777635,
+      "userAction": ""
+    },
+    "thumbs.ebaystatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535105272905,
       "userAction": ""
     },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537640116700,
+      "nextUpdateTime": 1535432484423,
       "userAction": ""
     },
-    "tianqijun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "timeinc.demdex.net": {
+    "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537729256682,
+      "nextUpdateTime": 1535420021607,
       "userAction": ""
     },
     "tinypass.com": {
@@ -3926,8 +3032,8 @@
     },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537937981013,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535026689669,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3936,34 +3042,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "token.rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535233393938,
+      "userAction": ""
+    },
+    "top100.rambler.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535125035641,
+      "userAction": ""
+    },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537465663923,
+      "nextUpdateTime": 1535406490099,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537563288279,
+      "nextUpdateTime": 1535061545317,
       "userAction": ""
     },
-    "track.tiara.daum.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537497236250,
-      "userAction": ""
-    },
-    "tracker.marinsm.com": {
+    "track.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537499812373,
-      "userAction": ""
-    },
-    "traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535155370781,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3975,49 +3081,13 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537523400406,
-      "userAction": ""
-    },
-    "tremorhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535140806281,
       "userAction": ""
     },
     "trends.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trends.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537901532266,
-      "userAction": ""
-    },
-    "tribalfusion.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trk.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537686193338,
-      "userAction": ""
-    },
-    "trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tt.onthe.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537581901703,
       "userAction": ""
     },
     "turn.com": {
@@ -4038,76 +3108,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "udmserve.net": {
+    "u.openx.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537562185323,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535092934568,
       "userAction": ""
     },
-    "uid1.vindicosuite.com": {
+    "unagi-eu.amazon.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537610408164,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535382929843,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537452363796,
+      "nextUpdateTime": 1535165883589,
+      "userAction": ""
+    },
+    "us.pixel.newscgp.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535390643472,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537575881910,
+      "nextUpdateTime": 1535170950487,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537608830235,
-      "userAction": ""
-    },
-    "useproof.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "usw-lax.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537763324807,
-      "userAction": ""
-    },
-    "utarget.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537715148141,
-      "userAction": ""
-    },
-    "utarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537682726445,
-      "userAction": ""
-    },
-    "uuidksinc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537618704274,
-      "userAction": ""
-    },
-    "va.tawk.to": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537805440945,
-      "userAction": ""
-    },
-    "va.v.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537878052703,
+      "nextUpdateTime": 1535361402673,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -4116,10 +3150,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "veinteractive.com": {
+    "vid.springserve.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535169227544,
       "userAction": ""
     },
     "video.google.com": {
@@ -4128,15 +3162,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vidthm.ora.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537694615731,
-      "userAction": ""
-    },
     "viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vimeo.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4149,7 +3183,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537952472327,
+      "nextUpdateTime": 1535199238726,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -4161,25 +3195,19 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537657186694,
+      "nextUpdateTime": 1535207908950,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "volvelle.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537667727470,
+      "nextUpdateTime": 1535027449792,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -4191,42 +3219,30 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537733912036,
+      "nextUpdateTime": 1535180305355,
       "userAction": ""
     },
-    "wal.wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537708569754,
-      "userAction": ""
-    },
-    "walker.zdbb.net": {
+    "wam-yahoo.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537817167307,
+      "nextUpdateTime": 1535313044985,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535283879516,
+      "userAction": ""
+    },
+    "web.hb.ad.cpe.dotomi.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537870871496,
+      "nextUpdateTime": 1535315460235,
       "userAction": ""
     },
     "weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webservices.webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537861304752,
-      "userAction": ""
-    },
-    "webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4239,12 +3255,12 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537948250508,
+      "nextUpdateTime": 1535484411512,
       "userAction": ""
     },
     "wired.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4260,70 +3276,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wms-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537745601171,
-      "userAction": ""
-    },
-    "wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "workandmoney.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ws.sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537883425353,
-      "userAction": ""
-    },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537679101909,
-      "userAction": ""
-    },
-    "wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535220842816,
       "userAction": ""
     },
     "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537627118861,
+      "nextUpdateTime": 1535108380967,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537706516009,
+      "nextUpdateTime": 1535451698656,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537908698667,
-      "userAction": ""
-    },
-    "www.beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537855591308,
+      "nextUpdateTime": 1535478914675,
       "userAction": ""
     },
     "www.bing.com": {
@@ -4335,55 +3309,43 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537879830064,
+      "nextUpdateTime": 1535198678997,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537909715373,
+      "nextUpdateTime": 1535335746123,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537937591373,
-      "userAction": ""
-    },
-    "www.dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537949042270,
-      "userAction": ""
-    },
-    "www.ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537620501826,
+      "nextUpdateTime": 1535523057317,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537576232432,
+      "nextUpdateTime": 1535385380509,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537464851481,
+      "nextUpdateTime": 1535341462375,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537760960508,
+      "nextUpdateTime": 1535086092034,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537799445735,
+      "nextUpdateTime": 1535118488381,
       "userAction": ""
     },
     "www.google.com": {
@@ -4395,121 +3357,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537796743624,
+      "nextUpdateTime": 1535056845706,
       "userAction": ""
     },
-    "www.gstatic.com": {
+    "www.justuno.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537700151945,
-      "userAction": ""
-    },
-    "www.iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537685163688,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535134268596,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537892903107,
+      "nextUpdateTime": 1535412347346,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537512827112,
-      "userAction": ""
-    },
-    "www.mediawiki.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537848643853,
+      "nextUpdateTime": 1535503327200,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537683006702,
+      "nextUpdateTime": 1535191271791,
       "userAction": ""
     },
-    "www.ora.tv": {
+    "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537655020701,
-      "userAction": ""
-    },
-    "www.proximus.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537909677592,
+      "nextUpdateTime": 1535478932878,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537623685582,
+      "nextUpdateTime": 1535236669569,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537917019886,
+      "nextUpdateTime": 1535386103543,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537575717845,
+      "nextUpdateTime": 1535446262570,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537930791168,
+      "nextUpdateTime": 1535037751236,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537876466089,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535528753563,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537491819248,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535365974182,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537678614153,
+      "nextUpdateTime": 1535532430753,
+      "userAction": ""
+    },
+    "www.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535024452155,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537896897167,
+      "nextUpdateTime": 1535040980033,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537567605963,
-      "userAction": ""
-    },
-    "x01.aidata.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537635458423,
-      "userAction": ""
-    },
-    "xe19io.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537820696009,
+      "nextUpdateTime": 1535454366224,
       "userAction": ""
     },
     "xiti.com": {
@@ -4542,9 +3480,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yotpo.com": {
+    "yastatic.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535352911929,
+      "userAction": ""
+    },
+    "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4557,40 +3501,22 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537634465236,
+      "nextUpdateTime": 1535507962998,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537573698898,
-      "userAction": ""
-    },
-    "zassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535038311647,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537925998104,
+      "nextUpdateTime": 1535217382463,
       "userAction": ""
     },
     "zemanta.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -4599,26 +3525,46 @@
   },
   "snitch_map": {
     "126.net": [
+      "163.com",
+      "fotki.com"
+    ],
+    "127.net": [
       "163.com"
     ],
     "15gifts.com": [
       "thetimes.co.uk"
     ],
     "1dmp.io": [
-      "radikal.ru"
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "1rx.io": [
+      "tinyurl.com",
+      "lycos.com",
+      "photobucket.com"
+    ],
+    "23video.com": [
+      "bandcamp.com"
+    ],
+    "247-inc.net": [
+      "marriott.com"
     ],
     "247realmedia.com": [
       "bmj.com",
+      "aappublications.org",
       "americanbar.org"
     ],
+    "2mdnsys.com": [
+      "liveuamap.com"
+    ],
     "2o7.net": [
+      "mysql.com",
       "cdc.gov",
+      "theatlantic.com",
       "prnewswire.com",
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
-      "philips.com",
-      "cancer.gov",
       "oclc.org"
     ],
     "33across.com": [
@@ -4627,20 +3573,29 @@
     "360.cn": [
       "so.com"
     ],
+    "360buyimg.com": [
+      "jd.com"
+    ],
     "360yield.com": [
       "springer.com",
-      "economist.com",
-      "home.pl"
+      "home.pl",
+      "allafrica.com"
     ],
     "3gl.net": [
-      "economist.com"
+      "istockphoto.com",
+      "gettyimages.com"
     ],
     "3lift.com": [
-      "msn.com",
+      "nature.com",
+      "springer.com",
+      "theverge.com",
       "usatoday.com",
-      "nginx.org",
-      "space.com",
-      "polygon.com"
+      "weather.com",
+      "jsonline.com",
+      "xda-developers.com"
+    ],
+    "4dsply.com": [
+      "wnd.com"
     ],
     "50bang.org": [
       "2345.com"
@@ -4652,26 +3607,50 @@
       "ganji.com"
     ],
     "5p4rk13.com": [
-      "sfu.ca"
+      "sfu.ca",
+      "cdbaby.com"
     ],
     "6sc.co": [
-      "brightcove.com"
+      "zendesk.com",
+      "gotomeeting.com",
+      "rsa.com"
+    ],
+    "7eer.net": [
+      "lenovo.com",
+      "adidas.com"
+    ],
+    "7grid.com": [
+      "mihanblog.com"
     ],
     "aamsitecertifier.com": [
+      "smh.com.au",
       "theglobeandmail.com",
-      "bostonglobe.com",
-      "post-gazette.com"
+      "bostonglobe.com"
+    ],
+    "aaxads.com": [
+      "forbes.com"
     ],
     "abmr.net": [
-      "nike.com",
-      "freetype.org"
+      "paypal.com",
+      "nike.com"
     ],
     "accessatlanta.com": [
       "ajc.com"
     ],
+    "accuweather.com": [
+      "miamiherald.com",
+      "sacbee.com",
+      "kansascity.com"
+    ],
+    "acint.net": [
+      "tomsk.ru",
+      "radikal.ru",
+      "diary.ru"
+    ],
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
+      "liberation.fr",
       "leparisien.fr"
     ],
     "acquia.com": [
@@ -4686,150 +3665,213 @@
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "dropbox.com",
-      "businessinsider.com"
+      "bartleby.com"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-plus.cn": [
-      "sohu.com"
+    "ad-score.com": [
+      "wnd.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
+      "biglobe.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com"
+      "huanqiu.com",
+      "yesky.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
     ],
+    "adaraanalytics.com": [
+      "hyatt.com"
+    ],
     "adc-srv.net": [
       "autodesk.com"
     ],
+    "adclear.net": [
+      "t-online.de"
+    ],
     "addroplet.com": [
-      "washingtonexaminer.com",
-      "wnd.com"
+      "wallinside.com",
+      "wnd.com",
+      "washingtonexaminer.com"
     ],
     "addthis.com": [
+      "nasa.gov",
+      "jimdo.com",
+      "yahoo.com",
       "who.int",
       "columbia.edu",
-      "giphy.com",
-      "heart.org",
       "gulfnews.com"
     ],
+    "addtoany.com": [
+      "irs.gov"
+    ],
     "adentifi.com": [
-      "metmuseum.org"
+      "metmuseum.org",
+      "infoplease.com"
     ],
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
       "springer.com",
-      "si.com",
-      "goal.com"
+      "shutterstock.com",
+      "helsinki.fi"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "sputniknews.com"
-    ],
-    "adhigh.net": [
       "rambler.ru"
     ],
+    "adfront.org": [
+      "joomla.org"
+    ],
+    "adhigh.net": [
+      "rambler.ru",
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "adidas.fi": [
+      "adidas.com"
+    ],
     "adingo.jp": [
-      "seesaa.jp"
+      "biglobe.ne.jp"
     ],
     "adition.com": [
-      "variety.com",
-      "lemonde.fr",
-      "sueddeutsche.de"
+      "bloomberg.com",
+      "dailymotion.com",
+      "spiegel.de",
+      "lemonde.fr"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
     "adkernel.com": [
+      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "howtogeek.com",
-      "dailydot.com"
+      "xda-developers.com"
+    ],
+    "adlmerge.com": [
+      "tomsk.ru"
+    ],
+    "admaster.com.cn": [
+      "autohome.com.cn",
+      "bshare.cn",
+      "youku.com"
     ],
     "admission.net": [
       "edmunds.com"
     ],
+    "admixer.net": [
+      "space.com"
+    ],
     "adnxs.com": [
+      "yahoo.com",
+      "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "dropbox.com",
-      "seattletimes.com",
+      "cisco.com",
+      "jsonline.com",
       "rfi.fr"
     ],
     "adobe.com": [
+      "wikipedia.org",
       "behance.net",
-      "history.com",
-      "nbc.com"
+      "history.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
-      "worldbank.org",
-      "nbcnews.com",
-      "aarp.org",
-      "networksolutions.com"
+      "bbb.org",
+      "bizjournals.com",
+      "worldbank.org"
     ],
     "adotmob.com": [
-      "variety.com"
+      "standard.co.uk",
+      "upwork.com"
     ],
     "adriver.ru": [
       "ria.ru",
-      "home.pl"
+      "rambler.ru",
+      "tomsk.ru"
     ],
     "adroll.com": [
+      "stumbleupon.com",
+      "nature.com",
       "nginx.org",
       "cloudflare.com",
       "ning.com",
-      "salesforce.com",
       "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
+      "bloomberg.com",
       "springer.com",
-      "home.pl"
+      "statista.com"
     ],
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "squareup.com",
+      "informationweek.com",
       "bostonherald.com"
+    ],
+    "adsniper.ru": [
+      "rambler.ru"
     ],
     "adsrvr.org": [
       "adobe.com",
+      "yahoo.com",
+      "googletagmanager.com",
       "sourceforge.net",
-      "nytimes.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "cisco.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "adswizz.com": [
-      "variety.com",
       "iheart.com",
-      "tunein.com"
+      "tunein.com",
+      "variety.com"
     ],
     "adsymptotic.com": [
+      "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "economist.com",
-      "space.com",
-      "colourlovers.com"
+      "foursquare.com",
+      "jsonline.com",
+      "xda-developers.com"
+    ],
+    "adtags.pro": [
+      "tomsk.ru"
+    ],
+    "adtdp.com": [
+      "biglobe.ne.jp"
     ],
     "advertising.com": [
+      "amazon.com",
+      "sourceforge.net",
       "dropbox.com",
-      "msn.com",
       "wsj.com",
-      "norton.com",
+      "theverge.com",
       "walgreens.com"
     ],
+    "advertur.ru": [
+      "radikal.ru"
+    ],
+    "adwstats.com": [
+      "cisco.com"
+    ],
     "adx.com.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "tomsk.ru"
+    ],
+    "adx1.com": [
+      "venturebeat.com",
+      "livescience.com",
+      "space.com"
     ],
     "adzerk.net": [
       "asp.net"
@@ -4837,81 +3879,94 @@
     "aetnd.com": [
       "history.com"
     ],
-    "afkp.net": [
-      "autodesk.com"
+    "afilio.com.br": [
+      "mcafee.com"
     ],
     "agkn.com": [
-      "dropbox.com",
+      "amazon.com",
+      "t-online.de",
+      "bloomberg.com",
       "cnet.com",
-      "businessinsider.com",
-      "cbs.com",
-      "gizmodo.com"
+      "zdnet.com",
+      "zerohedge.com"
+    ],
+    "aid-ad.jp": [
+      "shinobi.jp"
     ],
     "aidata.io": [
+      "rambler.ru",
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "aili.com": [
+      "sina.com.cn"
+    ],
+    "ajx130.online": [
       "radikal.ru"
     ],
+    "akamai.net": [
+      "newscientist.com"
+    ],
     "akamaihd.net": [
-      "forbes.com",
       "voanews.com",
-      "cracked.com"
+      "repubblica.it",
+      "iyfubh.com",
+      "forbes.com"
     ],
     "akamaized.net": [
       "tamu.edu",
       "microsoft.com",
-      "xbox.com",
-      "rice.edu",
-      "blizzard.com",
-      "office.com",
-      "jugem.jp"
+      "nbc.com"
     ],
     "albacross.com": [
       "rebelmouse.com"
     ],
     "alibaba.com": [
-      "tmall.com",
+      "youku.com",
+      "taobao.com",
       "aliexpress.com",
-      "alibabacloud.com"
+      "tmall.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
-      "youku.com",
-      "sohu.com",
-      "taobao.com",
       "alibaba.com",
-      "1688.com",
-      "toutiao.com",
-      "2345.com",
-      "tmall.com"
+      "youku.com",
+      "sohu.com"
     ],
     "alipay.com": [
-      "youku.com",
-      "taobao.com",
-      "tmall.com"
+      "alibaba.com",
+      "youku.com"
     ],
     "aliyun.com": [
-      "alibabacloud.com",
-      "gmw.cn"
+      "alibabacloud.com"
     ],
     "allure.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
+    ],
+    "am15.net": [
+      "radikal.ru"
     ],
     "amazon-adsystem.com": [
       "amazon.com",
-      "vimeo.com",
+      "nytimes.com",
       "reddit.com",
-      "nifty.com",
-      "pitchfork.com"
+      "cnn.com",
+      "goodreads.com",
+      "bostonherald.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
     ],
     "amazon.com": [
+      "qq.com",
       "imdb.com",
       "amazon.co.uk",
       "amazon.de",
-      "amazon.co.jp"
+      "amazon.co.jp",
+      "amazon.es"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -4926,73 +3981,119 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "aarp.org",
-      "walgreens.com"
+      "realtor.com"
+    ],
+    "antdsp.com": [
+      "hc360.com"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
     "aol.com": [
-      "techcrunch.com"
+      "engadget.com",
+      "indiatimes.com",
+      "autoblog.com"
+    ],
+    "ap.org": [
+      "post-gazette.com"
+    ],
+    "apester.com": [
+      "deadline.com",
+      "searchenginewatch.com",
+      "nme.com"
     ],
     "apn.co.nz": [
       "nzherald.co.nz"
     ],
     "app.link": [
-      "medium.com",
       "foursquare.com",
       "history.com",
       "nbc.com",
       "strava.com"
     ],
-    "apple.com": [
-      "digitaltrends.com"
+    "appdynamics.com": [
+      "nfl.com"
     ],
-    "apvdr.com": [
-      "goo.ne.jp"
+    "apple.com": [
+      "digitaltrends.com",
+      "icloud.com",
+      "softpedia.com"
+    ],
+    "aqtracker.com": [
+      "nikkei.com"
+    ],
+    "aralego.com": [
+      "accuweather.com"
+    ],
+    "arcgis.com": [
+      "chron.com"
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
     ],
+    "areyouahuman.com": [
+      "reuters.com",
+      "merriam-webster.com",
+      "accuweather.com"
+    ],
+    "arrivalist.com": [
+      "philly.com"
+    ],
     "art19.com": [
       "coindesk.com"
     ],
+    "asos-media.com": [
+      "asos.com"
+    ],
     "atdmt.com": [
       "facebook.com",
-      "shutterfly.com",
-      "xbox.com",
-      "slack.com"
+      "yahoo.com",
+      "msn.com",
+      "t-online.de"
     ],
     "atemda.com": [
       "springer.com",
       "home.pl"
     ],
+    "atgsvcs.com": [
+      "oracle.com",
+      "xerox.com"
+    ],
     "ati-host.net": [
-      "bbc.co.uk",
       "straitstimes.com"
     ],
     "att.com": [
       "att.net"
     ],
-    "auone.jp": [
-      "goo.ne.jp"
+    "audtd.com": [
+      "rambler.ru",
+      "tomsk.ru",
+      "radikal.ru"
+    ],
+    "autoimg.cn": [
+      "autohome.com.cn"
     ],
     "autopilothq.com": [
       "bitbucket.org",
+      "rfc-editor.org",
       "typeform.com",
-      "atlassian.com"
+      "quantcast.com"
+    ],
+    "b1img.com": [
+      "threadless.com"
     ],
     "baidu.com": [
       "sina.com.cn",
       "163.com",
+      "ifeng.com",
       "sohu.com",
-      "ce.cn",
-      "qianlong.com"
+      "51.la"
     ],
     "bam-x.com": [
       "gq.com"
@@ -5000,14 +4101,27 @@
     "barnebys.com": [
       "lemonde.fr"
     ],
-    "baur.de": [
-      "t-online.de"
-    ],
     "bazaarvoice.com": [
+      "target.com",
+      "lenovo.com",
       "motorola.com"
+    ],
+    "bbb.org": [
+      "penders.com",
+      "afternic.com",
+      "sedo.com"
+    ],
+    "bbbpromos.org": [
+      "bbb.org"
     ],
     "bbc.co.uk": [
       "bbc.com"
+    ],
+    "bbelements.com": [
+      "idnes.cz"
+    ],
+    "beatport.com": [
+      "tmall.com"
     ],
     "beemray.com": [
       "telegraph.co.uk",
@@ -5015,74 +4129,102 @@
     ],
     "beian.gov.cn": [
       "dzwww.com",
-      "qianlong.com"
+      "ku6.com"
+    ],
+    "benchtag2.co": [
+      "sbs.com.au"
+    ],
+    "betweendigital.com": [
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "bfmio.com": [
+      "symantec.com",
       "tinypic.com",
+      "venturebeat.com",
       "livescience.com",
-      "space.com",
-      "dailydot.com"
+      "xda-developers.com"
+    ],
+    "bfmtv.com": [
+      "liberation.fr",
+      "lexpress.fr"
     ],
     "biddingx.com": [
       "sina.com.cn"
     ],
     "bidr.io": [
       "adobe.com",
-      "hp.com",
+      "dailymotion.com",
+      "hootsuite.com",
       "symantec.com",
-      "sap.com",
       "box.com"
     ],
     "bidswitch.net": [
+      "yahoo.com",
+      "google.com",
+      "amazon.com",
       "dropbox.com",
-      "tinyurl.com",
-      "usatoday.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "theverge.com",
+      "jsonline.com",
+      "walgreens.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
+    ],
+    "bigmir.net": [
+      "kharkov.ua",
+      "kh.ua"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "sap.com",
-      "office.com",
+      "parallels.com",
       "pingdom.com"
+    ],
+    "bitbucket.org": [
+      "atlassian.com"
     ],
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
+      "zendesk.com",
       "ibm.com",
-      "eventbrite.co.uk",
       "gitlab.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
     ],
     "bizographics.com": [
+      "zend.com",
+      "nginx.com",
+      "oreilly.com",
       "jimdo.com",
-      "surveymonkey.com",
-      "techcrunch.com"
+      "ox.ac.uk"
     ],
     "bizrate.com": [
-      "time.com",
       "fortune.com",
+      "people.com",
       "ew.com",
-      "sourceforge.net",
-      "travelandleisure.com"
+      "time.com",
+      "slashdot.org"
+    ],
+    "blogos.com": [
+      "livedoor.com"
+    ],
+    "bloomberg.com": [
+      "macrumors.com"
     ],
     "bluecava.com": [
-      "giphy.com",
-      "walmart.com"
+      "history.com",
+      "biography.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
+      "theatlantic.com",
       "sfgate.com",
-      "chron.com",
-      "startribune.com"
+      "chron.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -5091,19 +4233,19 @@
       "variety.com"
     ],
     "bnidx.com": [
-      "bravenet.com",
-      "jigsy.com"
+      "jigsy.com",
+      "bravenet.com"
     ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
       "cancer.org",
-      "groupon.com",
       "networksolutions.com"
     ],
     "bonappetit.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "boston.com": [
@@ -5112,11 +4254,19 @@
     "bostonglobemedia.com": [
       "boston.com"
     ],
+    "botradar.tech": [
+      "radikal.ru"
+    ],
+    "boudja.com": [
+      "4shared.com"
+    ],
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
+      "wired.com",
       "usatoday.com",
-      "dictionary.com",
+      "fortune.com",
+      "jsonline.com",
       "pitchfork.com"
     ],
     "brandcdn.com": [
@@ -5124,33 +4274,39 @@
     ],
     "brides.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "brightcove.com": [
-      "aarp.org",
-      "theaustralian.com.au",
-      "informationweek.com",
-      "scholastic.com"
+      "scholastic.com",
+      "si.com",
+      "federalreserve.gov",
+      "informationweek.com"
     ],
     "brightcove.net": [
-      "aljazeera.com",
-      "lonelyplanet.com",
-      "techtarget.com",
-      "thenational.ae"
+      "lefigaro.fr",
+      "politico.com",
+      "bostonglobe.com"
     ],
     "bttrack.com": [
-      "mirror.co.uk",
-      "nypost.com",
+      "yahoo.com",
+      "independent.co.uk",
+      "zendesk.com",
       "livescience.com",
-      "salesforce.com",
       "dailydot.com"
     ],
     "btttag.com": [
-      "marriott.com"
+      "samsung.com",
+      "marriott.com",
+      "ihg.com"
+    ],
+    "bumlam.com": [
+      "rambler.ru"
     ],
     "c-ctrip.com": [
-      "ctrip.com"
+      "ctrip.com",
+      "qunar.com"
     ],
     "c212.net": [
       "prnewswire.com"
@@ -5161,24 +4317,35 @@
     "cadreon.com": [
       "economist.com"
     ],
+    "caltat.com": [
+      "live4fun.ru"
+    ],
+    "candlewoodsuites.com": [
+      "ihg.com"
+    ],
+    "capturehighered.net": [
+      "ku.edu",
+      "unm.edu"
+    ],
     "carambo.la": [
-      "salon.com",
-      "accuweather.com"
+      "accuweather.com",
+      "salon.com"
     ],
     "casalemedia.com": [
+      "amazon.com",
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
-      "techradar.com",
-      "colourlovers.com"
+      "theverge.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "cbsi.com": [
-      "cnet.com",
-      "cbsnews.com",
+      "zdnet.com",
       "last.fm",
       "gamespot.com",
-      "cbs.com",
-      "techrepublic.com"
+      "cnet.com",
+      "cbsnews.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -5187,8 +4354,15 @@
       "softonic.com",
       "biography.com"
     ],
-    "cdn-net.com": [
+    "cdn-apple.com": [
+      "icloud.com"
+    ],
+    "cdn-hotels.com": [
       "hotels.com"
+    ],
+    "cdn-net.com": [
+      "hotels.com",
+      "americanexpress.com"
     ],
     "cdnwidget.com": [
       "photoshelter.com"
@@ -5199,48 +4373,75 @@
     "changeagain.me": [
       "iconosquare.com"
     ],
+    "charitynavigator.org": [
+      "heart.org"
+    ],
     "chei.com.cn": [
       "chsi.com.cn"
+    ],
+    "chicagotribune.com": [
+      "wikipedia.org"
+    ],
+    "chinajob.com": [
+      "china.org.cn"
     ],
     "chinaso.com": [
       "weather.com.cn"
     ],
+    "chinavivaki.com": [
+      "bshare.cn"
+    ],
     "choozle.com": [
-      "photobucket.com",
-      "denverpost.com"
+      "denverpost.com",
+      "photobucket.com"
     ],
     "circularhub.com": [
       "suntimes.com",
-      "stltoday.com",
       "tampabay.com",
       "bostonherald.com"
     ],
     "civicscience.com": [
-      "post-gazette.com"
+      "post-gazette.com",
+      "knowyourmeme.com",
+      "ebaumsworld.com"
     ],
     "ckies.net": [
       "abril.com.br"
     ],
     "clickability.com": [
+      "prnewswire.com",
       "philly.com",
       "proquest.com"
+    ],
+    "clicktale.net": [
+      "xbox.com",
+      "office.com",
+      "microsoft.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
       "mapquest.com"
     ],
+    "clmbtech.com": [
+      "indiatimes.com"
+    ],
     "cloudflare.com": [
-      "sciencemag.org",
       "uci.edu",
+      "nbcnews.com",
+      "sciencemag.org",
       "symantec.com",
       "allaboutcookies.org"
     ],
     "cnet.com": [
       "zdnet.com"
     ],
+    "cnn.net": [
+      "cnn.com"
+    ],
     "cntraveler.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "cnzz.com": [
@@ -5249,11 +4450,20 @@
     "cobaltgroup.com": [
       "edmunds.com"
     ],
+    "coherentpath.com": [
+      "staples.com"
+    ],
     "cohesionapps.com": [
+      "americanexpress.com",
+      "admin.ch",
       "bankrate.com"
     ],
     "collegenet.com": [
-      "gmu.edu"
+      "gmu.edu",
+      "ku.edu"
+    ],
+    "comm100.com": [
+      "hobbyking.com"
     ],
     "commander1.com": [
       "ovh.com",
@@ -5263,19 +4473,30 @@
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "hp.com",
-      "sap.com",
+      "redhat.com",
+      "theverge.com",
+      "jsonline.com",
       "box.com"
+    ],
+    "complex.com": [
+      "knowyourmeme.com",
+      "dailydot.com",
+      "ebaumsworld.com"
+    ],
+    "conative.de": [
+      "focus.de"
     ],
     "condenastdigital.com": [
       "wired.com",
-      "newyorker.com",
       "arstechnica.com",
       "nj.com",
+      "newyorker.com",
       "pitchfork.com"
     ],
+    "conductrics.com": [
+      "nginx.com"
+    ],
     "connatix.com": [
-      "jpost.com",
       "alternet.org",
       "dailydot.com"
     ],
@@ -5283,71 +4504,109 @@
       "sourceforge.net"
     ],
     "consensu.org": [
-      "buzzfeed.com",
       "rollingstone.com",
       "variety.com",
-      "upi.com",
-      "washingtonexaminer.com"
+      "adweek.com",
+      "buzzfeed.com",
+      "thetimes.co.uk",
+      "nme.com"
     ],
-    "content.ad": [
-      "tinypic.com"
+    "consumable.com": [
+      "xfinity.com"
+    ],
+    "contentabc.com": [
+      "pornhub.com"
     ],
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "usatoday.com",
-      "space.com",
-      "colourlovers.com"
+      "bloomberg.com",
+      "forbes.com",
+      "uci.edu",
+      "walgreens.com"
+    ],
+    "convertful.com": [
+      "lifehack.org"
     ],
     "convertro.com": [
+      "ibm.com",
+      "logitech.com",
       "slack.com"
+    ],
+    "convio.net": [
+      "diabetes.org"
     ],
     "cornell.edu": [
       "arxiv.org"
     ],
-    "coxmediagroup.com": [
-      "ajc.com"
+    "cox.net": [
+      "cox.com"
+    ],
+    "coxbusiness.com": [
+      "cox.com"
+    ],
+    "cpex.cz": [
+      "idnes.cz"
     ],
     "cpx.to": [
-      "independent.co.uk",
-      "mirror.co.uk",
       "express.co.uk",
+      "digitaltrends.com",
       "techradar.com",
+      "independent.co.uk",
       "rfi.fr"
     ],
     "cquotient.com": [
       "gopro.com"
     ],
-    "creative-serving.com": [
-      "tinyurl.com"
+    "cr-nielsen.com": [
+      "youku.com"
     ],
     "creativecdn.com": [
-      "ria.ru"
+      "ria.ru",
+      "udn.com"
+    ],
+    "creativecommons.org": [
+      "perl.com"
     ],
     "criteo.com": [
-      "dropbox.com",
-      "forbes.com",
+      "tinyurl.com",
       "washingtonpost.com",
-      "fool.com",
+      "dailymail.co.uk",
+      "dropbox.com",
+      "webmd.com",
       "sedo.com"
+    ],
+    "croissed.info": [
+      "4shared.com"
+    ],
+    "crowneplaza.com": [
+      "ihg.com"
     ],
     "crsspxl.com": [
       "sourceforge.net",
-      "slashdot.org"
+      "slashdot.org",
+      "bartleby.com"
     ],
     "cssrvsync.com": [
       "springer.com",
       "home.pl"
     ],
-    "ctrmi.com": [
-      "sina.com.cn"
+    "ctv.ca": [
+      "ctvnews.ca"
+    ],
+    "curse.com": [
+      "wowdb.com"
+    ],
+    "custhelp.com": [
+      "oracle.com"
     ],
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
       "gizmodo.com",
-      "kotaku.com",
-      "coindesk.com"
+      "wsj.com",
+      "cbc.ca",
+      "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -5356,14 +4615,13 @@
       "webnode.com"
     ],
     "d2-apps.net": [
-      "goo.ne.jp",
-      "asahi.com"
+      "rakuten.co.jp",
+      "yahoo.co.jp"
     ],
     "d41.co": [
-      "hp.com",
       "intel.com",
       "hpe.com",
-      "sap.com"
+      "hp.com"
     ],
     "da-ads.com": [
       "deviantart.com"
@@ -5371,36 +4629,66 @@
     "dailymail.co.uk": [
       "metro.co.uk"
     ],
+    "dailymotion.com": [
+      "google.com"
+    ],
     "datamind.ru": [
+      "novostimira.com",
       "rambler.ru",
-      "novostimira.com"
+      "kharkov.ua"
+    ],
+    "datasteam.io": [
+      "ama-assn.org"
     ],
     "daum.net": [
       "shutterstock.com",
       "tistory.com"
     ],
+    "daumcdn.net": [
+      "daum.net"
+    ],
+    "daumdn.com": [
+      "shutterstock.com"
+    ],
     "dc-storm.com": [
       "nike.com",
-      "alibabacloud.com",
+      "shutterstock.com",
       "bostonglobe.com"
+    ],
+    "deep.bi": [
+      "hrw.org"
+    ],
+    "dell.com": [
+      "rsa.com"
     ],
     "demdex.net": [
       "adobe.com",
+      "yahoo.com",
       "amazon.com",
       "soundcloud.com",
-      "bluehost.com",
-      "syfy.com"
+      "webmd.com",
+      "jsonline.com",
+      "britishairways.com"
+    ],
+    "departapp.com": [
+      "liveuamap.com"
     ],
     "deployads.com": [
       "tinyurl.com",
-      "sciencedaily.com",
-      "zerohedge.com"
+      "lycos.com",
+      "sciencedaily.com"
+    ],
+    "deqwas.net": [
+      "rakuten.co.jp"
+    ],
+    "developermedia.com": [
+      "codeproject.com"
     ],
     "dezeenjobs.com": [
       "dezeen.com"
     ],
-    "df-srv.de": [
-      "sueddeutsche.de"
+    "dhs.gov": [
+      "fema.gov"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
@@ -5409,22 +4697,35 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
+      "entrepreneur.com",
       "zerohedge.com"
     ],
+    "dictionary.com": [
+      "thesaurus.com"
+    ],
+    "digitaladsystems.com": [
+      "tomsk.ru"
+    ],
     "digitaltarget.ru": [
-      "radikal.ru"
+      "liveinternet.ru",
+      "rambler.ru",
+      "tomsk.ru"
     ],
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
       "express.co.uk",
-      "theonion.com",
       "bostonherald.com"
     ],
+    "disney.com": [
+      "starwars.com"
+    ],
     "disqus.com": [
-      "rollingstone.com",
+      "pnas.org",
       "dyn.com",
-      "mercurynews.com"
+      "mercurynews.com",
+      "dw.com",
+      "rollingstone.com"
     ],
     "distiltag.com": [
       "reuters.com",
@@ -5432,12 +4733,20 @@
     ],
     "districtm.io": [
       "barnesandnoble.com",
-      "seattletimes.com",
-      "miamiherald.com",
-      "colourlovers.com"
+      "urbandictionary.com",
+      "axs.com",
+      "timeanddate.com",
+      "newatlas.com"
+    ],
+    "djv99sxoqpv11.cloudfront.net": [
+      "4shared.com"
     ],
     "dmxleo.com": [
-      "pastebin.com"
+      "dailymotion.com"
+    ],
+    "dnnapi.com": [
+      "zenfolio.com",
+      "gob.es"
     ],
     "dol.gov": [
       "osha.gov"
@@ -5445,15 +4754,16 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com",
-      "atlasobscura.com"
+      "tinypic.com"
     ],
     "dotomi.com": [
+      "tinyurl.com",
       "samsung.com",
-      "economist.com",
-      "barnesandnoble.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "webmd.com",
+      "forbes.com",
+      "illinois.edu",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -5462,38 +4772,49 @@
       "youtube.com",
       "twitter.com",
       "linkedin.com",
-      "billboard.com",
-      "syfy.com"
+      "sourceforge.net",
+      "zend.com",
+      "jsonline.com",
+      "britishairways.com"
+    ],
+    "doublemax.net": [
+      "udn.com"
     ],
     "doublepimpssl.com": [
       "pornhub.com"
     ],
-    "dowjones.io": [
-      "marketwatch.com"
+    "doubleverify.com": [
+      "military.com",
+      "allafrica.com"
     ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
+      "techtarget.com",
       "adweek.com"
-    ],
-    "dsp.com": [
-      "qq.com"
-    ],
-    "dudintrec.ru": [
-      "radikal.ru"
     ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
+      "t-online.de",
       "cnbc.com",
       "nbcnews.com",
-      "norton.com",
       "washingtonexaminer.com"
     ],
+    "dynatrace-managed.com": [
+      "delta.com"
+    ],
+    "dyntrk.com": [
+      "dailymotion.com",
+      "infoplease.com"
+    ],
     "ebay-us.com": [
-      "ebay.com",
-      "ebay.com.au"
+      "ebay.com.au",
+      "ebay.com"
+    ],
+    "ebay.co.uk": [
+      "synacor.com"
     ],
     "ebay.com": [
       "ebay.co.uk",
@@ -5503,27 +4824,46 @@
     "ebayrtm.com": [
       "ebay.co.uk",
       "ebay.de",
+      "ebay.com",
       "ebay.com.au"
     ],
+    "ebaystatic.com": [
+      "ebay.com.au"
+    ],
+    "ebdr3.com": [
+      "springer.com"
+    ],
     "ebis.ne.jp": [
-      "exblog.jp"
+      "exblog.jp",
+      "xrea.com"
+    ],
+    "econda-monitor.de": [
+      "expedia.com"
+    ],
+    "ecustomeropinions.com": [
+      "skysports.com"
     ],
     "edge-cdn.net": [
       "biomedcentral.com"
     ],
+    "edmunds.com": [
+      "unenvironment.org"
+    ],
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com"
+      "gulfnews.com",
+      "goal.com"
     ],
     "eloqua.com": [
       "intel.com",
-      "redhat.com",
-      "wisc.edu",
-      "thawte.com",
+      "cisco.com",
+      "prnewswire.com",
+      "siemens.com",
       "eset.com"
     ],
     "elsevier.com": [
+      "sciencedirect.com",
       "thelancet.com",
       "cell.com"
     ],
@@ -5531,7 +4871,14 @@
       "thelancet.com",
       "cell.com"
     ],
+    "emc.com": [
+      "rsa.com"
+    ],
     "emlgrid.com": [
+      "home.pl"
+    ],
+    "emxdgt.com": [
+      "springer.com",
       "home.pl"
     ],
     "envato.com": [
@@ -5539,30 +4886,61 @@
     ],
     "epicurious.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
     ],
+    "espn.com": [
+      "fivethirtyeight.com"
+    ],
+    "estara.com": [
+      "xerox.com"
+    ],
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "tomshardware.com"
+      "lefigaro.fr"
+    ],
+    "etracker.de": [
+      "sedo.com"
+    ],
+    "etsystudio.com": [
+      "etsy.com"
+    ],
+    "evenhotels.com": [
+      "ihg.com"
+    ],
+    "eventsabout.com": [
+      "sacbee.com"
     ],
     "everesttech.net": [
       "adobe.com",
+      "yahoo.com",
       "sourceforge.net",
-      "nytimes.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "dailymotion.com",
+      "webmd.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
     ],
     "evise.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
+    ],
+    "evolok.net": [
+      "scotsman.com"
+    ],
+    "evyy.net": [
+      "office.com"
+    ],
+    "ew3.io": [
+      "liberation.fr"
     ],
     "exactag.com": [
       "t-online.de"
@@ -5570,25 +4948,37 @@
     "excite.co.jp": [
       "exblog.jp"
     ],
+    "exe.bid": [
+      "rambler.ru"
+    ],
     "exelator.com": [
+      "soundcloud.com",
       "forbes.com",
+      "bloomberg.com",
       "businessinsider.com",
-      "talktalk.co.uk",
-      "bluehost.com",
-      "gizmodo.com"
+      "mirror.co.uk",
+      "zerohedge.com"
+    ],
+    "exosrv.com": [
+      "pornhub.com"
+    ],
+    "expedia.com": [
+      "excite.com"
     ],
     "eyeota.net": [
       "sourceforge.net",
-      "dropbox.com",
-      "wsj.com",
-      "space.com",
-      "zerohedge.com"
+      "forbes.com",
+      "bloomberg.com",
+      "gizmodo.com",
+      "xda-developers.com"
     ],
     "eyereturn.com": [
-      "thestar.com"
+      "thestar.com",
+      "queensu.ca"
     ],
     "eyeviewads.com": [
-      "nypost.com",
+      "staples.com",
+      "xda-developers.com",
       "walgreens.com"
     ],
     "ezoic.net": [
@@ -5597,16 +4987,38 @@
     ],
     "facebook.com": [
       "instagram.com",
+      "wordpress.org",
       "adobe.com",
-      "apple.com",
-      "bluehost.com",
-      "syfy.com"
+      "nytimes.com",
+      "goodreads.com",
+      "jsonline.com",
+      "helsinki.fi"
+    ],
+    "facetz.net": [
+      "novostimira.com",
+      "rambler.ru",
+      "kharkov.ua"
+    ],
+    "fairfax.com.au": [
+      "smh.com.au",
+      "theage.com.au"
+    ],
+    "fastcompany.com": [
+      "fastcodesign.com"
     ],
     "fdlstatic.com": [
       "cnet.com"
     ],
     "feathr.co": [
-      "informationweek.com"
+      "informationweek.com",
+      "eurogamer.net"
+    ],
+    "ffx.io": [
+      "smh.com.au",
+      "theage.com.au"
+    ],
+    "fidelity-media.com": [
+      "home.pl"
     ],
     "filepicker.io": [
       "enlightenment.org",
@@ -5614,58 +5026,75 @@
     ],
     "firstimpression.io": [
       "jpost.com",
+      "serverwatch.com",
       "haaretz.com"
     ],
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "aarp.org"
+      "msu.edu",
+      "bmj.com"
     ],
     "flickr.com": [
+      "state.gov",
       "oecd.org",
-      "enable-javascript.com",
-      "cia.gov",
-      "ncsu.edu",
-      "gatech.edu",
-      "colostate.edu"
+      "enable-javascript.com"
     ],
     "flipboard.com": [
       "venturebeat.com",
-      "popsugar.com",
-      "autoblog.com"
+      "autoblog.com",
+      "popsugar.com"
+    ],
+    "flyercity.ca": [
+      "canada.com"
     ],
     "flyertown.ca": [
-      "nationalpost.com",
+      "canada.com",
       "globalnews.ca",
+      "nationalpost.com",
       "vancouversun.com"
     ],
     "fontawesome.com": [
-      "webex.com",
-      "ucsc.edu",
-      "jugem.jp",
-      "sitepoint.com"
-    ],
-    "force.com": [
-      "constantcontact.com",
-      "teamviewer.com",
-      "salesforce.com"
+      "socarrao.com.br",
+      "clinicaltrials.gov",
+      "moonfruit.com",
+      "webex.com"
     ],
     "foresee.com": [
       "epa.gov",
+      "si.edu",
+      "theglobeandmail.com",
       "sec.gov",
-      "bls.gov",
-      "smithsonianmag.com"
+      "marthastewart.com"
     ],
     "formstack.com": [
       "in.gov"
     ],
     "fout.jp": [
       "economist.com",
-      "exblog.jp",
-      "goo.ne.jp"
+      "hatena.ne.jp"
+    ],
+    "fox.com": [
+      "nationalgeographic.com",
+      "foxnews.com",
+      "foxbusiness.com"
+    ],
+    "foxbusiness.com": [
+      "fox.com"
+    ],
+    "foxnews.com": [
+      "foxbusiness.com",
+      "fox.com"
+    ],
+    "foxsports.com": [
+      "fox.com"
     ],
     "foxycart.com": [
       "brookings.edu"
+    ],
+    "freeskreen.com": [
+      "nationalpost.com",
+      "wattpad.com"
     ],
     "freshdesk.com": [
       "podbean.com"
@@ -5673,122 +5102,186 @@
     "friendbuy.com": [
       "lulu.com"
     ],
+    "funcaptcha.com": [
+      "axs.com"
+    ],
+    "funnyordie.com": [
+      "deadline.com",
+      "videojs.com"
+    ],
     "fwmrm.net": [
+      "yahoo.com",
+      "mlb.com",
+      "xfinity.com",
       "discovery.com",
-      "foodnetwork.com",
-      "channel4.com",
       "hgtv.com"
     ],
-    "geetest.com": [
-      "axs.com"
+    "g2crowd.com": [
+      "prezi.com",
+      "teamviewer.us",
+      "wpengine.com"
+    ],
+    "gakogedifoda.ru": [
+      "radikal.ru"
+    ],
+    "gamer-network.net": [
+      "eurogamer.net"
     ],
     "gemius.pl": [
       "sapo.pt",
+      "interia.pl",
       "ria.ru"
+    ],
+    "gentags.net": [
+      "sina.com.cn"
     ],
     "getclicky.com": [
       "icio.us",
       "newatlas.com",
       "cyberchimps.com"
     ],
+    "getdrip.com": [
+      "dreamhost.com"
+    ],
+    "getpocket.com": [
+      "cronolog.org"
+    ],
     "getsmartcontent.com": [
-      "pcworld.com"
+      "pcworld.com",
+      "computerworld.com",
+      "hpe.com"
+    ],
+    "gfycat.com": [
+      "reddit.com"
     ],
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
       "abc.net.au",
-      "redcross.org",
-      "syfy.com"
+      "sfgate.com",
+      "hgtv.com"
     ],
     "giphy.com": [
-      "urbandictionary.com"
+      "urbandictionary.com",
+      "liberation.fr",
+      "webshots.com"
+    ],
+    "github.com": [
+      "wsj.com"
     ],
     "glamour.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com",
-      "ew.com",
-      "travelandleisure.com"
+      "fortune.com"
+    ],
+    "gmossp-sp.jp": [
+      "shinobi.jp",
+      "shop-pro.jp"
     ],
     "go.com": [
       "disney.com",
+      "espn.com",
       "starwars.com",
       "fivethirtyeight.com"
     ],
     "golfdigest.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
+    "google.co.jp": [
+      "forumotion.com"
+    ],
     "google.com": [
       "youtube.com",
       "linkedin.com",
-      "pinterest.com",
+      "google.de",
+      "godaddy.com",
+      "goodreads.com",
+      "scmp.com",
       "chromium.org",
-      "designboom.com"
+      "jsonline.com",
+      "britishairways.com"
     ],
     "gq.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "gridsumdissector.com": [
-      "www.gov.cn"
+      "qq.com",
+      "www.gov.cn",
+      "autohome.com.cn"
     ],
     "groupondata.com": [
       "groupon.com"
     ],
-    "gstatic.com": [
-      "google.ch",
-      "propublica.org",
-      "facebook.com",
-      "google.com.tw",
-      "goal.com",
-      "google.ca"
+    "gsimedia.net": [
+      "acehardware.com"
+    ],
+    "gssprt.jp": [
+      "dropbox.com",
+      "biglobe.ne.jp"
     ],
     "gtags.net": [
+      "sina.com.cn",
       "ctrip.com"
     ],
     "gumgum.com": [
-      "snopes.com",
-      "thehindu.com",
-      "home.pl",
-      "colourlovers.com"
+      "liveuamap.com",
+      "colourlovers.com",
+      "infoplease.com",
+      "coindesk.com"
+    ],
+    "guoshipartners.com": [
+      "udn.com"
     ],
     "gwallet.com": [
       "adobe.com",
-      "economist.com",
       "ox.ac.uk",
-      "alternet.org",
-      "nme.com"
+      "ihg.com",
+      "economist.com",
+      "business2community.com"
+    ],
+    "hadcs.de": [
+      "t-online.de"
     ],
     "hatena.com": [
       "hatena.ne.jp"
     ],
     "hatena.ne.jp": [
-      "hatenablog.com"
-    ],
-    "hdslb.com": [
-      "bilibili.com"
+      "hatenablog.com",
+      "cronolog.org"
     ],
     "healte.de": [
+      "spiegel.de",
       "reuters.com"
     ],
     "hearstnp.com": [
       "sfgate.com",
-      "chron.com"
+      "chron.com",
+      "seattlepi.com"
     ],
     "help.com": [
-      "comodo.com"
+      "comodo.com",
+      "couchsurfing.com"
+    ],
+    "hiexpress.com": [
+      "ihg.com"
+    ],
+    "highwire.org": [
+      "pnas.org"
     ],
     "hitslink.com": [
       "webstarts.com"
@@ -5796,126 +5289,207 @@
     "hive.co": [
       "complex.com"
     ],
+    "hlserve.com": [
+      "bestbuy.com",
+      "macys.com",
+      "kohls.com"
+    ],
+    "holidayinn.com": [
+      "ihg.com"
+    ],
+    "holidayinnresorts.com": [
+      "ihg.com"
+    ],
     "horyzon-media.com": [
       "skyrock.com"
     ],
-    "huanqiu.com": [
-      "sina.com.cn"
+    "hotelindigo.com": [
+      "ihg.com"
+    ],
+    "hotelsapi.io": [
+      "ovh.net"
+    ],
+    "htmedia.in": [
+      "hindustantimes.com"
     ],
     "hubspot.com": [
-      "scoop.it",
-      "500px.com",
-      "thelancet.com"
+      "wpengine.com",
+      "shopify.com",
+      "technologyreview.com",
+      "scoop.it"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
     ],
-    "hugedata.com.cn": [
-      "miit.gov.cn"
+    "huffingtonpost.com": [
+      "huffingtonpost.co.uk"
     ],
     "huihui.cn": [
       "youdao.com"
     ],
+    "hwcdn.net": [
+      "boingboing.net"
+    ],
     "hybrid.ai": [
-      "rambler.ru"
+      "rambler.ru",
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "hypemarks.com": [
+      "uchicago.edu",
+      "purdue.edu",
+      "brown.edu"
+    ],
+    "i.ua": [
+      "kharkov.ua",
+      "kh.ua"
+    ],
+    "i1img.com": [
+      "excite.com"
+    ],
+    "ib-ibi.com": [
+      "globo.com"
     ],
     "ibclick.stream": [
-      "webmd.com"
+      "webmd.com",
+      "wikitravel.org",
+      "inhabitat.com"
     ],
     "ibillboard.com": [
       "springer.com",
-      "home.pl"
+      "home.pl",
+      "idnes.cz"
     ],
     "ibt.com": [
       "newsweek.com",
       "ibtimes.com"
     ],
     "id5-sync.com": [
+      "bloomberg.com",
+      "venturebeat.com",
+      "dailymotion.com",
       "livescience.com",
-      "skyrock.com",
-      "space.com"
+      "xda-developers.com"
+    ],
+    "idealmedia.com": [
+      "alternet.org",
+      "thehill.com"
     ],
     "ign.com": [
       "videojs.com"
     ],
     "igodigital.com": [
-      "motorola.com",
-      "nintendo.com"
+      "apa.org",
+      "adidas.com",
+      "motorola.com"
     ],
     "iheart.com": [
       "variety.com"
     ],
     "im-apps.net": [
-      "economist.com",
       "exblog.jp",
-      "biglobe.ne.jp",
-      "nifty.com"
+      "rakuten.co.jp",
+      "biglobe.ne.jp"
+    ],
+    "imagetopng.club": [
+      "4shared.com"
+    ],
+    "imedia.cz": [
+      "idnes.cz"
+    ],
+    "imgfarm.com": [
+      "excite.com"
     ],
     "imgur.com": [
       "stackoverflow.com",
-      "stackexchange.com"
+      "stackexchange.com",
+      "unm.edu"
     ],
     "impact-ad.jp": [
-      "economist.com",
+      "rakuten.co.jp",
       "yahoo.co.jp",
-      "hatena.ne.jp",
-      "nifty.com"
+      "goo.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
+      "bbc.com",
       "wsj.com",
-      "speedtest.net",
-      "syfy.com"
+      "altervista.org",
+      "marthastewart.com",
+      "hgtv.com"
+    ],
+    "ineity.pro": [
+      "4shared.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
       "gartner.com"
     ],
-    "innity.com": [
-      "thestar.com.my"
+    "infolinks.com": [
+      "infoplease.com"
+    ],
+    "innovid.com": [
+      "nationalreview.com"
     ],
     "inq.com": [
+      "att.com",
+      "shutterstock.com",
       "ups.com"
     ],
+    "inquisitr.com": [
+      "www.poznan.pl"
+    ],
+    "inside-graph.com": [
+      "staples.com"
+    ],
     "insightexpressai.com": [
-      "giphy.com",
       "unsplash.com",
+      "standard.co.uk",
+      "motorola.com",
+      "reddit.com",
       "gopro.com"
     ],
     "instagram.com": [
-      "illinois.edu",
       "cam.ac.uk",
+      "illinois.edu",
       "cbslocal.com",
       "arizona.edu",
-      "tmz.com",
-      "patch.com"
+      "tmz.com"
     ],
     "instinctiveads.com": [
-      "rollingstone.com",
       "variety.com",
-      "indiewire.com"
+      "dp.ua",
+      "blackberry.com",
+      "rollingstone.com"
     ],
     "intentiq.com": [
-      "thinkgeek.com"
+      "sourceforge.net",
+      "symantec.com"
     ],
     "intentmedia.net": [
+      "hotels.com",
       "tripadvisor.com",
-      "hotels.com"
+      "expedia.com"
     ],
     "intercom.io": [
-      "visual.ly",
-      "yumpu.com",
+      "themeforest.net",
+      "ft.com",
+      "elegantthemes.com",
       "iconfinder.com"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
-      "wikitravel.org"
+      "wikitravel.org",
+      "inhabitat.com"
     ],
     "investingchannel.com": [
       "zerohedge.com"
+    ],
+    "investis.com": [
+      "ge.com"
     ],
     "invoc.us": [
       "prweb.com"
@@ -5923,41 +5497,48 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com",
-      "welt.de"
+      "xing.com"
     ],
     "iolam.it": [
       "virgilio.it"
     ],
     "iperceptions.com": [
+      "ford.com",
+      "seagate.com",
+      "honeywell.com",
       "boeing.com"
     ],
     "ipinyou.com": [
-      "suning.com"
+      "autohome.com.cn"
     ],
     "ipredictive.com": [
       "myspace.com",
-      "usatoday.com"
+      "dailymotion.com"
     ],
     "irs01.com": [
       "youku.com"
     ],
-    "ixiaa.com": [
-      "businessinsider.com"
+    "izooto.com": [
+      "indianexpress.com"
+    ],
+    "janrainsso.com": [
+      "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
+      "ifeng.com",
       "sohu.com"
     ],
     "jquery.com": [
-      "opensource.org",
-      "lemonde.fr",
-      "businessinsider.com"
+      "dyn.com",
+      "fujitsu.com",
+      "liveleak.com",
+      "lemonde.fr"
     ],
     "jrs5.com": [
       "nike.com",
-      "bostonglobe.com",
-      "coursera.org"
+      "shutterstock.com",
+      "bostonglobe.com"
     ],
     "jsrdn.com": [
       "thestar.com",
@@ -5965,11 +5546,23 @@
       "dallasnews.com",
       "vancouversun.com"
     ],
+    "justpremium.com": [
+      "tvtropes.org"
+    ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com"
+      "searchengineland.com",
+      "zenfolio.com",
+      "gopro.com"
+    ],
+    "jword.jp": [
+      "excite.co.jp"
+    ],
+    "jyxo.com": [
+      "blog.cz"
     ],
     "kakao.com": [
+      "tistory.com",
       "daum.net"
     ],
     "kameleoon.eu": [
@@ -5977,10 +5570,11 @@
       "orange.fr"
     ],
     "keywee.co": [
-      "nytimes.com",
       "latimes.com",
       "nationalgeographic.com",
-      "smithsonianmag.com",
+      "chicagotribune.com",
+      "nytimes.com",
+      "rollingstone.com",
       "apartmenttherapy.com"
     ],
     "kinja.com": [
@@ -5992,72 +5586,100 @@
       "enlightenment.org"
     ],
     "krxd.net": [
-      "businessinsider.com",
-      "usatoday.com",
-      "nature.com",
-      "billboard.com",
-      "gizmodo.com"
+      "inhabitat.com",
+      "bgr.com",
+      "jalopnik.com",
+      "cnn.com",
+      "gizmodo.com",
+      "jsonline.com",
+      "realtor.com"
+    ],
+    "ladsp.com": [
+      "exblog.jp",
+      "biglobe.ne.jp",
+      "shop-pro.jp"
     ],
     "leadintel.io": [
       "nme.com"
     ],
+    "leaf.io": [
+      "ehow.com",
+      "livestrong.com"
+    ],
     "legocdn.com": [
       "lego.com"
     ],
+    "lejwaengv.com": [
+      "rd.com"
+    ],
     "liadm.com": [
+      "webmd.com",
+      "nj.com",
+      "patch.com",
       "bloomberg.com",
-      "time.com",
-      "economist.com",
-      "ew.com",
-      "travelandleisure.com"
+      "usmagazine.com"
+    ],
+    "libero.it": [
+      "virgilio.it"
     ],
     "licasd.com": [
-      "ew.com",
-      "travelandleisure.com"
+      "nj.com",
+      "usmagazine.com"
+    ],
+    "licdn.com": [
+      "linkedin.com"
     ],
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "lefigaro.fr",
       "home.pl"
     ],
     "lightboxcdn.com": [
-      "gizmodo.com",
+      "zdnet.com",
       "fastcompany.com",
+      "adweek.com",
       "lifehacker.com",
-      "theonion.com",
-      "dailycaller.com"
+      "usmagazine.com"
     ],
     "lijit.com": [
       "sourceforge.net",
+      "bloomberg.com",
       "deviantart.com",
-      "mirror.co.uk",
-      "upi.com",
+      "howstuffworks.com",
       "infoplease.com"
     ],
+    "lincoln.com": [
+      "ford.com"
+    ],
     "link-page.info": [
-      "netvibes.com"
+      "netvibes.com",
+      "icq.com"
     ],
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "sap.com",
-      "lexisnexis.com"
+      "dropbox.com",
+      "cisco.com",
+      "unity3d.com",
+      "helsinki.fi"
     ],
     "linksynergy.com": [
+      "rakuten.co.jp",
       "pcworld.com",
-      "nike.com",
-      "alibabacloud.com",
-      "infoworld.com"
+      "nike.com"
+    ],
+    "list-manage.com": [
+      "boingboing.net"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "microsoft.com",
+      "paypal.com",
+      "skype.com",
       "msn.com",
-      "bing.com",
+      "microsoft.com",
       "office.com"
     ],
     "livechatinc.com": [
@@ -6066,201 +5688,262 @@
       "sophos.com",
       "nazwa.pl"
     ],
+    "livedoor.jp": [
+      "livedoor.com"
+    ],
     "livejournal.net": [
       "livejournal.com"
     ],
     "liveperson.net": [
-      "talktalk.co.uk",
-      "earthlink.net",
-      "thetimes.co.uk",
-      "trendmicro.com",
-      "lexisnexis.com"
+      "apache.org",
+      "prnewswire.com",
+      "ibm.com",
+      "earthlink.net"
+    ],
+    "lkqd.net": [
+      "allafrica.com"
     ],
     "loc.gov": [
+      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
-      "jpost.com",
-      "infoplease.com"
+      "infoplease.com",
+      "coindesk.com",
+      "edmunds.com"
     ],
     "logly.co.jp": [
       "goo.ne.jp",
       "nifty.com"
     ],
-    "lp1block.com": [
-      "radikal.ru"
+    "lqm.io": [
+      "lefigaro.fr"
     ],
     "lrcontent.com": [
       "cbc.ca",
       "arte.tv"
     ],
+    "lucklayed.info": [
+      "4shared.com"
+    ],
+    "lwcal.com": [
+      "sfu.ca"
+    ],
     "lytics.io": [
-      "economist.com",
-      "digitaltrends.com",
       "adweek.com",
-      "fool.com"
+      "digitaltrends.com",
+      "fool.com",
+      "economist.com"
     ],
     "m6r.eu": [
       "t-online.de",
       "statista.com"
     ],
-    "macromill.com": [
-      "asahi.com"
+    "madeleine.de": [
+      "t-online.de"
     ],
     "mail.ru": [
       "vk.com",
+      "novostimira.com",
+      "google.com",
       "yandex.ru",
-      "thehill.com",
-      "icq.com",
-      "ok.ru",
-      "liveinternet.ru",
-      "novostimira.com"
+      "ok.ru"
+    ],
+    "mailchimp.com": [
+      "colorlib.com",
+      "fas.org",
+      "tias.com",
+      "nap.edu"
+    ],
+    "mantisadnetwork.com": [
+      "tvtropes.org"
     ],
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "smugmug.com",
-      "eventbrite.co.uk",
-      "godaddy.com"
+      "hootsuite.com",
+      "smugmug.com"
     ],
     "marketlinc.com": [
-      "teamviewer.com",
-      "eset.com"
+      "kaspersky.com",
+      "norton.com",
+      "eset.com",
+      "teamviewer.us"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
       "dyn.com",
-      "docker.com",
-      "searchengineland.com",
-      "hootsuite.com",
-      "domaintools.com"
+      "ubuntu.com"
     ],
     "matheranalytics.com": [
+      "theglobeandmail.com",
       "thestar.com",
-      "mercurynews.com",
       "seattletimes.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "ew.com",
-      "colourlovers.com"
+      "forbes.com",
+      "prnewswire.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
       "forbes.com",
-      "thestreet.com",
+      "reuters.com",
+      "webmd.com",
       "cracked.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
-      "columbia.edu",
       "uci.edu",
-      "colourlovers.com"
+      "autodesk.com",
+      "box.com"
     ],
     "mediaforge.com": [
-      "bostonglobe.com",
-      "coursera.org"
+      "nike.com",
+      "shutterstock.com",
+      "bostonglobe.com"
+    ],
+    "medialand.ru": [
+      "rbc.ru"
     ],
     "mediaplex.com": [
-      "economist.com",
       "dell.com",
-      "shutterfly.com"
+      "shutterfly.com",
+      "military.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
+      "lynda.com",
+      "liberation.fr",
       "leparisien.fr"
     ],
     "mediav.com": [
-      "so.com",
       "ctrip.com",
-      "toutiao.com"
+      "2345.com",
+      "so.com"
     ],
     "mediawallahscript.com": [
       "sourceforge.net",
-      "gopro.com"
+      "photobucket.com",
+      "shopko.com"
     ],
-    "mediawiki.org": [
-      "wikimedia.org"
+    "medscape.com": [
+      "medicinenet.com"
     ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
     ],
     "metadsp.co.uk": [
-      "usatoday.com",
-      "mirror.co.uk",
-      "nypost.com"
+      "nypost.com",
+      "standard.co.uk"
     ],
     "mfadsrvr.com": [
-      "nbcsports.com"
+      "jsonline.com"
     ],
     "mg2connext.com": [
+      "mercurynews.com",
       "philly.com",
-      "newsday.com",
-      "ajc.com"
+      "denverpost.com"
     ],
     "mgid.com": [
-      "liveleak.com"
+      "liveleak.com",
+      "radikal.ru"
+    ],
+    "miamiherald.com": [
+      "sacbee.com",
+      "kansascity.com"
     ],
     "miaozhen.com": [
-      "qq.com",
       "sina.com.cn",
-      "pconline.com.cn"
+      "163.com",
+      "dzwww.com",
+      "sohu.com",
+      "autohome.com.cn"
     ],
     "microad.jp": [
+      "rakuten.co.jp",
       "sakura.ne.jp",
-      "hatena.ne.jp"
+      "biglobe.ne.jp"
     ],
     "microsoft.com": [
-      "msn.com",
       "live.com",
       "skype.com",
+      "or.kr",
+      "msn.com",
       "office.com",
       "xbox.com",
-      "complex.com"
+      "complex.com",
+      "encyclopedia.com"
     ],
     "microsoftonline.com": [
       "microsoft.com",
       "office.com"
     ],
+    "mirtesen.ru": [
+      "rbc.ru"
+    ],
     "mktoresp.com": [
       "parallels.com",
+      "prnewswire.com",
       "zend.com",
-      "prweb.com",
-      "proofpoint.com",
+      "nginx.com",
+      "oreilly.com",
       "pingdom.com"
     ],
     "ml314.com": [
       "sourceforge.net",
-      "wsj.com",
+      "forbes.com",
       "bloomberg.com",
-      "space.com",
-      "zerohedge.com"
+      "wsj.com",
+      "zdnet.com",
+      "xda-developers.com"
+    ],
+    "mlb.com": [
+      "nhl.com"
+    ],
+    "mlive.com": [
+      "nola.com"
     ],
     "mmstat.com": [
+      "alibaba.com",
       "youku.com",
-      "sohu.com",
       "taobao.com",
-      "tmall.com"
+      "sohu.com",
+      "51.la"
+    ],
+    "mmtro.com": [
+      "upwork.com"
+    ],
+    "molefefiseranis.ru": [
+      "radikal.ru"
     ],
     "monetate.net": [
       "nationalgeographic.com",
-      "marriott.com"
+      "marriott.com",
+      "ticketmaster.com"
+    ],
+    "monster.com": [
+      "military.com"
     ],
     "mookie1.com": [
-      "businessinsider.com",
-      "photobucket.com",
+      "t-online.de",
+      "nbcnews.com",
       "theglobeandmail.com",
-      "eonline.com"
+      "thetimes.co.uk"
     ],
     "mouseflow.com": [
+      "bbb.org",
       "nintendo.com"
     ],
     "mpnrs.com": [
@@ -6269,6 +5952,7 @@
     ],
     "mrpfd.com": [
       "symantec.com",
+      "gouv.fr",
       "hpe.com"
     ],
     "msgapp.com": [
@@ -6276,63 +5960,108 @@
       "odin.com"
     ],
     "msn.com": [
-      "marketwatch.com"
+      "w3.org",
+      "marketwatch.com",
+      "google.com"
+    ],
+    "mthsense.com": [
+      "alternet.org"
+    ],
+    "mtty.com": [
+      "163.com"
     ],
     "mtvnservices.com": [
       "mtv.com",
       "cc.com"
     ],
+    "multiview.com": [
+      "symantec.com",
+      "nutrition.org"
+    ],
     "musthird.com": [
       "airbnb.com"
+    ],
+    "muumuu-domain.com": [
+      "shop-pro.jp"
+    ],
+    "mybuys.com": [
+      "shopko.com"
+    ],
+    "myhard.com": [
+      "yesky.com"
     ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
+    ],
+    "myregistry.com": [
+      "shopko.com"
     ],
     "myspacecdn.com": [
       "myspace.com"
     ],
     "myvisualiq.net": [
       "soundcloud.com",
-      "paypal.com",
       "surveymonkey.com",
-      "bluehost.com"
+      "spotify.com",
+      "paypal.com",
+      "dell.com"
     ],
     "nanigans.com": [
-      "squareup.com",
       "thinkgeek.com",
-      "yellowpages.com"
+      "overstock.com",
+      "squareup.com",
+      "zappos.com"
     ],
     "narrative.io": [
-      "sourceforge.net",
-      "businessinsider.com"
+      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
     ],
     "nationalgeographic.com": [
-      "foxnews.com"
+      "foxnews.com",
+      "foxbusiness.com",
+      "fox.com"
+    ],
+    "native.ai": [
+      "rollingstone.com"
     ],
     "nativendo.de": [
-      "t-online.de"
+      "t-online.de",
+      "gnu.org",
+      "focus.de"
     ],
     "naver.com": [
-      "unity3d.com"
+      "unity3d.com",
+      "cafe24.com"
     ],
     "naver.jp": [
-      "line.me"
+      "line.me",
+      "livedoor.com"
+    ],
+    "nbcnews.com": [
+      "today.com",
+      "msnbc.com"
     ],
     "nbcuni.com": [
       "cnbc.com",
-      "nbcnews.com",
-      "today.com",
+      "msnbc.com",
       "nbc.com",
-      "syfy.com"
+      "nbcnews.com"
+    ],
+    "netdna-ssl.com": [
+      "alternet.org"
     ],
     "netmng.com": [
-      "businessinsider.com",
-      "lemonde.fr",
-      "colourlovers.com"
+      "lenovo.com",
+      "theknot.com",
+      "shopko.com",
+      "jsonline.com",
+      "xda-developers.com"
+    ],
+    "newatlas.com": [
+      "flipboard.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -6346,25 +6075,26 @@
     ],
     "news.com.au": [
       "theaustralian.com.au",
-      "heraldsun.com.au",
-      "dailytelegraph.com.au"
+      "heraldsun.com.au"
     ],
     "newscdn.com.au": [
-      "heraldsun.com.au",
-      "dailytelegraph.com.au"
+      "heraldsun.com.au"
     ],
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
       "thesun.co.uk",
-      "biblegateway.com",
-      "heraldsun.com.au"
+      "wsj.com",
+      "news.com.au",
+      "realtor.com"
     ],
     "newsinc.com": [
       "latimes.com",
-      "hollywoodreporter.com",
-      "thehill.com",
-      "ajc.com"
+      "nydailynews.com",
+      "hollywoodreporter.com"
+    ],
+    "newsmemory.com": [
+      "cleveland.com"
     ],
     "newsvine.com": [
       "nbcnews.com",
@@ -6376,6 +6106,7 @@
     ],
     "newyorker.com": [
       "wired.com",
+      "vanityfair.com",
       "vogue.com",
       "pitchfork.com"
     ],
@@ -6385,33 +6116,84 @@
     "ngpvan.com": [
       "greenpeace.org"
     ],
+    "nih.gov": [
+      "medlineplus.gov",
+      "clinicaltrials.gov"
+    ],
+    "nj.com": [
+      "nola.com"
+    ],
+    "nokia.com": [
+      "bell-labs.com"
+    ],
+    "norton.com": [
+      "namejet.com"
+    ],
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "huffingtonpost.com",
-      "redcross.org",
-      "nbcsports.com"
+      "oracle.com",
+      "washingtonpost.com",
+      "domainmarket.com",
+      "jsonline.com",
+      "helsinki.fi"
+    ],
+    "nsaudience.pl": [
+      "interia.pl"
+    ],
+    "nscontext.eu": [
+      "interia.pl",
+      "home.pl"
     ],
     "nuggad.net": [
-      "t-online.de"
+      "t-online.de",
+      "liberation.fr",
+      "lexpress.fr"
     ],
     "nxtck.com": [
       "nike.com",
-      "bostonglobe.com",
-      "coursera.org",
-      "orange.fr"
+      "shutterstock.com",
+      "bostonglobe.com"
+    ],
+    "nymag.com": [
+      "vulture.com"
+    ],
+    "nzaza.com": [
+      "upwork.com"
     ],
     "o0bg.com": [
       "bostonglobe.com"
     ],
-    "offaces-butional.com": [
-      "pornhub.com"
+    "oath.com": [
+      "tumblr.com",
+      "huffingtonpost.co.uk",
+      "techradar.com"
+    ],
+    "ocdn.eu": [
+      "onet.pl",
+      "brightcove.net"
+    ],
+    "oclc.org": [
+      "worldcat.org"
+    ],
+    "ofapes.com": [
+      "radikal.ru"
+    ],
+    "office.com": [
+      "microsoftonline.com"
+    ],
+    "office365.com": [
+      "microsoftonline.com"
     ],
     "ojrq.net": [
-      "autodesk.com"
+      "office.com"
     ],
     "ok.ru": [
-      "ria.ru"
+      "ria.ru",
+      "mail.ru"
+    ],
+    "olark.com": [
+      "webstarts.com"
     ],
     "olympicchannel.com": [
       "olympic.org"
@@ -6423,30 +6205,36 @@
       "rambler.ru"
     ],
     "omnitagjs.com": [
-      "mirror.co.uk",
-      "variety.com",
-      "skyrock.com",
-      "standard.co.uk"
+      "springer.com",
+      "standard.co.uk",
+      "home.pl",
+      "newatlas.com"
     ],
     "omtrdc.net": [
       "adobe.com",
-      "telegraph.co.uk",
       "amazon.com",
-      "sap.com",
-      "rtve.es"
+      "telegraph.co.uk",
+      "dell.com",
+      "eset.com"
+    ],
+    "onclickmega.com": [
+      "brothersoft.com"
     ],
     "onecount.net": [
       "foreignpolicy.com"
     ],
-    "oneroof.co.nz": [
-      "nzherald.co.nz"
+    "onet.tv": [
+      "onet.pl"
     ],
     "onetrust.com": [
-      "cnn.com",
-      "thesun.co.uk",
       "themeisle.com",
-      "atlassian.com",
+      "bitbucket.org",
+      "namecheap.com",
+      "thesun.co.uk",
       "active.com"
+    ],
+    "onevision.com.tw": [
+      "udn.com"
     ],
     "online-metrix.net": [
       "gotomeeting.com"
@@ -6456,26 +6244,29 @@
     ],
     "onthe.io": [
       "indiatimes.com",
-      "express.co.uk",
-      "rbc.ru"
+      "wn.com",
+      "express.co.uk"
     ],
     "ooyala.com": [
-      "bizjournals.com",
       "accuweather.com",
-      "fedex.com"
+      "technologyreview.com",
+      "bizjournals.com"
     ],
     "openhub.net": [
       "mariadb.org"
     ],
     "openstat.net": [
-      "novostimira.com"
+      "novostimira.com",
+      "kharkov.ua"
     ],
     "openx.net": [
+      "yahoo.com",
+      "amazon.com",
       "nytimes.com",
       "dropbox.com",
-      "telegraph.co.uk",
-      "liveinternet.ru",
-      "colourlovers.com"
+      "theverge.com",
+      "jsonline.com",
+      "active.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -6483,146 +6274,206 @@
     "optaim.com": [
       "sohu.com"
     ],
+    "optimix.asia": [
+      "bshare.cn"
+    ],
     "optimizely.com": [
-      "nytimes.com",
       "cnn.com",
-      "microsoft.com",
+      "creativecommons.org",
+      "webs.com",
       "bbc.com",
-      "hp.com",
+      "live.com",
+      "ibm.com",
       "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
-      "foxnews.com",
-      "change.org",
-      "wikihow.com",
+      "constantcontact.com",
       "imageshack.us",
+      "wikihow.com",
       "newyorker.com",
+      "scientificamerican.com",
+      "evernote.com",
       "box.com",
       "prezi.com",
       "prweb.com",
-      "ign.com",
+      "dictionary.com",
       "bitbucket.org",
-      "gotomeeting.com",
       "accorhotels.com",
+      "uber.com",
+      "xbox.com",
       "history.com",
       "bestbuy.com",
-      "salesforce.com",
-      "www.nhs.uk",
-      "office.com",
+      "jamanetwork.com",
       "imageshack.com",
+      "atlassian.com",
       "dallasnews.com",
       "metmuseum.org",
       "intuit.com",
       "blizzard.com",
-      "foxbusiness.com",
-      "ama-assn.org",
       "squareup.com",
       "starbucks.com",
-      "care2.com",
       "ajc.com",
       "justgiving.com",
-      "bankrate.com",
       "dreamhost.com",
+      "microsoft.com",
       "edx.org",
       "bartleby.com",
+      "malwarebytes.com",
+      "theknot.com",
+      "zenfolio.com",
+      "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
-      "peta.org",
       "fox.com"
+    ],
+    "optimove.events": [
+      "bhphotovideo.com"
     ],
     "ora.tv": [
       "cheezburger.com",
-      "alternet.org",
-      "wnd.com"
+      "alternet.org"
+    ],
+    "oracleimg.com": [
+      "dyn.com"
     ],
     "orangeads.fr": [
       "orange.fr"
+    ],
+    "oreilly.com": [
+      "onlamp.com",
+      "ora.com"
+    ],
+    "otm-r.com": [
+      "tomsk.ru",
+      "radikal.ru",
+      "diary.ru"
     ],
     "otto.de": [
       "t-online.de"
     ],
     "outbrain.com": [
+      "nature.com",
+      "scribd.com",
+      "foxnews.com",
       "cnn.com",
-      "msn.com",
-      "wsj.com",
-      "ew.com",
+      "news.com.au",
       "rfi.fr"
     ],
+    "ovh.com": [
+      "ovh.co.uk"
+    ],
     "owneriq.net": [
+      "lycos.com",
       "lg.com",
-      "acer.com",
+      "washingtontimes.com",
       "walgreens.com"
+    ],
+    "owox.com": [
+      "simplesite.com"
+    ],
+    "paddle.com": [
+      "snapwidget.com"
     ],
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
       "ap.org",
-      "heroku.com",
       "propublica.org"
     ],
     "parsely.com": [
-      "huffingtonpost.com",
-      "bloomberg.com",
       "time.com",
-      "huffingtonpost.co.uk",
-      "syfy.com"
+      "wired.com",
+      "wikia.com",
+      "wsj.com",
+      "fortune.com",
+      "rfi.fr"
     ],
     "paypal.com": [
-      "greenpeace.org",
       "paypal.me"
     ],
     "paypalobjects.com": [
       "paypal.com",
-      "paypal.me",
-      "freetype.org"
+      "freetype.org",
+      "paypal.me"
     ],
     "payroll.com": [
       "intuit.com"
+    ],
+    "pbbl.co": [
+      "zappos.com"
+    ],
+    "pbskids.org": [
+      "pbs.org"
+    ],
+    "pcmag.com": [
+      "macrumors.com",
+      "extremetech.com"
+    ],
+    "pdmp.jp": [
+      "shop-pro.jp"
     ],
     "performgroup.com": [
       "goal.com"
     ],
     "perimeterx.net": [
-      "udemy.com",
-      "zillow.com",
-      "seekingalpha.com",
-      "couchsurfing.com"
+      "bloomberg.com",
+      "pixnet.net",
+      "macrumors.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
-    ],
-    "photobucket.com": [
-      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
     ],
     "pinterest.com": [
-      "nytimes.com",
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "huffingtonpost.co.uk"
+      "nytimes.com",
+      "themeforest.net",
+      "booking.com",
+      "marthastewart.com"
     ],
     "pitchfork.com": [
       "wired.com",
-      "vogue.com"
+      "newyorker.com",
+      "vanityfair.com",
+      "epicurious.com"
+    ],
+    "pixanalytics.com": [
+      "pixnet.net"
     ],
     "piximedia.com": [
       "orange.fr"
     ],
+    "pixnet.cc": [
+      "pixnet.net"
+    ],
+    "placed.com": [
+      "imdb.com"
+    ],
     "placelocal.com": [
       "gopro.com"
+    ],
+    "playwire.com": [
+      "infoplease.com",
+      "zotero.org"
     ],
     "plista.com": [
       "express.co.uk"
     ],
     "po.st": [
-      "nme.com",
-      "wnd.com"
+      "smithsonianmag.com",
+      "wnd.com",
+      "business2community.com",
+      "nme.com"
+    ],
+    "polymorphicads.jp": [
+      "shinobi.jp"
     ],
     "popin.cc": [
-      "nifty.com"
+      "infoseek.co.jp"
     ],
     "popsugar-assets.com": [
       "popsugar.com"
@@ -6631,29 +6482,36 @@
       "reuters.com",
       "independent.co.uk",
       "chicagotribune.com",
-      "seattletimes.com",
+      "wsj.com",
+      "marketwatch.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
-      "variety.com",
       "lemonde.fr",
-      "howtogeek.com"
+      "livescience.com",
+      "standard.co.uk"
+    ],
+    "pressboard.ca": [
+      "observer.com"
     ],
     "prfct.co": [
-      "smugmug.com"
+      "smugmug.com",
+      "marthastewart.com",
+      "business2community.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
+      "symantec.com",
       "slashdot.org",
-      "thinkgeek.com"
-    ],
-    "prod-cmg-proxy-connext.azurewebsites.net": [
-      "ajc.com"
+      "business2community.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
       "denverpost.com",
       "ocregister.com"
+    ],
+    "proparm.jp": [
+      "biglobe.ne.jp"
     ],
     "provenpixel.com": [
       "shopify.com"
@@ -6661,24 +6519,33 @@
     "providesupport.com": [
       "jigsy.com"
     ],
-    "proximus.be": [
+    "proximustv.be": [
       "skynet.be"
     ],
     "pscp.tv": [
+      "ey.com",
+      "ria.ru",
       "nasa.gov"
     ],
     "pub.network": [
+      "metacafe.com",
       "coindesk.com"
+    ],
+    "publishme.se": [
+      "blogg.se"
     ],
     "pubmatic.com": [
       "dropbox.com",
-      "businessinsider.com",
+      "tinyurl.com",
+      "bloomberg.com",
       "usatoday.com",
-      "space.com",
-      "colourlovers.com"
+      "webmd.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "pubmine.com": [
-      "foreignpolicy.com"
+      "foreignpolicy.com",
+      "onecount.net"
     ],
     "pulpix.com": [
       "variety.com"
@@ -6686,34 +6553,61 @@
     "purch.com": [
       "livescience.com",
       "space.com",
-      "tomshardware.com",
-      "anandtech.com"
+      "tomshardware.com"
     ],
     "purechat.com": [
       "byu.edu"
     ],
-    "pushanert.com": [
-      "4shared.com"
+    "pxf.io": [
+      "namecheap.com",
+      "udemy.com"
     ],
-    "pxi.pub": [
-      "mentalfloss.com"
+    "pxtres.com": [
+      "howstuffworks.com"
+    ],
+    "pxuno.com": [
+      "howstuffworks.com"
+    ],
+    "pxzwei.com": [
+      "howstuffworks.com"
     ],
     "pymx5.com": [
-      "sfgate.com",
       "seattletimes.com",
+      "seattlepi.com",
+      "sfgate.com",
       "cracked.com"
     ],
+    "qnsr.com": [
+      "serverwatch.com"
+    ],
+    "qq.com": [
+      "sina.com.cn",
+      "ctrip.com",
+      "weather.com.cn"
+    ],
+    "qsstats.com": [
+      "serverwatch.com",
+      "eweek.com"
+    ],
+    "qtmojo.com": [
+      "dzwww.com"
+    ],
     "qualtrics.com": [
-      "techrepublic.com",
-      "nintendo.com",
-      "cnet.com"
+      "adidas.com",
+      "cnet.com",
+      "babycenter.com"
     ],
     "quantserve.com": [
-      "vimeo.com",
       "wordpress.org",
+      "vimeo.com",
       "reddit.com",
-      "fool.com",
+      "soundcloud.com",
+      "goodreads.com",
+      "jsonline.com",
       "rfi.fr"
+    ],
+    "quantummetric.com": [
+      "macys.com"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -6725,7 +6619,7 @@
       "weebly.com",
       "bloomberg.com",
       "ning.com",
-      "billboard.com",
+      "nypost.com",
       "eset.com"
     ],
     "rackcdn.com": [
@@ -6734,25 +6628,50 @@
     "radiotime.com": [
       "tunein.com"
     ],
+    "rakuten.co.jp": [
+      "infoseek.co.jp"
+    ],
     "rambler.ru": [
       "livejournal.com",
+      "washingtonpost.com",
       "novostimira.com",
-      "ria.ru"
+      "ria.ru",
+      "kharkov.ua"
     ],
-    "reactful.com": [
-      "thawte.com"
+    "rbnt.org": [
+      "radikal.ru"
+    ],
+    "rcsmetrics.it": [
+      "corriere.it"
+    ],
+    "reachmax.cn": [
+      "sina.com.cn",
+      "autohome.com.cn",
+      "bshare.cn"
     ],
     "reddit.com": [
       "acm.org",
       "perl.com"
     ],
+    "redditmedia.com": [
+      "reddit.com"
+    ],
     "redlink.com": [
-      "jamanetwork.com"
+      "jamanetwork.com",
+      "ccc.de"
+    ],
+    "reference.com": [
+      "thesaurus.com"
     ],
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
+    "relap.io": [
+      "diary.ru"
+    ],
     "republer.com": [
+      "tomsk.ru",
+      "radikal.ru",
       "rambler.ru"
     ],
     "researchintel.com": [
@@ -6769,27 +6688,26 @@
       "reuters.com"
     ],
     "revcontent.com": [
-      "jpost.com",
-      "breitbart.com",
-      "bostonherald.com"
+      "liveuamap.com",
+      "wnd.com",
+      "jpost.com"
     ],
     "revjet.com": [
+      "homedepot.com",
+      "expedia.com",
       "bankrate.com"
     ],
     "rezync.com": [
       "economist.com",
-      "accuweather.com",
-      "investopedia.com"
+      "accuweather.com"
     ],
     "rfihub.com": [
       "dropbox.com",
+      "tinyurl.com",
       "npr.org",
-      "economist.com",
-      "kaspersky.com",
+      "forbes.com",
+      "foursquare.com",
       "gopro.com"
-    ],
-    "rhombusads.com": [
-      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6800,77 +6718,109 @@
       "mlive.com"
     ],
     "richrelevance.com": [
-      "hbr.org"
+      "hbr.org",
+      "kohls.com"
+    ],
+    "rightnowtech.com": [
+      "oracle.com"
     ],
     "rkdms.com": [
-      "dropbox.com",
-      "usatoday.com",
+      "time.com",
       "wired.com",
-      "kotaku.com",
-      "gizmodo.com"
+      "cbsnews.com",
+      "zdnet.com",
+      "pitchfork.com"
     ],
     "rlcdn.com": [
       "adobe.com",
+      "yahoo.com",
       "sourceforge.net",
       "reddit.com",
-      "sap.com",
-      "colourlovers.com"
+      "uci.edu",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "rnengage.com": [
+      "oracle.com",
       "thinkgeek.com"
     ],
     "rockyou.net": [
       "springer.com"
     ],
-    "rqtrk.eu": [
-      "dropbox.com"
+    "roomkey.com": [
+      "hilton.com",
+      "ihg.com"
+    ],
+    "roymorgan.com": [
+      "smh.com.au"
+    ],
+    "rtb.com.ru": [
+      "radikal.ru",
+      "diary.ru"
     ],
     "rtk.io": [
-      "seattletimes.com",
-      "miamiherald.com",
-      "startribune.com"
+      "post-gazette.com",
+      "azcentral.com",
+      "freep.com"
     ],
     "ru4.com": [
-      "dropbox.com"
+      "dropbox.com",
+      "bloomberg.com",
+      "uci.edu"
     ],
     "rubiconproject.com": [
+      "yahoo.com",
+      "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "cnn.com",
-      "techradar.com",
-      "colourlovers.com"
+      "gizmodo.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "rundsp.com": [
-      "hpe.com"
+      "hpe.com",
+      "alternet.org"
+    ],
+    "rutarget.ru": [
+      "rambler.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "bell-labs.com",
-      "hwg.org"
+      "codepen.io",
+      "tvtropes.org"
     ],
     "s3xified.com": [
-      "thehindu.com"
+      "venturebeat.com",
+      "livescience.com",
+      "lycos.com"
+    ],
+    "sabavision.com": [
+      "mihanblog.com"
     ],
     "salesforceliveagent.com": [
+      "constantcontact.com",
       "marriott.com",
-      "teamviewer.com",
       "prweb.com",
       "salesforce.com",
       "eset.com"
     ],
     "salesloft.com": [
-      "wpengine.com",
       "techtarget.com",
-      "upwork.com"
+      "upwork.com",
+      "wpengine.com"
     ],
     "salesmanago.pl": [
       "home.pl"
     ],
     "samba.tv": [
+      "imdb.com",
       "gizmodo.com",
-      "lifehacker.com",
-      "history.com",
-      "tmz.com",
-      "syfy.com"
+      "lifehacker.com"
+    ],
+    "sbal4kp.com": [
+      "dropbox.com"
+    ],
+    "scarabresearch.com": [
+      "tate.org.uk"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -6879,174 +6829,238 @@
       "thelancet.com",
       "cell.com"
     ],
+    "sciencedirectassets.com": [
+      "sciencedirect.com"
+    ],
     "sciverse.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
+    ],
+    "scoop.it": [
+      "investorseurope.technology"
     ],
     "scopus.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
     ],
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
       "tumblr.com",
-      "billboard.com",
-      "syfy.com"
+      "nytimes.com",
+      "goodreads.com",
+      "jsonline.com",
+      "drugs.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
-      "startribune.com"
+      "startribune.com",
+      "ctvnews.ca"
     ],
-    "sdp-campaign.de": [
-      "t-online.de"
+    "sddan.com": [
+      "upwork.com"
+    ],
+    "seadform.net": [
+      "bloomberg.com"
+    ],
+    "searchmarketing.com": [
+      "macys.com"
     ],
     "securedvisit.com": [
-      "cafepress.com"
+      "cafepress.com",
+      "staples.com"
+    ],
+    "seekingalpha.com": [
+      "ytimg.com"
     ],
     "sekindo.com": [
       "allafrica.com"
     ],
     "selectablemedia.com": [
-      "time.com",
       "fortune.com",
       "people.com",
       "ew.com",
-      "travelandleisure.com"
+      "time.com",
+      "marthastewart.com"
     ],
     "self.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "semasio.net": [
-      "space.com"
+      "bloomberg.com"
     ],
     "sendtonews.com": [
+      "canada.com",
       "bostonherald.com"
     ],
     "servebom.com": [
+      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "howtogeek.com",
-      "dailydot.com"
+      "xda-developers.com"
+    ],
+    "servedby-buysellads.com": [
+      "dribbble.com"
     ],
     "serverbid.com": [
-      "sciencedaily.com"
+      "coindesk.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
-      "businessinsider.com",
+      "t-online.de",
+      "nbcnews.com",
       "news.com.au",
-      "redbull.com",
-      "syfy.com"
+      "hgtv.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
       "fitbit.com"
     ],
+    "shareaholic.com": [
+      "washingtontimes.com",
+      "turnerpublishing.com"
+    ],
     "sharethis.com": [
-      "uk.com",
-      "www.vic.gov.au",
-      "mcafee.com",
-      "findlaw.com",
+      "www.uk.com",
+      "whatsapp.com",
+      "lycos.com",
+      "uci.edu",
       "dailycaller.com"
     ],
     "sharethrough.com": [
-      "springer.com",
-      "samsung.com",
-      "cnbc.com",
-      "squareup.com"
+      "yahoo.com",
+      "cnn.com",
+      "time.com",
+      "cnet.com",
+      "fortune.com"
+    ],
+    "sheego.de": [
+      "t-online.de"
     ],
     "shop.pe": [
-      "dyn.com"
+      "dyn.com",
+      "bluehost.com",
+      "fourseasons.com"
     ],
-    "siftscience.com": [
-      "kickstarter.com",
-      "flickr.com",
-      "shutterstock.com",
-      "patreon.com",
-      "couchsurfing.com"
+    "shopify.com": [
+      "codepen.io",
+      "raspberrypi.org"
+    ],
+    "simplereach.com": [
+      "theatlantic.com"
     ],
     "simpli.fi": [
-      "thinkgeek.com",
-      "tampabay.com"
+      "symantec.com",
+      "washingtontimes.com",
+      "thinkgeek.com"
     ],
     "sina.cn": [
       "sina.com.cn"
     ],
     "sina.com.cn": [
       "weibo.com",
-      "suning.com"
+      "dzwww.com",
+      "sina.com"
+    ],
+    "sinoptik.ua": [
+      "kharkov.ua",
+      "kh.ua"
+    ],
+    "sitehelix.com": [
+      "overstock.com"
     ],
     "siteimprove.com": [
-      "berkeley.edu",
+      "usda.gov",
       "verisign.com",
       "udel.edu",
-      "ethz.ch",
-      "ucsb.edu",
-      "fsu.edu",
-      "buffalo.edu",
-      "unsw.edu.au",
-      "ucsf.edu",
+      "berkeley.edu",
+      "helsinki.fi",
       "case.edu",
       "oclc.org"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
     ],
+    "sitelabweb.com": [
+      "lenovo.com",
+      "upwork.com"
+    ],
     "sitelock.com": [
-      "joomla.org"
+      "joomla.org",
+      "netfirms.com"
     ],
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "accuweather.com",
       "seattletimes.com",
-      "travelandleisure.com"
+      "accuweather.com",
+      "newatlas.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
-      "digital.com",
-      "atlasobscura.com"
+      "arstechnica.com",
+      "coindesk.com"
     ],
     "sky.com": [
-      "skygroup.sky"
+      "skygroup.sky",
+      "skysports.com"
     ],
     "slashdotmedia.com": [
       "slashdot.org"
     ],
     "smartadserver.com": [
       "springer.com",
-      "elpais.com",
       "skyrock.com",
-      "home.pl"
+      "sapo.pt"
+    ],
+    "smartclip.net": [
+      "infoplease.com"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
+    ],
+    "smi2.net": [
+      "rbc.ru"
     ],
     "smi2.ru": [
       "rbc.ru"
     ],
     "smithsonian.museum": [
+      "si.edu",
       "smithsonianmag.com"
     ],
+    "smyte.com": [
+      "indiegogo.com",
+      "zendesk.com"
+    ],
     "snapchat.com": [
+      "jimdo.com",
+      "overstock.com",
+      "complex.com",
+      "wsj.com",
       "giphy.com",
-      "walmart.com",
-      "wpengine.com",
-      "motorola.com",
-      "syfy.com"
+      "zappos.com"
+    ],
+    "snapwidget.com": [
+      "udel.edu"
+    ],
+    "snplow.net": [
+      "wetransfer.com"
     ],
     "so.com": [
       "360.cn"
     ],
     "socdm.com": [
-      "goo.ne.jp",
-      "hatena.ne.jp",
-      "ocn.ne.jp"
+      "rakuten.co.jp",
+      "biglobe.ne.jp",
+      "goo.ne.jp"
     ],
     "sociomantic.com": [
       "springer.com",
@@ -7055,34 +7069,68 @@
     "soflopxl.com": [
       "howstuffworks.com"
     ],
+    "softonic-analytics.net": [
+      "softonic.com"
+    ],
+    "sogou.com": [
+      "soso.com"
+    ],
+    "sohu.com": [
+      "ifeng.com",
+      "ctrip.com",
+      "focus.cn"
+    ],
     "sojern.com": [
+      "ihg.com",
+      "hyatt.com",
       "gopro.com"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
+    "soliditet.se": [
+      "jalbum.net"
+    ],
+    "solocpm.com": [
+      "edx.org"
+    ],
     "sonobi.com": [
-      "usatoday.com",
-      "springer.com",
+      "photobucket.com",
       "deviantart.com",
-      "space.com",
-      "goal.com"
+      "springer.com",
+      "forbes.com",
+      "theverge.com",
+      "jsonline.com",
+      "couchsurfing.com"
+    ],
+    "sonyentertainmentnetwork.com": [
+      "playstation.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "tmz.com",
-      "irishtimes.com",
       "mo.gov"
+    ],
+    "sourceforge.net": [
+      "libpng.org"
+    ],
+    "sp.global.ssl.fastly.net": [
+      "theglobeandmail.com"
+    ],
+    "spectate.com": [
+      "emory.edu"
     ],
     "sphereup.com": [
       "jpost.com"
     ],
     "spiceworks.com": [
-      "hp.com",
-      "salesforce.com",
-      "slack.com"
+      "cloudflare.com",
+      "symantec.com",
+      "sophos.com"
+    ],
+    "spineuniverse.com": [
+      "psychcentral.com"
     ],
     "spingo.com": [
       "detroitnews.com"
@@ -7094,14 +7142,17 @@
       "engadget.com",
       "denverpost.com"
     ],
+    "spotify.com": [
+      "oregonstate.edu"
+    ],
     "spots.im": [
       "denverpost.com"
     ],
     "spotxchange.com": [
+      "amazon.com",
       "dropbox.com",
-      "npr.org",
-      "express.co.uk",
-      "jpost.com",
+      "dailymotion.com",
+      "thenextweb.com",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -7110,11 +7161,14 @@
     ],
     "springernature.com": [
       "nature.com",
-      "springer.com",
-      "biomedcentral.com"
+      "biomedcentral.com",
+      "springer.com"
     ],
     "springserve.com": [
-      "tinypic.com"
+      "tinypic.com",
+      "liveuamap.com",
+      "magento.com",
+      "dailydot.com"
     ],
     "sprinklr.com": [
       "autodesk.com"
@@ -7123,40 +7177,72 @@
       "straitstimes.com"
     ],
     "stackadapt.com": [
-      "shopify.com",
-      "farfetch.com"
+      "thehill.com",
+      "farfetch.com",
+      "threadless.com"
+    ],
+    "staples-sparx.com": [
+      "staples.com"
+    ],
+    "staples-static.com": [
+      "staples.com"
+    ],
+    "starfieldtech.com": [
+      "scamnumbers.info"
     ],
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "freepik.com",
+      "man7.org",
+      "cbslocal.com",
       "zerohedge.com"
+    ],
+    "staticimgfarm.com": [
+      "excite.com"
+    ],
+    "staybridge.com": [
+      "ihg.com"
     ],
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "gettyimages.com",
-      "newegg.com",
+      "istockphoto.com",
       "careerbuilder.com"
+    ],
+    "steepto.com": [
+      "liveleak.com"
     ],
     "stg-sp.global.ssl.fastly.net": [
       "theglobeandmail.com"
     ],
+    "stg8.com": [
+      "sina.com.cn"
+    ],
     "stickyadstv.com": [
-      "pastebin.com",
-      "thinkgeek.com"
+      "bloomberg.com",
+      "dailymotion.com",
+      "feedburner.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
     ],
     "storygize.net": [
       "autodesk.com",
-      "squareup.com"
+      "squareup.com",
+      "dn.ua"
+    ],
+    "streem.com.au": [
+      "smh.com.au",
+      "theage.com.au"
+    ],
+    "streetscout.com": [
+      "azcentral.com"
     ],
     "stripe.com": [
-      "smashballoon.com",
+      "iconfinder.com",
       "presscustomizr.com",
       "themezee.com",
+      "feedly.com",
       "documentcloud.org"
     ],
     "sumo.com": [
@@ -7166,49 +7252,60 @@
       "makezine.com"
     ],
     "sundaysky.com": [
-      "fiverr.com",
-      "jpost.com",
+      "overstock.com",
+      "alternet.org",
+      "infoplease.com",
       "dailydot.com"
-    ],
-    "suning.cn": [
-      "suning.com"
     ],
     "suning.com": [
       "qq.com",
+      "ifeng.com",
       "sohu.com"
     ],
+    "sunrtb.com": [
+      "yesky.com"
+    ],
     "supplyframe.com": [
-      "arduino.cc",
       "ti.com"
     ],
     "survata.com": [
       "tripadvisor.com"
     ],
-    "surveygizmo.com": [
-      "berkeley.edu"
-    ],
     "surveymonkey.com": [
-      "techcrunch.com",
       "cambridge.org",
-      "iop.org",
+      "investopedia.com",
       "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
-      "thehindu.com"
+      "metacafe.com",
+      "indianexpress.com",
+      "springer.com"
     ],
     "symantec.com": [
-      "norton.com"
+      "norton.com",
+      "opinionlab.com"
+    ],
+    "synacor.com": [
+      "att.net"
     ],
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
+      "t-online.de",
       "msn.com",
-      "fool.com",
-      "nbcsports.com"
+      "zdnet.com",
+      "jsonline.com",
+      "edmunds.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
+    ],
+    "tag4arm.com": [
+      "norton.com"
+    ],
+    "tagdelivery.com": [
+      "overstock.com"
     ],
     "tailtarget.com": [
       "uol.com.br"
@@ -7218,57 +7315,84 @@
       "hotels.com"
     ],
     "tanx.com": [
-      "sohu.com",
-      "ifeng.com",
-      "tmall.com",
-      "2345.com"
+      "sina.com.cn",
+      "alibaba.com",
+      "ifeng.com"
     ],
     "taobao.com": [
       "sina.com.cn",
-      "alibaba.com",
+      "1688.com",
       "tmall.com",
-      "1688.com"
+      "51.la"
     ],
     "tapad.com": [
       "adobe.com",
+      "yahoo.com",
       "soundcloud.com",
       "dropbox.com",
-      "rottentomatoes.com"
+      "newyorker.com"
+    ],
+    "targetimg1.com": [
+      "target.com"
     ],
     "tawk.to": [
-      "cba.pl",
-      "affordable-papers.net"
+      "cba.pl"
     ],
-    "taylorandfrancis.com": [
-      "tandfonline.com"
+    "tcell.io": [
+      "sophos.com"
     ],
     "teads.tv": [
-      "walgreens.com"
+      "alternet.org"
     ],
     "tealiumiq.com": [
       "ibm.com",
+      "cbsnews.com",
+      "evernote.com",
       "cnet.com",
-      "samsung.com",
-      "welt.de",
+      "politico.com",
       "usmagazine.com"
+    ],
+    "technolutions.net": [
+      "illinois.edu",
+      "upenn.edu",
+      "uci.edu",
+      "udel.edu",
+      "case.edu"
+    ],
+    "technoratimedia.com": [
+      "accuweather.com"
     ],
     "techweb.com": [
       "informationweek.com"
     ],
     "teenvogue.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
+    ],
+    "telegraph.co.uk": [
+      "wordpress.com"
+    ],
+    "telekom.de": [
+      "t-online.de"
+    ],
+    "tenmax.io": [
+      "biglobe.ne.jp"
     ],
     "theadex.com": [
       "t-online.de",
-      "spiegel.de",
-      "sueddeutsche.de"
+      "gnu.org",
+      "spiegel.de"
+    ],
+    "theatlas.com": [
+      "qz.com"
     ],
     "thebrighttag.com": [
+      "netflix.com",
+      "wufoo.com",
       "playstation.com",
-      "mercurynews.com",
-      "ubisoft.com"
+      "zappos.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -7276,37 +7400,49 @@
     "theguardian.com": [
       "videojs.com"
     ],
-    "thrtle.com": [
-      "sourceforge.net"
+    "thesaurus.com": [
+      "dictionary.com"
     ],
-    "tianqijun.com": [
-      "qianlong.com"
+    "thomsonreuters.com": [
+      "reuters.com"
+    ],
+    "thrtle.com": [
+      "xda-developers.com"
+    ],
+    "tidaltv.com": [
+      "dailymotion.com",
+      "nationalgeographic.com",
+      "xfinity.com"
     ],
     "tidelinedata.io": [
       "deviantart.com"
     ],
     "timecommerce.net": [
-      "time.com",
       "fortune.com",
       "people.com",
       "ew.com",
-      "travelandleisure.com"
+      "time.com",
+      "marthastewart.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
     ],
     "tinypass.com": [
-      "bloomberg.com",
       "businessinsider.com",
       "techcrunch.com",
-      "adage.com",
-      "gizmodo.com"
+      "kickstarter.com",
+      "bloomberg.com",
+      "gizmodo.com",
+      "vancouversun.com"
     ],
     "tiqcdn.com": [
-      "wsj.com",
       "cisco.com",
+      "nbcnews.com",
+      "ibm.com",
+      "wsj.com",
       "marketwatch.com",
-      "here.com"
+      "hpe.com",
+      "orange.fr"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -7315,24 +7451,46 @@
     "tm-awx.com": [
       "mirror.co.uk"
     ],
+    "tmall.com": [
+      "taobao.com"
+    ],
     "tns-counter.ru": [
-      "vk.com",
       "livejournal.com",
+      "vk.com",
       "yandex.ru",
+      "mail.ru",
       "ok.ru",
       "radikal.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
     ],
+    "tracc.it": [
+      "france24.com",
+      "rfi.fr"
+    ],
+    "trackad.cz": [
+      "idnes.cz"
+    ],
     "trackalyzer.com": [
       "squareup.com"
     ],
+    "tradedoubler.com": [
+      "lemonde.fr",
+      "interia.pl"
+    ],
     "tradelab.fr": [
-      "eklablog.com"
+      "eklablog.com",
+      "leparisien.fr"
     ],
     "traffic-media.co": [
       "radikal.ru"
+    ],
+    "trafficgate.net": [
+      "rakuten.co.jp"
+    ],
+    "trafficjam.cn": [
+      "youku.com"
     ],
     "trafficjunky.net": [
       "pornhub.com"
@@ -7343,27 +7501,28 @@
     "trb.com": [
       "latimes.com",
       "chicagotribune.com",
-      "baltimoresun.com"
+      "nydailynews.com"
     ],
     "treasuredata.com": [
-      "exblog.jp",
-      "hatena.ne.jp",
-      "asahi.com"
+      "biglobe.ne.jp",
+      "nintendo.com",
+      "exblog.jp"
     ],
     "tremorhub.com": [
       "usatoday.com",
-      "freep.com",
-      "detroitnews.com"
+      "azcentral.com",
+      "freep.com"
     ],
     "tribalfusion.com": [
+      "dailymotion.com",
       "pastebin.com",
       "liveleak.com",
-      "xe.com",
-      "colourlovers.com"
+      "marriott.com"
     ],
     "tribl.io": [
-      "prnewswire.com",
-      "zimbra.com"
+      "prezi.com",
+      "zimbra.com",
+      "prnewswire.com"
     ],
     "tripadvisor.com": [
       "accorhotels.com"
@@ -7371,70 +7530,107 @@
     "tronc.com": [
       "latimes.com",
       "chicagotribune.com",
-      "baltimoresun.com"
+      "nydailynews.com"
     ],
     "trumba.com": [
-      "ucdavis.edu"
+      "ucdavis.edu",
+      "utah.edu",
+      "emory.edu"
+    ],
+    "truoptik.com": [
+      "slashdot.org",
+      "infoplease.com"
     ],
     "trustarc.com": [
       "skynet.be"
     ],
+    "trustev.com": [
+      "lenovo.com"
+    ],
     "trustpilot.com": [
       "jalbum.net",
+      "avira.com",
       "moonfruit.com"
     ],
     "trvl-px.com": [
-      "hotels.com"
+      "hotels.com",
+      "expedia.com"
+    ],
+    "tumblr.com": [
+      "dailydot.com"
     ],
     "turn.com": [
-      "hp.com",
+      "bloomberg.com",
       "wired.com",
+      "webmd.com",
       "economist.com",
-      "miamiherald.com",
+      "booking.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
     ],
     "tvsquared.com": [
-      "wsj.com",
+      "telegraph.co.uk",
       "jimdo.com",
       "squarespace.com",
-      "aarp.org"
+      "economist.com",
+      "booking.com"
+    ],
+    "twimg.com": [
+      "coe.int",
+      "ey.com",
+      "dol.gov"
     ],
     "twitter.com": [
-      "amazon.com",
       "wordpress.org",
+      "yahoo.com",
+      "chicagotribune.com",
       "nytimes.com",
       "cnn.com",
       "msn.com",
-      "perl.com",
-      "syfy.com"
+      "ca.gov",
+      "parallels.com",
+      "sfgate.com",
+      "marthastewart.com",
+      "helsinki.fi",
+      "edmunds.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "digital.com",
+      "washingtontimes.com",
       "dailycaller.com"
     ],
-    "uc.se": [
-      "jalbum.net"
+    "ubi.com": [
+      "ubisoft.com"
     ],
     "uciservice.com": [
-      "hotels.com"
+      "hotels.com",
+      "expedia.com"
     ],
     "ucoz.net": [
       "narod.ru"
     ],
     "udmserve.net": [
+      "colourlovers.com",
+      "dailydot.com",
       "washingtonexaminer.com"
+    ],
+    "udnfunlife.com": [
+      "udn.com"
+    ],
+    "uefa.com": [
+      "bleacherreport.com"
+    ],
+    "ufpcdn.com": [
+      "brothersoft.com"
     ],
     "ugdturner.com": [
       "cnn.com",
       "nba.com"
     ],
     "undertone.com": [
-      "hpe.com",
       "dallasnews.com",
       "alternet.org"
     ],
@@ -7446,21 +7642,29 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "businessweek.com",
+      "earthlink.net",
       "boingboing.net"
     ],
     "upravel.com": [
-      "rambler.ru"
+      "rambler.ru",
+      "tomsk.ru"
     ],
     "upsellit.com": [
       "samsung.com",
+      "garmin.com",
       "motorola.com"
+    ],
+    "uptolike.com": [
+      "live4fun.ru"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
     ],
     "usa.gov": [
-      "transportation.gov"
+      "transportation.gov",
+      "dhs.gov",
+      "usembassy.gov",
+      "osha.gov"
     ],
     "useproof.com": [
       "iconosquare.com"
@@ -7468,8 +7672,8 @@
     "usergram.info": [
       "ocn.ne.jp"
     ],
-    "uservoice.com": [
-      "scoop.it"
+    "userreport.com": [
+      "scotsman.com"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -7478,88 +7682,120 @@
       "radikal.ru"
     ],
     "utarget.ru": [
-      "radikal.ru"
+      "radikal.ru",
+      "diary.ru"
     ],
     "uuidksinc.net": [
-      "radikal.ru"
+      "radikal.ru",
+      "diary.ru"
     ],
-    "v-biz.com.ua": [
-      "novostimira.com"
+    "v12group.com": [
+      "tinyurl.com",
+      "shopko.com"
     ],
     "vanityfair.com": [
       "wired.com",
+      "newyorker.com",
       "vogue.com",
       "pitchfork.com"
     ],
     "veinteractive.com": [
       "prweb.com",
+      "logitech.com",
       "wnd.com"
     ],
     "velaro.com": [
-      "lg.com"
+      "lg.com",
+      "eff.org"
+    ],
+    "velemh.com": [
+      "liveuamap.com"
+    ],
+    "verticalhealth.net": [
+      "psychcentral.com"
+    ],
+    "veruta.com": [
+      "shopko.com"
     ],
     "viafoura.co": [
       "cbc.ca",
-      "nj.com",
-      "irishtimes.com"
-    ],
-    "viafoura.com": [
-      "irishtimes.com"
+      "columbia.edu",
+      "nj.com"
     ],
     "viafoura.net": [
       "cbc.ca"
     ],
     "videoamp.com": [
-      "alternet.org"
+      "hpe.com"
+    ],
+    "videohub.tv": [
+      "liveuamap.com",
+      "wsj.com",
+      "uci.edu"
     ],
     "vidible.tv": [
       "aol.com",
-      "autoblog.com"
+      "nydailynews.com",
+      "autoblog.com",
+      "huffingtonpost.com"
     ],
     "viglink.com": [
+      "zdnet.com",
+      "softonic.com",
+      "techrepublic.com",
       "cnet.com",
       "thedailybeast.com",
-      "softonic.com",
-      "dailycaller.com"
+      "xda-developers.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
       "olympic.org",
-      "today.com",
-      "cbs.com"
+      "tmz.com"
     ],
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "wufoo.com"
+      "livestream.com",
+      "wufoo.com",
+      "heroku.com",
+      "emarketer.com",
+      "oclc.org"
     ],
     "vindicosuite.com": [
       "myspace.com",
-      "time.com",
       "fortune.com",
-      "ew.com",
-      "travelandleisure.com"
+      "people.com",
+      "time.com",
+      "marthastewart.com",
+      "zappos.com"
     ],
     "virgilio.it": [
       "libero.it"
     ],
-    "visitor-track.com": [
-      "redcross.org"
+    "visualstudio.com": [
+      "microsoft.com"
+    ],
+    "vizury.com": [
+      "dreamstime.com"
     ],
     "vk.com": [
-      "yandex.ru",
       "rt.com",
-      "ria.ru"
+      "templatemonster.com",
+      "ria.ru",
+      "yandex.ru"
     ],
     "vmmpxl.com": [
       "networksolutions.com"
     ],
     "vogue.com": [
       "wired.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "volvelle.tech": [
-      "colourlovers.com"
+      "prweb.com",
+      "logitech.com"
     ],
     "voxmedia.com": [
       "theverge.com",
@@ -7568,22 +7804,31 @@
       "sbnation.com",
       "polygon.com"
     ],
+    "vtracy.de": [
+      "bloomberg.com"
+    ],
     "w55c.net": [
-      "hp.com",
-      "businessinsider.com",
+      "hpe.com",
+      "ebay.com",
+      "sourceforge.net",
       "pbs.org"
     ],
     "wallst.com": [
       "reuters.com"
     ],
+    "waptime.cn": [
+      "tianqi.com"
+    ],
+    "warnerbros.com": [
+      "tmz.com"
+    ],
     "wbtrk.net": [
+      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
     "wcfbc.net": [
-      "repubblica.it",
-      "bild.de",
-      "goethe.de"
+      "bild.de"
     ],
     "weather.com": [
       "wunderground.com"
@@ -7594,8 +7839,9 @@
     ],
     "weborama.fr": [
       "lemonde.fr",
-      "lefigaro.fr",
-      "rbc.ru"
+      "rbc.ru",
+      "lexpress.fr",
+      "leparisien.fr"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -7608,18 +7854,18 @@
       "freewebs.com"
     ],
     "webspectator.com": [
-      "goal.com"
+      "goal.com",
+      "guinnessworldrecords.com"
     ],
     "webtrekk.net": [
       "springer.com",
-      "repubblica.it",
-      "goethe.de"
+      "localiser-ip.com",
+      "welt.de"
     ],
     "webtrendslive.com": [
+      "nature.com",
       "abc.net.au",
       "oup.com",
-      "ethz.ch",
-      "www.nhs.uk",
       "dhl.com"
     ],
     "weibo.com": [
@@ -7637,24 +7883,34 @@
     "wikimedia.org": [
       "wikipedia.org",
       "wiktionary.org",
-      "wikisource.org",
       "mediawiki.org",
+      "wikisource.org",
       "wikibooks.org"
     ],
     "wired.com": [
+      "newyorker.com",
+      "vanityfair.com",
       "vogue.com",
       "pitchfork.com"
+    ],
+    "wise.space": [
+      "purevolume.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
+      "canada.com",
       "globalnews.ca",
       "bostonherald.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
     ],
+    "wishpond.net": [
+      "discovermagazine.com"
+    ],
     "wistia.com": [
+      "zendesk.com",
       "typeform.com",
       "photoshelter.com"
     ],
@@ -7665,15 +7921,19 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "upwork.com"
+      "upwork.com",
+      "zappos.com",
+      "redbubble.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "wnyc.org": [
-      "newyorker.com"
+      "newyorker.com",
+      "qq.com"
     ],
     "wolfram.com": [
       "wolframalpha.com"
@@ -7682,41 +7942,50 @@
       "tinypic.com"
     ],
     "woopic.com": [
-      "orange.fr"
+      "orange.fr",
+      "2345.com"
     ],
     "wordpress.com": [
       "time.com",
-      "fortune.com",
-      "akismet.com",
+      "prnewswire.com",
       "cbslocal.com",
+      "fortune.com",
       "nypost.com",
+      "akismet.com",
       "news.com.au",
-      "variety.com",
       "metro.co.uk",
-      "people.com",
-      "woocommerce.com"
-    ],
-    "workandmoney.com": [
-      "nbcsports.com"
+      "variety.com"
     ],
     "wrating.com": [
+      "163.com",
       "jrj.com.cn",
       "weather.com.cn"
     ],
-    "wsj.net": [
-      "wsj.com",
+    "wsj.com": [
       "marketwatch.com"
     ],
+    "wsj.net": [
+      "marketwatch.com",
+      "sfgate.com",
+      "wsj.com"
+    ],
     "wsod.com": [
-      "yahoo.com",
+      "seekingalpha.com",
       "zerohedge.com"
     ],
     "wt-eu02.net": [
-      "libero.it",
-      "virgilio.it"
+      "virgilio.it",
+      "libero.it"
     ],
-    "xe19io.com": [
-      "nme.com"
+    "wurfl.io": [
+      "dw.com",
+      "bartleby.com"
+    ],
+    "wywyuserservice.com": [
+      "vmware.com"
+    ],
+    "xad.com": [
+      "vt.edu"
     ],
     "xg4ken.com": [
       "bluehost.com",
@@ -7727,27 +7996,30 @@
     ],
     "xiti.com": [
       "lemonde.fr",
+      "unblog.fr",
+      "uefa.com",
       "skyrock.com",
-      "faz.net",
       "leparisien.fr"
     ],
     "xlisting.jp": [
-      "goo.ne.jp",
-      "ocn.ne.jp"
+      "rakuten.co.jp",
+      "biglobe.ne.jp",
+      "goo.ne.jp"
     ],
     "xplosion.de": [
+      "t-online.de",
       "spiegel.de",
-      "sueddeutsche.de",
-      "zeit.de"
+      "faz.net"
     ],
     "xs4all.net": [
       "xs4all.nl"
     ],
-    "xtgreat.com": [
-      "qq.com"
+    "xxxlutz.de": [
+      "t-online.de"
     ],
     "yadro.ru": [
       "vk.com",
+      "novostimira.com",
       "mail.ru",
       "rt.com",
       "ok.ru",
@@ -7755,72 +8027,106 @@
     ],
     "yahoo.co.jp": [
       "dropbox.com",
-      "economist.com",
       "exblog.jp",
-      "ocn.ne.jp"
+      "rakuten.co.jp",
+      "economist.com",
+      "biglobe.ne.jp"
     ],
     "yahoo.com": [
+      "amazon.com",
       "vimeo.com",
-      "tumblr.com",
       "flickr.com",
-      "fool.com",
-      "eset.com"
+      "sourceforge.net",
+      "theverge.com",
+      "xda-developers.com"
+    ],
+    "yahoosmallbusiness.com": [
+      "yahoo.com"
     ],
     "yandex.ru": [
-      "opera.com",
       "livejournal.com",
+      "opera.com",
+      "stanford.edu",
       "ning.com",
       "rt.com",
-      "liveinternet.ru",
-      "sputniknews.com",
-      "radikal.ru"
+      "fourseasons.com",
+      "radikal.ru",
+      "yandex.com",
+      "kharkov.ua",
+      "rambler.ru"
+    ],
+    "yandex.ua": [
+      "kharkov.ua",
+      "kh.ua"
     ],
     "yastatic.net": [
-      "sputniknews.com",
-      "ria.ru",
-      "yandex.ru"
+      "qip.ru",
+      "tass.ru",
+      "radikal.ru",
+      "yandex.com"
+    ],
+    "yieldify.com": [
+      "logitech.com"
     ],
     "yieldlab.net": [
-      "t-online.de",
-      "springer.com",
       "spiegel.de",
-      "heise.de"
+      "heise.de",
+      "faz.net",
+      "statista.com"
     ],
     "yieldoptimizer.com": [
-      "groupon.com"
+      "ihg.com",
+      "hyatt.com",
+      "philly.com"
     ],
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
-      "qualtrics.com"
+      "dropbox.com",
+      "aol.com",
+      "qualtrics.com",
+      "eset.com"
     ],
     "yldbt.com": [
-      "usatoday.com",
-      "pcworld.com",
-      "computerworld.com",
-      "biography.com"
+      "wired.com",
+      "arstechnica.com",
+      "newyorker.com",
+      "pcworld.com"
+    ],
+    "ymetrica1.com": [
+      "kharkov.ua",
+      "kh.ua",
+      "ucoz.ru"
+    ],
+    "yoox.it": [
+      "net-a-porter.com"
     ],
     "yotpo.com": [
       "gopro.com"
     ],
     "youtube-nocookie.com": [
+      "epa.gov",
       "moodle.org",
       "popsci.com",
       "uscourts.gov"
     ],
     "youtube.com": [
+      "vimeo.com",
       "google.com",
-      "mozilla.org",
+      "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
-      "boutell.com",
-      "uh.edu",
-      "dezeen.com",
-      "honeywell.com"
+      "redhat.com",
+      "skyrock.com",
+      "caltech.edu",
+      "dailykos.com",
+      "honeywell.com",
+      "amazon.com"
     ],
     "youvisit.com": [
       "osu.edu",
+      "oregonstate.edu",
       "fsu.edu"
     ],
     "ypcdn.com": [
@@ -7829,50 +8135,68 @@
     "yudu.co.nz": [
       "nzherald.co.nz"
     ],
-    "zassets.com": [
-      "zappos.com"
-    ],
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
       "ign.com",
-      "speedtest.net",
       "everydayhealth.com"
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com"
+      "thehindu.com",
+      "infoplease.com"
     ],
     "zemanta.com": [
-      "paypal.com",
-      "usatoday.com",
-      "mirror.co.uk",
+      "independent.co.uk",
+      "thehill.com",
       "farfetch.com",
-      "colourlovers.com"
+      "paypal.com",
+      "lemonde.fr",
+      "infoplease.com"
+    ],
+    "zendesk.com": [
+      "jugem.jp",
+      "in.gov",
+      "hobbyking.com"
     ],
     "zergnet.com": [
       "imdb.com",
-      "marketwatch.com",
-      "weather.com",
-      "tmz.com"
+      "pcmag.com",
+      "rollingstone.com",
+      "marketwatch.com"
+    ],
+    "zhaopin.cn": [
+      "zhaopin.com"
+    ],
+    "zhiziyun.com": [
+      "ctrip.com"
     ],
     "zidtech.com": [
       "coindesk.com"
     ],
     "ziffdavis.com": [
+      "ign.com",
       "extremetech.com"
     ],
+    "zoho.com": [
+      "zoho.in"
+    ],
+    "zohopublic.com": [
+      "zoho.com"
+    ],
     "zoomph.com": [
+      "udel.edu",
+      "biglobe.ne.jp",
       "uga.edu"
+    ],
+    "zopim.com": [
+      "lulu.com"
     ],
     "zprk.io": [
       "news.com.au",
       "theaustralian.com.au",
       "heraldsun.com.au"
-    ],
-    "zynbit.com": [
-      "parallels.com"
     ]
   },
-  "version": "2018.9.19"
+  "version": "2018.8.22"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,7 +3,13 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535574366154,
+      "nextUpdateTime": 1538180650544,
+      "userAction": ""
+    },
+    "112-tzm-766.mktoresp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538394933849,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -18,49 +24,79 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "126.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "194-vvc-221.mktoresp.com": {
+    "15gifts.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535940577860,
-      "userAction": ""
-    },
-    "1dmp.io": {
-      "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "20798148p.rfihub.com": {
+    "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535651482302,
+      "nextUpdateTime": 1538483514256,
+      "userAction": ""
+    },
+    "247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "254a.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535556135314,
+      "nextUpdateTime": 1538368660302,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695702688,
-      "userAction": ""
-    },
-    "2ecd5.v.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535927532754,
+      "nextUpdateTime": 1538256664930,
       "userAction": ""
     },
     "2o7.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "33across.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360yield.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "3gl.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -72,160 +108,220 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "4139589.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538385347766,
+      "userAction": ""
+    },
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535895120778,
+      "nextUpdateTime": 1538095276395,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535610484977,
-      "userAction": ""
-    },
-    "4303900.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535857837364,
-      "userAction": ""
-    },
-    "4351288.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535596840473,
+      "nextUpdateTime": 1538443166948,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535803262487,
+      "nextUpdateTime": 1538206007436,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560640124,
+      "nextUpdateTime": 1538083902504,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535564507606,
+      "nextUpdateTime": 1538456849026,
       "userAction": ""
     },
-    "516-dgm-318.mktoresp.com": {
+    "50bang.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535612912168,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535672353106,
+      "nextUpdateTime": 1538323409082,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535922487903,
+      "nextUpdateTime": 1538531334136,
       "userAction": ""
     },
-    "5779616.fls.doubleclick.net": {
+    "58.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "58cdn.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "5p4rk13.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535748710087,
+      "nextUpdateTime": 1538145560460,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535720157703,
+      "nextUpdateTime": 1538338401506,
       "userAction": ""
     },
-    "6954342.fls.doubleclick.net": {
+    "6sc.co": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535922263721,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535558701365,
+      "nextUpdateTime": 1538334719410,
+      "userAction": ""
+    },
+    "8136595.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538150124402,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535705793636,
+      "nextUpdateTime": 1538132491651,
       "userAction": ""
     },
-    "8758559.fls.doubleclick.net": {
+    "8329645.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535729644705,
+      "nextUpdateTime": 1538200870446,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535817179790,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538500225994,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695345166,
+      "nextUpdateTime": 1538059890436,
+      "userAction": ""
+    },
+    "a.quora.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538122796132,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535690460813,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538294298158,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535515726416,
+      "nextUpdateTime": 1538194589363,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535681555823,
+      "nextUpdateTime": 1538427938823,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535644294827,
+      "nextUpdateTime": 1538404954879,
+      "userAction": ""
+    },
+    "a6264210458.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538338901088,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535738145329,
+      "nextUpdateTime": 1538508807697,
+      "userAction": ""
+    },
+    "a8298190319.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538384086156,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535467395021,
+      "nextUpdateTime": 1538142584062,
+      "userAction": ""
+    },
+    "aamsitecertifier.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598814522,
+      "nextUpdateTime": 1538049200350,
       "userAction": ""
     },
-    "aax.amazon-adsystem.com": {
+    "aaxads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535901789257,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "abmr.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "acast.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "accessatlanta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -234,16 +330,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.us1.gigya.com": {
+    "accounts.pinterest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535736262835,
+      "nextUpdateTime": 1538249417948,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535895412521,
+      "nextUpdateTime": 1538062628696,
       "userAction": ""
     },
     "acpm.fr": {
@@ -252,51 +348,105 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "action.media6degrees.com": {
+    "acquia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535510347212,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535451360532,
+      "nextUpdateTime": 1538535925079,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535546516924,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538355264350,
       "userAction": ""
     },
-    "ad-score.com": {
+    "acuityplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "acxiomapac.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-stir.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-survey.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad.adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538277008771,
+      "userAction": ""
+    },
     "ad.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535755342766,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538242542788,
       "userAction": ""
     },
-    "ad.mail.ru": {
+    "ad.wsod.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535793253863,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538425057023,
       "userAction": ""
     },
-    "ad.yieldlab.net": {
+    "adapf.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535951806065,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adc-srv.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adclear.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adentifi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -306,9 +456,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adhigh.net": {
+    "adfox.ru": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adingo.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adition.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adjust-net.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -318,15 +492,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adlmerge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535497530432,
-      "userAction": ""
-    },
     "adm.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "admiral.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538420953790,
+      "userAction": ""
+    },
+    "admission.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -336,10 +516,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ado.pro-market.net": {
+    "adobe.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535748637442,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adotmob.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adroll.com": {
@@ -348,46 +546,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adrta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ads.investingchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538447339353,
+      "userAction": ""
+    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535458586592,
+      "nextUpdateTime": 1538496601089,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535871108745,
+      "nextUpdateTime": 1538445794602,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535471847357,
-      "userAction": ""
-    },
-    "ads.twitter.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535837937648,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538373205501,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535522038868,
+      "nextUpdateTime": 1538418132951,
+      "userAction": ""
+    },
+    "adsafety.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adscale.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535535646707,
+      "nextUpdateTime": 1538488159302,
+      "userAction": ""
+    },
+    "adserver.intentiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538557381542,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535549205489,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538153556785,
       "userAction": ""
     },
     "adsnative.com": {
@@ -396,13 +618,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsniper.ru": {
+    "adsrvr.org": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsrvr.org": {
+    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -414,7 +636,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtags.pro": {
+    "adtng.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -428,8 +650,26 @@
     },
     "adx.com.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535858535725,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adzerk.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aetnd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "afkp.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "agkn.com": {
@@ -438,16 +678,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aidata.io": {
+    "akamaihd.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "akamaized.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "albacross.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alibaba.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aimfar.solution.weborama.fr": {
+    "alicdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535679293961,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alipay.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aliyun.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "allure.com": {
@@ -462,40 +732,124 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazon.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "amazon.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "amazoncustomerservice.d2.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazonwebservices.d2.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538516307010,
+      "userAction": ""
+    },
+    "amazonwebservicesinc.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538414598582,
+      "userAction": ""
+    },
+    "ameba.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535852651670,
+      "nextUpdateTime": 1538212864175,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535756031250,
+      "nextUpdateTime": 1538500466583,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535739670165,
+      "nextUpdateTime": 1538293517643,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535489431737,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538328395538,
       "userAction": ""
     },
-    "analytics.twitter.com": {
+    "ancestry.ca": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535497570934,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.mx": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.se": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "and.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "answcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -504,64 +858,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "aol.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ap.lijit.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535545407977,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538225149247,
+      "userAction": ""
+    },
+    "apester.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535734725089,
-      "userAction": ""
-    },
-    "api-iam.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535646885704,
-      "userAction": ""
-    },
-    "api-v3.tinypass.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535496392864,
+      "nextUpdateTime": 1538364760079,
       "userAction": ""
     },
     "api.adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535610556073,
+      "nextUpdateTime": 1538168277917,
       "userAction": ""
     },
-    "api.bounceexchange.com": {
+    "api.adsymptotic.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538545671107,
+      "userAction": ""
+    },
+    "api.circularhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535667795032,
+      "nextUpdateTime": 1538545915720,
+      "userAction": ""
+    },
+    "api.company-target.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538204919804,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535799853232,
-      "userAction": ""
-    },
-    "api.nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535573272097,
+      "nextUpdateTime": 1538343500501,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535526188562,
+      "nextUpdateTime": 1538328923918,
       "userAction": ""
     },
-    "api.viglink.com": {
+    "api.sabavision.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535837253495,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538058807775,
       "userAction": ""
     },
     "apis.google.com": {
@@ -570,10 +930,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "apn.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535705741301,
+      "nextUpdateTime": 1538267380235,
+      "userAction": ""
+    },
+    "app.vssps.visualstudio.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538349547779,
+      "userAction": ""
+    },
+    "apple.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aps.hearstnp.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538071048301,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -582,10 +966,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "arcpublishing.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "art19.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535778737155,
+      "nextUpdateTime": 1538321865785,
+      "userAction": ""
+    },
+    "as.casalemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538094506065,
+      "userAction": ""
+    },
+    "assets-gulfnews.sportz.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538268936081,
+      "userAction": ""
+    },
+    "assets.adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538518662620,
+      "userAction": ""
+    },
+    "assets.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538397145272,
+      "userAction": ""
+    },
+    "atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atemda.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ati-host.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atlasobscura-travel.t.domdex.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538333342983,
+      "userAction": ""
+    },
+    "att.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -594,52 +1044,106 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.audience.newscgp.com": {
+    "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535493275684,
+      "nextUpdateTime": 1538525497075,
       "userAction": ""
     },
-    "au.pixel.newscgp.com": {
+    "audtd.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535533997563,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "auth.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "autopilothq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535486459205,
+      "nextUpdateTime": 1538297140111,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535826163427,
+      "nextUpdateTime": 1538294619765,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538132077041,
+      "userAction": ""
+    },
+    "baidu.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535850919219,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bam-x.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535503086090,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538443530778,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535857829768,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538247008130,
       "userAction": ""
     },
-    "beacon.krxd.net": {
+    "baur.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbbpromos.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbc.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bdimg.share.baidu.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535588620683,
+      "nextUpdateTime": 1538404525556,
+      "userAction": ""
+    },
+    "beemray.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bfmio.com": {
@@ -650,20 +1154,38 @@
     },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535918584905,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538421717180,
+      "userAction": ""
+    },
+    "bid.contextweb.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538470282368,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535462855319,
+      "nextUpdateTime": 1538243655658,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535847717423,
+      "nextUpdateTime": 1538449269932,
+      "userAction": ""
+    },
+    "biddingx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bidr.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -681,6 +1203,60 @@
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizrate.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "block.lp1block.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538176389447,
+      "userAction": ""
+    },
+    "bluecava.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluemix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluetoad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bnidx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bobo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -702,16 +1278,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "boston.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bostonglobemedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boxinc.sc.omtrdc.net": {
+    "brandcdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535788486927,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "brides.com": {
@@ -720,76 +1308,112 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bs.serving-sys.com": {
+    "brightcove.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535882683488,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "btlr.sharethrough.com": {
+    "brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535742566208,
+      "nextUpdateTime": 1538238980390,
+      "userAction": ""
+    },
+    "bshare.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bshare.optimix.asia": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538143370691,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535714537026,
+      "nextUpdateTime": 1538135297080,
+      "userAction": ""
+    },
+    "btttag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c-ctrip.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535499348118,
+      "nextUpdateTime": 1538456439921,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535593788843,
-      "userAction": ""
-    },
-    "c.datpix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535929878835,
+      "nextUpdateTime": 1538109343951,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535843909307,
+      "nextUpdateTime": 1538317787251,
       "userAction": ""
     },
-    "c.liadm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535745741276,
-      "userAction": ""
-    },
-    "c.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535633412069,
-      "userAction": ""
-    },
-    "c1.adform.net": {
+    "c.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535883830729,
+      "nextUpdateTime": 1538549605036,
+      "userAction": ""
+    },
+    "c.pub.network": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538231054008,
+      "userAction": ""
+    },
+    "c1.neweggimages.com": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538193299183,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694406005,
+      "nextUpdateTime": 1538552135048,
       "userAction": ""
     },
-    "cache.vindicosuite.com": {
+    "c212.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535646678212,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c3tag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cadreon.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -798,22 +1422,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "canwestglobal.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535936828607,
-      "userAction": ""
-    },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585773243,
+      "nextUpdateTime": 1538149772927,
+      "userAction": ""
+    },
+    "carambo.la": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -822,76 +1440,136 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cbsi.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cbsistatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ccgateway.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478492051,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538505275561,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535678194329,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538183210921,
+      "userAction": ""
+    },
+    "cdn.blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538409772024,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535878784206,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538464924771,
       "userAction": ""
     },
-    "cdn.inquisitr.com": {
+    "cdn.districtm.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535620914588,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538502123391,
       "userAction": ""
     },
-    "cdn.justuno.com": {
+    "cdn.dynamicyield.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535489425202,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538054972489,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535640903944,
+      "nextUpdateTime": 1538056897091,
       "userAction": ""
     },
     "cdn.native.ai": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1529084908284,
+      "nextUpdateTime": 1538112716764,
       "userAction": ""
     },
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535916357377,
+      "nextUpdateTime": 1538491657369,
+      "userAction": ""
+    },
+    "cdn.selectablemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538325259903,
+      "userAction": ""
+    },
+    "cdn.siftscience.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538255124011,
+      "userAction": ""
+    },
+    "cdn.static.zdbb.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538423691203,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535647079432,
+      "nextUpdateTime": 1538052152256,
       "userAction": ""
     },
-    "cdn.tt.omtrdc.net": {
+    "cdn.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535754928056,
+      "nextUpdateTime": 1538350048168,
+      "userAction": ""
+    },
+    "cdn.tynt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538121563634,
+      "userAction": ""
+    },
+    "cdn.viglink.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538552819503,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598133851,
+      "nextUpdateTime": 1538331283935,
       "userAction": ""
     },
-    "cdns.gigya.com": {
+    "cdnwidget.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535604636517,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cern.ch": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -903,7 +1581,61 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535912957647,
+      "nextUpdateTime": 1538056961121,
+      "userAction": ""
+    },
+    "chei.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinaso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "choozle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "circularhub.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "civicscience.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ck.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538079083152,
+      "userAction": ""
+    },
+    "ckies.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538290612775,
+      "userAction": ""
+    },
+    "clickability.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clicktripz.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -918,16 +1650,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "clmbtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cloudflare.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535545995328,
+      "nextUpdateTime": 1538084946321,
+      "userAction": ""
+    },
+    "cms.tanx.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538314445492,
+      "userAction": ""
+    },
+    "cnet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535500216943,
+      "nextUpdateTime": 1538212613316,
+      "userAction": ""
+    },
+    "cnn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -936,10 +1698,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cobaltgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cohesionapps.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535914813920,
+      "nextUpdateTime": 1538216572940,
+      "userAction": ""
+    },
+    "collector-963.tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538075212407,
+      "userAction": ""
+    },
+    "collector-pxbecn7fqx.perimeterx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538178626553,
+      "userAction": ""
+    },
+    "collegenet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "commander1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "company-target.com": {
@@ -948,13 +1746,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "condenast.demdex.net": {
+    "condenastdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535961983554,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "condenastdigital.com": {
+    "config.lrcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538224661599,
+      "userAction": ""
+    },
+    "connatix.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -963,7 +1767,13 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535610657582,
+      "nextUpdateTime": 1538044706175,
+      "userAction": ""
+    },
+    "connexity.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "consensu.org": {
@@ -972,22 +1782,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "consent-pref.trustarc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538382256612,
+      "userAction": ""
+    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumer.krxd.net": {
+    "content.ad": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535644691945,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535769653005,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538123517033,
       "userAction": ""
     },
     "contextweb.com": {
@@ -996,15 +1812,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "convertro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "core.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538077162990,
+      "userAction": ""
+    },
+    "cornell.edu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535484862572,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538315953930,
+      "userAction": ""
+    },
+    "coxmediagroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1014,16 +1860,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "crsspxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cstatic.weborama.fr": {
+    "cssrvsync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ct.pinterest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535817088302,
+      "nextUpdateTime": 1538334484197,
+      "userAction": ""
+    },
+    "cx.atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538107799509,
       "userAction": ""
     },
     "cxense.com": {
@@ -1032,100 +1896,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "d.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535892452597,
-      "userAction": ""
-    },
-    "d.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535636389666,
-      "userAction": ""
-    },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535557003597,
-      "userAction": ""
-    },
-    "d.df-srv.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535942927369,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538510704544,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535683801735,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538196982209,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535759989893,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538294378750,
       "userAction": ""
     },
-    "d3kkw-y716t.ads.tremorhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535711046845,
-      "userAction": ""
-    },
-    "data.ad-score.com": {
+    "d1af033869koo7.cloudfront.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535770730900,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "data.dianomi.com": {
+    "d1rv23qj5kas56.cloudfront.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535762735169,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datacloud-us-east-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535857345882,
-      "userAction": ""
-    },
-    "datacloud.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535789663952,
-      "userAction": ""
-    },
-    "datamind.ru": {
+    "d41.co": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datpix.net": {
+    "da-ads.com": {
       "dnt": false,
       "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dailymail.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "data.dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538215972432,
+      "userAction": ""
+    },
+    "datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dc-storm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535873979413,
+      "nextUpdateTime": 1538143536390,
       "userAction": ""
     },
-    "de.ioam.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535466422250,
-      "userAction": ""
-    },
-    "deepintent.com": {
+    "decajo.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1538503040838,
+      "userAction": ""
+    },
+    "delivery.zidtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538180066266,
       "userAction": ""
     },
     "demdex.net": {
@@ -1146,7 +1998,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "df-srv.de": {
+    "dezeenjobs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "di-dtaectolog-us-prod-1.appspot.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1158,15 +2016,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "digitaladsystems.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "digitaltarget.ru": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1176,16 +2028,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dis.us.criteo.com": {
+    "display.apester.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535670042661,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538272371129,
       "userAction": ""
     },
-    "display.bfmio.com": {
+    "disqus.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535720094693,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "distiltag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "districtm.io": {
@@ -1194,33 +2052,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dm-us.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535589581939,
-      "userAction": ""
-    },
-    "dm.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535689555708,
-      "userAction": ""
-    },
-    "dmg.digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535852281239,
-      "userAction": ""
-    },
     "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535595988233,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538077158657,
+      "userAction": ""
+    },
+    "dmxleo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dol.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "domdex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1230,16 +2088,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dotsub.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "doublepimpssl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535607931755,
+      "nextUpdateTime": 1538127110451,
+      "userAction": ""
+    },
+    "dpmsrv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1248,10 +2124,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dsum-sec.casalemedia.com": {
+    "dt.admission.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538348346597,
+      "userAction": ""
+    },
+    "dt.cobaltgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538296791629,
+      "userAction": ""
+    },
+    "dx.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535938750810,
+      "nextUpdateTime": 1538412044496,
+      "userAction": ""
+    },
+    "dynad.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1260,10 +2154,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eb2.3lift.com": {
+    "dyntrk.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535826511101,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "e-2072.adzerk.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538325723457,
+      "userAction": ""
+    },
+    "ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1272,10 +2178,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ebis.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "echo.intergient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538161191136,
+      "userAction": ""
+    },
+    "eclick.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538421526521,
+      "userAction": ""
+    },
+    "edge-cdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535881020504,
+      "nextUpdateTime": 1538303768684,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1290,34 +2220,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "elsevier.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "elsevierhealth.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "embed.sendtonews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538199320008,
+      "userAction": ""
+    },
+    "emlgrid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "engage.commander1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538534356108,
+      "userAction": ""
+    },
+    "engine.addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538467483460,
+      "userAction": ""
+    },
     "epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eset.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535674741536,
-      "userAction": ""
-    },
-    "eu.track.digitaladsystems.com": {
+    "equalstyle.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535871670836,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eus.rubiconproject.com": {
+    "eset.marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538430898085,
+      "userAction": ""
+    },
+    "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535957567699,
+      "nextUpdateTime": 1538356537340,
+      "userAction": ""
+    },
+    "estat.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535542299351,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538345920195,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1329,7 +2301,37 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535624124109,
+      "nextUpdateTime": 1538552306958,
+      "userAction": ""
+    },
+    "evise.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "evvnt-api.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538336434789,
+      "userAction": ""
+    },
+    "ewscripps.hb.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538506157825,
+      "userAction": ""
+    },
+    "exactag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "excite.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "exelator.com": {
@@ -1340,8 +2342,8 @@
     },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535598114496,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538171166728,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1350,9 +2352,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "eyereturn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ezoic.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1362,22 +2376,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "faggrim.com": {
+    "fastapi.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535612994323,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535463240415,
+      "nextUpdateTime": 1538455076395,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535905176352,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538277861999,
+      "userAction": ""
+    },
+    "fdlstatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "feathr.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1392,22 +2418,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "filepicker.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "firstimpression.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flashtalking.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flickr.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flipboard.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538174863248,
+      "userAction": ""
+    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "foxnet.demdex.net": {
+    "force.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535788047904,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "freestar-d.openx.net": {
+    "foresee.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "forms.hubspot.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535744855557,
+      "nextUpdateTime": 1538138908700,
+      "userAction": ""
+    },
+    "formstack.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fout.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxycart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "freshdesk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1422,64 +2514,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.cn.miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535694446011,
-      "userAction": ""
-    },
-    "g2.gumgum.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535682782409,
-      "userAction": ""
-    },
-    "gads.pubmatic.com": {
+    "g.3gl.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535628645321,
+      "nextUpdateTime": 1538410704427,
       "userAction": ""
     },
-    "gakogedifoda.ru": {
+    "g.ign.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535579017912,
-      "userAction": ""
-    },
-    "gannett-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535532577705,
-      "userAction": ""
-    },
-    "gannett.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535738506516,
-      "userAction": ""
-    },
-    "gannett.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535558203644,
+      "nextUpdateTime": 1538148864057,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535485170416,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538395883518,
+      "userAction": ""
+    },
+    "gemius.pl": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "geocoding.internetbrands.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538536149847,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535563893270,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538218189361,
       "userAction": ""
     },
-    "geosync.solution.weborama.fr": {
+    "getclicky.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535926178244,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gigya.com": {
@@ -1488,7 +2562,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "giphy.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "glamour.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "globalwebindex.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1506,6 +2592,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "goo.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "google.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1515,7 +2607,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598569331,
+      "nextUpdateTime": 1538370377555,
       "userAction": ""
     },
     "gq.com": {
@@ -1527,7 +2619,19 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711236388,
+      "nextUpdateTime": 1538295132337,
+      "userAction": ""
+    },
+    "gridsumdissector.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "groupondata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1536,22 +2640,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gscounters.us1.gigya.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535770595777,
-      "userAction": ""
-    },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535871768873,
+      "nextUpdateTime": 1538471693280,
       "userAction": ""
     },
-    "gum.criteo.com": {
+    "gtags.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535579223748,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1566,76 +2664,214 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "gwiqcdn.globalwebindex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538329164909,
+      "userAction": ""
+    },
+    "hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hatena.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585198153,
+      "nextUpdateTime": 1538228306081,
       "userAction": ""
     },
-    "hgbn.rocks": {
+    "healte.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535863358694,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hgbnr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535728786580,
-      "userAction": ""
-    },
-    "hpr.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535497040220,
-      "userAction": ""
-    },
-    "hybrid.ai": {
+    "hearstnp.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "i.liadm.com": {
+    "help.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535739388610,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "i.po.st": {
+    "hitslink.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hive.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hm.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538383968817,
+      "userAction": ""
+    },
+    "horyzon-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hubspot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535735230278,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ib.3lift.com": {
+    "hugedata.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huihui.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hwcdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "i.connatix.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535579900537,
+      "nextUpdateTime": 1538433396017,
+      "userAction": ""
+    },
+    "i.tianqi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538262509948,
+      "userAction": ""
+    },
+    "iasds01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535879292043,
+      "nextUpdateTime": 1538182536434,
       "userAction": ""
     },
-    "ic.tynt.com": {
+    "ibclick.stream": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ibillboard.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535551583447,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ibt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535730891780,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538459618997,
       "userAction": ""
     },
-    "images.taboola.com": {
+    "id5-sync.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "idealmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "identityssl.newscdn.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538550188509,
+      "userAction": ""
+    },
+    "idsync.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535479823214,
+      "nextUpdateTime": 1538467403404,
+      "userAction": ""
+    },
+    "ign.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "igodigital.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "iheart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "im-apps.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "img.purch.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imgur.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "impact-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1644,13 +2880,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "infinityid.condenastdigital.com": {
+    "in.getclicky.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535542941029,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538484989853,
       "userAction": ""
     },
-    "inquisitr.com": {
+    "infinity-tracking.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "infinityid.condenastdigital.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538163838777,
+      "userAction": ""
+    },
+    "inq.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1659,19 +2907,43 @@
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535576906508,
+      "nextUpdateTime": 1538092323704,
       "userAction": ""
     },
     "insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "instagram.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535916640573,
+      "nextUpdateTime": 1538177453642,
+      "userAction": ""
+    },
+    "instinctiveads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentmedia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "intercom.io": {
@@ -1680,10 +2952,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "intergient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "internetbrands.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535958592894,
+      "nextUpdateTime": 1538398006786,
+      "userAction": ""
+    },
+    "investingchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "invoc.us": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ioam.de": {
@@ -1692,7 +2988,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "iperceptions.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ipredictive.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1700,26 +3008,62 @@
     },
     "ips-invite.iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535746109483,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538513891249,
+      "userAction": ""
+    },
+    "irs01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "italiaonline01.wt-eu02.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538262101357,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538426276329,
+      "userAction": ""
+    },
+    "janrainsso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jquery.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jrs5.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535501210103,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "js.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535523156086,
+      "nextUpdateTime": 1538190129186,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1529472262192,
+      "nextUpdateTime": 1538279062905,
       "userAction": ""
     },
     "jsrdn.com": {
@@ -1730,7 +3074,13 @@
     },
     "justuno.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kameleoon.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1776,6 +3126,24 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "kinja.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kiwiirc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "knet.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1788,7 +3156,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "leadintel.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538046595757,
+      "userAction": ""
+    },
+    "leadlander.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "legocdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "liadm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "licasd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ligadx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1806,15 +3204,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "link-page.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "linksynergy.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "listrakbi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "live.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "live.sekindo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538332400243,
+      "userAction": ""
+    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "livejournal.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1824,52 +3258,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load77.exelator.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535541362768,
-      "userAction": ""
-    },
-    "loadm.exelator.com": {
+    "load.sumo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535938747750,
+      "nextUpdateTime": 1538194386904,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535583123603,
+      "nextUpdateTime": 1538189709302,
       "userAction": ""
     },
-    "log.outbrain.com": {
+    "loc.gov": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535577619677,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "login-ds.dotomi.com": {
+    "lockerdome.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538146284566,
+      "userAction": ""
+    },
+    "log.mmstat.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535487720538,
+      "nextUpdateTime": 1538355091856,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535602940193,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538513913912,
       "userAction": ""
     },
-    "logp2.xiti.com": {
+    "logly.co.jp": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535800795531,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "m.addthis.com": {
+    "logs11.xiti.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538403190845,
+      "userAction": ""
+    },
+    "logs1136.xiti.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538251719016,
+      "userAction": ""
+    },
+    "lp1block.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lptag.liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538533427768,
+      "userAction": ""
+    },
+    "lqm.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lrcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lytics.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535797170899,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "m6r.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mail.ru": {
@@ -1896,46 +3372,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "marinsm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketo.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "match.adsrvr.org": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538200836706,
+      "userAction": ""
+    },
+    "match.prod.bidr.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538339384874,
+      "userAction": ""
+    },
+    "matheranalytics.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535858739536,
-      "userAction": ""
-    },
-    "match.deepintent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535770736865,
-      "userAction": ""
-    },
-    "match.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535669407198,
-      "userAction": ""
-    },
-    "matching.adtags.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535931796491,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mc.webvisor.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535584418815,
-      "userAction": ""
-    },
-    "mc.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535737532185,
       "userAction": ""
     },
     "media.net": {
@@ -1953,16 +3429,76 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535842898170,
+      "nextUpdateTime": 1538439252020,
       "userAction": ""
     },
-    "mediarithmics.com": {
+    "mediaforge.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mediaplex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediarithmics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediav.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediawallahscript.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medtargetsystem.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mendeley.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "messenger.live.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "metadsp.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mfadsrvr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mg2connext.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mgid.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1974,10 +3510,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "microad.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoft.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoftonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mid.rkdms.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535865290211,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538247909740,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1989,7 +3543,61 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535541848986,
+      "nextUpdateTime": 1538394141616,
+      "userAction": ""
+    },
+    "mmstat.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "monetate.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mookie1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mouseflow.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mpnrs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mrpfd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msgapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mssl.fwmrm.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538487358307,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -2004,6 +3612,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mtrx.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538555902065,
+      "userAction": ""
+    },
     "mts0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -2016,7 +3630,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "multiview.com": {
+    "mtvnservices.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "musthird.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2034,16 +3654,118 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nanigans.com": {
+    "mynativeplatform.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myspacecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myvisualiq.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nanigans.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nasdaq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nationalgeographic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "native.ai": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560186363,
+      "nextUpdateTime": 1538320667027,
+      "userAction": ""
+    },
+    "nativendo.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nbcu.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538463121539,
+      "userAction": ""
+    },
+    "nbcuni.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "neweggimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newscdn.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newscgp.com": {
@@ -2055,7 +3777,25 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535858989061,
+      "nextUpdateTime": 1538421923960,
+      "userAction": ""
+    },
+    "newsinc.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsvine.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsweekgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newyorker.com": {
@@ -2064,16 +3804,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-a.intercom.io": {
+    "nexac.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535683012789,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-b.intercom.io": {
+    "ngpvan.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535610146889,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nokia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "nr-data.net": {
@@ -2082,10 +3828,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oclc.112.2o7.net": {
+    "nuggad.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535501585551,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nxtck.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "o0bg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oasc10.247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538268830533,
+      "userAction": ""
+    },
+    "office.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "office365.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ojrq.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ok.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olark.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olympicchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omkt.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnidsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnitagjs.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -2094,9 +3912,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "onecount.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oneroof.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onetag.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538426323108,
+      "userAction": ""
+    },
     "onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "online-metrix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onsugar.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2106,21 +3954,75 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openhub.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openstat.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "openx.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "optimize-stats.voxmedia.com": {
+    "ophan.theguardian.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535895613989,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538371630281,
+      "userAction": ""
+    },
+    "opinionstage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optaim.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optimix.asia": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ora.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "orangeads.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "otto.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2130,52 +4032,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ovh.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "p.adsymptotic.com": {
+    "owox.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535495458906,
-      "userAction": ""
-    },
-    "p.cpx.to": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535875406126,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535716223948,
+      "nextUpdateTime": 1538076392629,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535555301108,
-      "userAction": ""
-    },
-    "p.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535760257854,
-      "userAction": ""
-    },
-    "p.yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535783323409,
+      "nextUpdateTime": 1538159006482,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535815373509,
+      "nextUpdateTime": 1538075969602,
       "userAction": ""
     },
     "pardot.com": {
@@ -2190,27 +4080,81 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pbid.pro-market.net": {
+    "paypal.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535792440906,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "paypalobjects.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "payroll.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538125278981,
+      "userAction": ""
+    },
+    "performgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "perimeterx.net": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535797919846,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "phonograph2.voxmedia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538254593492,
+      "userAction": ""
+    },
+    "photobucket.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535582597532,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538374590064,
+      "userAction": ""
+    },
+    "pic.fastapi.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538255329652,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pingan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2222,74 +4166,62 @@
     },
     "pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535876656131,
-      "userAction": ""
-    },
-    "pixel-geo.prfct.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535836609372,
-      "userAction": ""
-    },
-    "pixel.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535531983715,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535859784800,
+      "nextUpdateTime": 1538133315883,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535459106331,
-      "userAction": ""
-    },
-    "pixel.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535748451871,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538133366404,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535639969032,
-      "userAction": ""
-    },
-    "pixel.rubiconproject.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535645678163,
+      "nextUpdateTime": 1538522752196,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535635208019,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538192671832,
       "userAction": ""
     },
-    "pixel.tapad.com": {
+    "pixel.zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535610784392,
+      "nextUpdateTime": 1538486726252,
       "userAction": ""
     },
-    "pixeltrack.eyeviewads.com": {
+    "piximedia.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535897272070,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "placelocal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "platform-api.sharethis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538056097475,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535554574334,
+      "nextUpdateTime": 1538260131857,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2304,16 +4236,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "player.performgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538214631976,
+      "userAction": ""
+    },
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535916234173,
+      "nextUpdateTime": 1538362569129,
+      "userAction": ""
+    },
+    "players.brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535930452354,
+      "nextUpdateTime": 1538319307097,
+      "userAction": ""
+    },
+    "plista.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2324,14 +4274,26 @@
     },
     "po.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535756748496,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538187345852,
       "userAction": ""
     },
-    "postmedia.demdex.net": {
+    "popsugar-assets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pos.baidu.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535710477120,
+      "nextUpdateTime": 1538418412765,
+      "userAction": ""
+    },
+    "postmedia.us.janrainsso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538174985349,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2340,15 +4302,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pr-bh.ybp.yahoo.com": {
+    "powerlinks.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535914334685,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pressboard.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "prfct.co": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2358,28 +4326,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "profile.ssp.rambler.ru": {
+    "prod-cmg-proxy-connext.azurewebsites.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535789715456,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "prod-mng-proxy-connext.azurewebsites.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "provenpixel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "providesupport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "proximus.be": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "proximus.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535737146713,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538427583405,
       "userAction": ""
     },
-    "ps.eyeota.net": {
+    "pub.network": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535788753573,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535909696148,
+      "nextUpdateTime": 1538202489440,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2388,63 +4380,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "purch-match.dotomi.com": {
+    "pubmine.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535842539658,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "px.adhigh.net": {
+    "pulpix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535700996611,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purechat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pushanert.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535686118831,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538206203762,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535707783947,
+      "nextUpdateTime": 1538460515426,
       "userAction": ""
     },
-    "px.owneriq.net": {
+    "pxi.pub": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535951971781,
-      "userAction": ""
-    },
-    "px.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535887595495,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535801751541,
+      "nextUpdateTime": 1538200483882,
       "userAction": ""
     },
-    "q.quora.com": {
+    "qq.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535857711077,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "qcx.quantserve.com": {
+    "qualtrics.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535884922283,
+      "nextUpdateTime": 1538327762416,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooks.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooksonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2454,10 +4476,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.skimresources.com": {
+    "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535790117318,
+      "nextUpdateTime": 1538114432566,
+      "userAction": ""
+    },
+    "rackcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "radiotime.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2466,51 +4500,105 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rand.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535724135338,
-      "userAction": ""
-    },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535943279957,
+      "nextUpdateTime": 1538208445032,
       "userAction": ""
     },
-    "reachms.bfmio.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535922335285,
-      "userAction": ""
-    },
-    "registercom.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535959894691,
-      "userAction": ""
-    },
-    "registercom.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535760317951,
-      "userAction": ""
-    },
-    "relap.io": {
+    "reachmax.cn": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535610652702,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "republer-sync.rutarget.ru": {
+    "reddit.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535696676261,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "redlink.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "regmedia.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "republer.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reson8.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "responsetap.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reutersmedia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revjet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rezync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rhombusads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ria.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richmetrics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richrelevance.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2526,34 +4614,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "rnengage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rockyou.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535789708558,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538294745257,
+      "userAction": ""
+    },
+    "rqtrk.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535574550900,
+      "nextUpdateTime": 1538129421105,
       "userAction": ""
     },
-    "rtb.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535878658398,
-      "userAction": ""
-    },
-    "rtb.mfadsrvr.com": {
+    "rss.art19.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535602308341,
+      "nextUpdateTime": 1538167421505,
+      "userAction": ""
+    },
+    "rtb.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538352452690,
+      "userAction": ""
+    },
+    "rtk.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rtve.d1.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538202862196,
+      "userAction": ""
+    },
+    "ru4.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rudy.adsnative.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538152569067,
       "userAction": ""
     },
     "rutarget.ru": {
@@ -2571,79 +4701,85 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535635426495,
+      "nextUpdateTime": 1538369224004,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535692857867,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538062771361,
       "userAction": ""
     },
-    "s.cpx.to": {
+    "s.clickability.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535952869756,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538478226394,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535783451713,
-      "userAction": ""
-    },
-    "s.jsrdn.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535498662982,
+      "nextUpdateTime": 1538149322611,
       "userAction": ""
     },
-    "s.po.st": {
+    "s.nexac.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535560094637,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538515216122,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535860326137,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538221863124,
+      "userAction": ""
+    },
+    "s.spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538331458176,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535818293290,
-      "userAction": ""
-    },
-    "s.yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535622978260,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538183045497,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535617312775,
+      "nextUpdateTime": 1538180635780,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535723340329,
+      "nextUpdateTime": 1538367243127,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535575485409,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538366295174,
+      "userAction": ""
+    },
+    "s3-us-west-2.amazonaws.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535580484432,
+      "nextUpdateTime": 1538491765915,
+      "userAction": ""
+    },
+    "sabavision.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2652,7 +4788,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sape.ru": {
+    "salesloft.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "salesmanago.pl": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "samba.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "samplicio.us": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2661,25 +4815,55 @@
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535700559367,
+      "nextUpdateTime": 1538303818062,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535725608507,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538237980451,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535951923078,
+      "nextUpdateTime": 1538343887161,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535728176589,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538475610945,
+      "userAction": ""
+    },
+    "scholarlyiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirect.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirectassets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciverse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scopus.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2688,10 +4872,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "scribblelive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scribd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535742086735,
+      "nextUpdateTime": 1538500013668,
+      "userAction": ""
+    },
+    "scripps.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538350668625,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -2700,10 +4902,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sdc-qczj.pingan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538490872689,
+      "userAction": ""
+    },
+    "sdp-campaign.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535520532074,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538422064517,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2715,90 +4929,108 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535677815299,
-      "userAction": ""
-    },
-    "secfld.vmmpxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535800058823,
+      "nextUpdateTime": 1538546208242,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465743467,
+      "nextUpdateTime": 1538187034130,
+      "userAction": ""
+    },
+    "secure-dcr.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538214152681,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535785998221,
+      "nextUpdateTime": 1538262143169,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535914435468,
+      "nextUpdateTime": 1538371117898,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535948798377,
+      "nextUpdateTime": 1538367254534,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535877945891,
+      "nextUpdateTime": 1538062926851,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535597555162,
-      "userAction": ""
-    },
-    "secure.insightexpressai.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535791667902,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538515294111,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535639340469,
+      "nextUpdateTime": 1538269531819,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535564812848,
+      "nextUpdateTime": 1538219869201,
+      "userAction": ""
+    },
+    "secure.statcounter.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538453154129,
+      "userAction": ""
+    },
+    "securedvisit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535650108629,
+      "nextUpdateTime": 1538165745281,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535464387320,
+      "nextUpdateTime": 1538077819865,
       "userAction": ""
     },
-    "segments.company-target.com": {
+    "sekindo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535734903711,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "selectablemedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sendtonews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2808,9 +5040,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "servedby.flashtalking.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538477934971,
+      "userAction": ""
+    },
+    "serverbid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "session.timecommerce.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538421892505,
+      "userAction": ""
+    },
+    "sessioncam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sf14g.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "shareaholic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2826,15 +5094,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simage2.pubmatic.com": {
+    "shop.pe": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "siftscience.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535730445037,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "simpli.fi": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "siteimproveanalytics.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitelock.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2850,7 +5154,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sjs.bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538374333246,
+      "userAction": ""
+    },
     "skimresources.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sky.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "slashdotmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartadserver.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2859,13 +5187,79 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535498866607,
+      "nextUpdateTime": 1538354484555,
+      "userAction": ""
+    },
+    "smashing-delivery.herokuapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smi2.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smithsonian.museum": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "so.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "socdm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sociomantic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "soflopxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sogou.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sohu.irs01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538175757124,
+      "userAction": ""
+    },
+    "sokrati.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "solarwinds.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538167927210,
       "userAction": ""
     },
     "sonobi.com": {
@@ -2882,13 +5276,49 @@
     },
     "sp.analytics.yahoo.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538339922746,
+      "userAction": ""
+    },
+    "sphereup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spiceworks.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535555922438,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sportz.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spot.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spots.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2898,64 +5328,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-27-09.config.parsely.com": {
+    "springernature.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606591829,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-27-09.pixel.parsely.com": {
+    "springserve.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535775011168,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-27-10.config.parsely.com": {
+    "springserve.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "srv-2018-09-26-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535756373485,
+      "nextUpdateTime": 1538359586941,
+      "userAction": ""
+    },
+    "srv-2018-09-26-09.pixel.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538445425688,
+      "userAction": ""
+    },
+    "srv-2018-09-26-10.config.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538474458903,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535710872574,
+      "nextUpdateTime": 1538460842793,
       "userAction": ""
     },
-    "ssl.siteimprove.com": {
+    "srx.com.sg": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535689859677,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535454314181,
-      "userAction": ""
-    },
-    "sso.caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535761951625,
-      "userAction": ""
-    },
-    "ssp-rtb.sape.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535766755060,
-      "userAction": ""
-    },
-    "ssum-sec.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535761311673,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538250386292,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535924056645,
+      "nextUpdateTime": 1538512151649,
+      "userAction": ""
+    },
+    "stackadapt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stanza-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538238071781,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2964,34 +5406,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "static.addtoany.com": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1529315030088,
-      "userAction": ""
-    },
-    "static.datamind.ru": {
+    "static.bshare.cn": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535845316114,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538407047481,
       "userAction": ""
     },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535639204569,
+      "nextUpdateTime": 1538438476744,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535592093085,
-      "userAction": ""
-    },
-    "static.quantcast.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535861273600,
+      "nextUpdateTime": 1538374661983,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -3003,18 +5433,42 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535757740002,
+      "nextUpdateTime": 1538123969054,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535490242831,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538383272999,
       "userAction": ""
     },
     "steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stg-sp.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stickyadstv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storage.googleapis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storygize.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3027,7 +5481,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535936086555,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -3036,94 +5490,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "suning.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "supplyframe.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "survata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535543303368,
+      "nextUpdateTime": 1538409550581,
+      "userAction": ""
+    },
+    "surveymonkey.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "svcs.ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538325865068,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535878443632,
+      "nextUpdateTime": 1538045911214,
       "userAction": ""
     },
-    "sync-tm.everesttech.net": {
+    "switchadhub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535753717531,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sync.1dmp.io": {
+    "symantec.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535866711433,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535474216425,
+      "nextUpdateTime": 1538159389370,
       "userAction": ""
     },
-    "sync.adkernel.com": {
+    "sync.graph.bluecava.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535616105586,
-      "userAction": ""
-    },
-    "sync.bfmio.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535792114790,
-      "userAction": ""
-    },
-    "sync.datamind.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535757781917,
-      "userAction": ""
-    },
-    "sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535699991298,
-      "userAction": ""
-    },
-    "sync.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535939733228,
-      "userAction": ""
-    },
-    "sync.multiview.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535809892152,
+      "nextUpdateTime": 1538100879756,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465474316,
-      "userAction": ""
-    },
-    "sync.teads.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535793050783,
-      "userAction": ""
-    },
-    "sync.upravel.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535705180457,
-      "userAction": ""
-    },
-    "sync3.adsniper.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535672244398,
+      "nextUpdateTime": 1538407016386,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -3138,10 +5574,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tacdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535701257955,
+      "nextUpdateTime": 1538489495789,
+      "userAction": ""
+    },
+    "tag.mtrcs.samba.tv": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538210741846,
+      "userAction": ""
+    },
+    "tag.placelocal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538095525832,
+      "userAction": ""
+    },
+    "tags.news.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538246007029,
+      "userAction": ""
+    },
+    "tailtarget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -3150,10 +5616,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tamgrt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tanx.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "taobao.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535764731289,
+      "nextUpdateTime": 1538492207266,
       "userAction": ""
     },
     "tapad.com": {
@@ -3162,7 +5646,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "teads.tv": {
+    "tapestry.tapad.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538235641061,
+      "userAction": ""
+    },
+    "target.smi2.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538428202945,
+      "userAction": ""
+    },
+    "tawk.to": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "taylorandfrancis.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3171,6 +5673,12 @@
     "tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "techweb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3192,16 +5700,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "theglobeandmail.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "theguardian.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "thrtle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535484616929,
+      "nextUpdateTime": 1538123580474,
       "userAction": ""
     },
-    "timeuk.demdex.net": {
+    "tianqi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tidaltv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tidelinedata.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "timecommerce.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "timeinc.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535590619071,
+      "nextUpdateTime": 1538072239103,
+      "userAction": ""
+    },
+    "timewarnercable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tinypass.com": {
@@ -3210,10 +5766,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tiqcdn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535694887621,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538202979002,
+      "userAction": ""
+    },
+    "tm-awx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tmall.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3222,28 +5796,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "top100.rambler.ru": {
+    "toutapp.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535891887087,
-      "userAction": ""
-    },
-    "tr.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535664544534,
-      "userAction": ""
-    },
-    "tr.snapchat.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535741046224,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535674993267,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538111155067,
+      "userAction": ""
+    },
+    "track.hubspot.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538073273875,
+      "userAction": ""
+    },
+    "tradelab.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficjunky.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3252,13 +5832,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trc.taboola.com": {
+    "travelsmarter.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535758029438,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tremorhub.com": {
+    "travelzoo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trb.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "treasuredata.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3270,15 +5862,99 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "trends.revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538067659492,
+      "userAction": ""
+    },
+    "tribalfusion.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tribl.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "triblive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tripadvisor.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trk.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538056981974,
+      "userAction": ""
+    },
+    "tronc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trumba.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "truoptik.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustarc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustpilot.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535677023679,
+      "nextUpdateTime": 1538407164376,
       "userAction": ""
     },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tutorialize.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "twimg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3294,51 +5970,177 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "u.openx.net": {
+    "uc.se": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535606318085,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "upravel.com": {
+    "uciservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uconnect.tealiumiq.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538086919054,
+      "userAction": ""
+    },
+    "ucoz.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "udmserve.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538457145899,
+      "userAction": ""
+    },
+    "ugdturner.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unagi-eu.amazon.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538257470790,
+      "userAction": ""
+    },
+    "undertone.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unicc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unity.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unrulymedia.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ups.xplosion.de": {
+    "upsellit.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535897007154,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "urbandictionary.store": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535697248099,
+      "nextUpdateTime": 1538339771741,
       "userAction": ""
     },
-    "us4.siteimprove.com": {
+    "usa.gov": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535464144110,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us5.siteimprove.com": {
+    "usergram.info": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535699974981,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "va.v.liveperson.net": {
+    "uservoice.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535466934945,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ustream.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "utarget.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538409562664,
+      "userAction": ""
+    },
+    "utarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538382140645,
+      "userAction": ""
+    },
+    "uuidksinc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538344768057,
+      "userAction": ""
+    },
+    "v-biz.com.ua": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "veinteractive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "velaro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vendorlist.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538143303737,
+      "userAction": ""
+    },
+    "viafoura.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3348,7 +6150,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "videohub.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vidible.tv": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vilynx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3366,34 +6186,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "visitor-service-us-east-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535733808496,
-      "userAction": ""
-    },
-    "vmmpxl.com": {
+    "virgilio.it": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vmss.boldchat.com": {
+    "visualstudio.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535601239497,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vk.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535498479361,
+      "nextUpdateTime": 1538418284544,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3405,28 +6225,100 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535636170372,
+      "nextUpdateTime": 1538264689912,
       "userAction": ""
     },
-    "wam-yahoo.solution.weborama.fr": {
+    "w55c.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535796722948,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wal.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wal.wolfram.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538507015629,
+      "userAction": ""
+    },
+    "wallst.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535855791363,
+      "nextUpdateTime": 1538404424123,
       "userAction": ""
     },
-    "web.hb.ad.cpe.dotomi.com": {
+    "wbtrk.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535923593881,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wcfbc.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "weather.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webmd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webpush.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webservices.webspectator.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538420584854,
+      "userAction": ""
+    },
+    "websimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webspectator.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webtrekk.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3438,21 +6330,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "webvisor.org": {
+    "weibo.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "widgets.outbrain.com": {
+    "welt.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "whistleout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "widget.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535670143608,
+      "nextUpdateTime": 1538468993614,
+      "userAction": ""
+    },
+    "wikia-services.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wikimedia.org": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wired.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3462,34 +6378,130 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wishpond.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wkxppshj-qx.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wms-na.amazon-adsystem.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538561096392,
+      "userAction": ""
+    },
+    "wnyc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wolfram.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woobi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woopic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wordpress.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wrating.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ws.sessioncam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538093572796,
+      "userAction": ""
+    },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535840821698,
+      "nextUpdateTime": 1538495803032,
       "userAction": ""
     },
-    "ww.steelhousemedia.com": {
+    "wsj.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535813179789,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wsod.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wt-eu02.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535765401859,
+      "nextUpdateTime": 1538510946198,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535489564334,
+      "nextUpdateTime": 1538087322367,
+      "userAction": ""
+    },
+    "www.beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538073326388,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3501,25 +6513,31 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535595495451,
+      "nextUpdateTime": 1538446372221,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535586988900,
+      "nextUpdateTime": 1538493655891,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535930397006,
+      "nextUpdateTime": 1538123690650,
+      "userAction": ""
+    },
+    "www.dezeenjobs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538195644309,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535509674049,
+      "nextUpdateTime": 1538168960663,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -3531,13 +6549,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535739774613,
+      "nextUpdateTime": 1538116834884,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535560046524,
+      "nextUpdateTime": 1538157891279,
       "userAction": ""
     },
     "www.google.com": {
@@ -3549,97 +6567,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535756312610,
+      "nextUpdateTime": 1538093232146,
+      "userAction": ""
+    },
+    "www.iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538193507860,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535879616929,
-      "userAction": ""
-    },
-    "www.linkedin.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535800042571,
+      "nextUpdateTime": 1538121151651,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535800256120,
+      "nextUpdateTime": 1538278936690,
       "userAction": ""
     },
-    "www.pitchfork.com": {
+    "www.proximus.be": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535749245992,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538480707132,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535728733870,
+      "nextUpdateTime": 1538341119642,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535468979631,
+      "nextUpdateTime": 1538191505978,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535776576351,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538165597564,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535467088529,
+      "nextUpdateTime": 1538511390052,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535653525547,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538445532831,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535873679290,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538290704894,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535804763970,
-      "userAction": ""
-    },
-    "www.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535541713916,
+      "nextUpdateTime": 1538343058111,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535773470002,
+      "nextUpdateTime": 1538182668807,
+      "userAction": ""
+    },
+    "wwwimages.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535481472835,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538550095595,
       "userAction": ""
     },
-    "x01.aidata.io": {
+    "xad.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535957511051,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "xiti.com": {
@@ -3648,15 +6666,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "xpl.theadex.com": {
+    "xlisting.jp": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535914264605,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xs4all.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xsdownload.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3667,6 +6697,12 @@
       "userAction": ""
     },
     "yadro.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3684,13 +6720,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yastatic.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538421382254,
+      "userAction": ""
+    },
     "yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yieldoptimizer.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yldbt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "youtube-nocookie.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
@@ -3702,22 +6762,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "youvisit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ypcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535571133437,
+      "nextUpdateTime": 1538367319132,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535964428669,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538234483947,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535649235764,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zedo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3725,55 +6803,62 @@
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
+    },
+    "zergnet.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zidtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ziffdavis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zoomph.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zprk.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zynbit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
     }
   },
   "snitch_map": {
     "126.net": [
-      "163.com",
-      "fotki.com"
-    ],
-    "127.net": [
       "163.com"
     ],
     "15gifts.com": [
       "thetimes.co.uk"
     ],
-    "1dmp.io": [
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
-    ],
-    "1rx.io": [
-      "tinyurl.com",
-      "lycos.com",
-      "photobucket.com"
-    ],
-    "23video.com": [
-      "bandcamp.com"
-    ],
-    "247-inc.net": [
-      "marriott.com"
-    ],
     "247realmedia.com": [
       "bmj.com",
-      "aappublications.org",
       "americanbar.org"
     ],
     "254a.com": [
-      "thehindu.com"
-    ],
-    "2mdnsys.com": [
-      "liveuamap.com"
+      "tinyurl.com"
     ],
     "2o7.net": [
-      "mysql.com",
       "cdc.gov",
-      "theatlantic.com",
       "prnewswire.com",
-      "fastcompany.com",
-      "earthlink.net",
-      "qz.com",
-      "oclc.org"
+      "fastcompany.com"
     ],
     "33across.com": [
       "accuweather.com"
@@ -3781,29 +6866,19 @@
     "360.cn": [
       "so.com"
     ],
-    "360buyimg.com": [
-      "jd.com"
-    ],
     "360yield.com": [
       "springer.com",
-      "home.pl",
-      "allafrica.com"
+      "home.pl"
     ],
     "3gl.net": [
-      "istockphoto.com",
-      "gettyimages.com",
-      "economist.com"
+      "go.com",
+      "economist.com",
+      "sfgate.com"
     ],
     "3lift.com": [
-      "nature.com",
-      "springer.com",
-      "theverge.com",
+      "msn.com",
       "usatoday.com",
-      "infoworld.com",
-      "focus.de"
-    ],
-    "4dsply.com": [
-      "wnd.com"
+      "springer.com"
     ],
     "50bang.org": [
       "2345.com"
@@ -3815,50 +6890,33 @@
       "ganji.com"
     ],
     "5p4rk13.com": [
-      "sfu.ca",
-      "cdbaby.com"
+      "sfu.ca"
     ],
     "6sc.co": [
-      "zendesk.com",
-      "gotomeeting.com",
-      "rsa.com"
-    ],
-    "7eer.net": [
-      "lenovo.com",
-      "adidas.com"
-    ],
-    "7grid.com": [
-      "mihanblog.com"
+      "brightcove.com"
     ],
     "aamsitecertifier.com": [
-      "smh.com.au",
       "theglobeandmail.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "post-gazette.com"
     ],
     "aaxads.com": [
-      "forbes.com"
+      "forbes.com",
+      "speedtest.net"
     ],
     "abmr.net": [
-      "paypal.com",
-      "nike.com"
+      "nike.com",
+      "freetype.org"
+    ],
+    "acast.com": [
+      "cam.ac.uk"
     ],
     "accessatlanta.com": [
       "ajc.com"
     ],
-    "accuweather.com": [
-      "miamiherald.com",
-      "sacbee.com",
-      "kansascity.com"
-    ],
-    "acint.net": [
-      "tomsk.ru",
-      "radikal.ru",
-      "diary.ru"
-    ],
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr",
       "leparisien.fr"
     ],
     "acquia.com": [
@@ -3866,35 +6924,25 @@
       "osu.edu",
       "amd.com"
     ],
-    "actionnetwork.org": [
-      "dailykos.com"
-    ],
     "acuityplatform.com": [
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "bartleby.com"
+      "businessinsider.com",
+      "npr.org"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-score.com": [
-      "infoplease.com"
-    ],
     "ad-stir.com": [
       "sakura.ne.jp",
-      "biglobe.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com",
-      "yesky.com"
+      "huanqiu.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
-    ],
-    "adaraanalytics.com": [
-      "hyatt.com"
     ],
     "adc-srv.net": [
       "autodesk.com"
@@ -3903,58 +6951,36 @@
       "t-online.de"
     ],
     "addroplet.com": [
-      "wallinside.com",
-      "wnd.com",
+      "tinypic.com",
       "washingtonexaminer.com"
     ],
     "addthis.com": [
       "nasa.gov",
-      "jimdo.com",
-      "yahoo.com",
       "who.int",
-      "unenvironment.org",
-      "gulfnews.com"
-    ],
-    "addtoany.com": [
-      "irs.gov"
+      "npr.org"
     ],
     "adentifi.com": [
-      "metmuseum.org",
-      "infoplease.com"
+      "metmuseum.org"
     ],
     "adform.net": [
-      "t-online.de",
-      "bloomberg.com",
-      "springer.com",
-      "sciencemag.org",
-      "thehindu.com",
-      "helsinki.fi"
+      "forbes.com",
+      "imdb.com",
+      "t-online.de"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "rambler.ru",
-      "ria.ru"
-    ],
-    "adfront.org": [
-      "joomla.org"
+      "sputniknews.com"
     ],
     "adhigh.net": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
-    ],
-    "adidas.fi": [
-      "adidas.com"
+      "rambler.ru"
     ],
     "adingo.jp": [
-      "biglobe.ne.jp"
+      "seesaa.jp"
     ],
     "adition.com": [
-      "bloomberg.com",
+      "t-online.de",
       "dailymotion.com",
-      "spiegel.de",
       "lemonde.fr"
     ],
     "adjust-net.jp": [
@@ -3962,133 +6988,83 @@
       "ocn.ne.jp"
     ],
     "adkernel.com": [
-      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "xda-developers.com",
-      "dailydot.com"
-    ],
-    "adlmerge.com": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "admaster.com.cn": [
-      "autohome.com.cn",
-      "bshare.cn"
+      "howtogeek.com"
     ],
     "admission.net": [
       "edmunds.com"
     ],
-    "admixer.net": [
-      "space.com"
-    ],
     "adnxs.com": [
-      "yahoo.com",
-      "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "thehindu.com",
-      "rfi.fr"
+      "forbes.com"
     ],
     "adobe.com": [
-      "wikipedia.org",
       "behance.net",
       "history.com",
-      "fotolia.com"
+      "nbc.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
-      "bbb.org",
-      "bizjournals.com",
+      "symantec.com",
       "worldbank.org"
     ],
     "adotmob.com": [
-      "standard.co.uk",
-      "upwork.com",
-      "variety.com"
+      "variety.com",
+      "standard.co.uk"
     ],
     "adriver.ru": [
-      "ria.ru",
-      "rambler.ru",
-      "tomsk.ru",
-      "home.pl"
+      "liveinternet.ru",
+      "sputniknews.com",
+      "rambler.ru"
     ],
     "adroll.com": [
-      "stumbleupon.com",
-      "nature.com",
-      "nginx.org",
+      "photobucket.com",
       "cloudflare.com",
-      "sitepoint.com",
-      "case.edu"
+      "ning.com"
+    ],
+    "adrta.com": [
+      "seesaa.jp"
+    ],
+    "adsafety.net": [
+      "npr.org"
     ],
     "adscale.de": [
       "t-online.de",
-      "bloomberg.com",
       "springer.com",
-      "statista.com",
       "home.pl"
     ],
     "adsnative.com": [
-      "autodesk.com",
-      "thehill.com",
+      "squareup.com",
       "informationweek.com",
       "bostonherald.com"
     ],
-    "adsniper.ru": [
-      "rambler.ru",
-      "radikal.ru"
-    ],
     "adsrvr.org": [
-      "adobe.com",
-      "yahoo.com",
-      "googletagmanager.com",
       "sourceforge.net",
-      "thehindu.com",
-      "hgtv.com"
+      "nytimes.com",
+      "forbes.com"
     ],
     "adswizz.com": [
+      "variety.com",
       "iheart.com",
-      "tunein.com",
-      "variety.com"
+      "tunein.com"
     ],
     "adsymptotic.com": [
-      "tinyurl.com",
-      "etsy.com",
-      "tripadvisor.com",
-      "usatoday.com",
-      "thehindu.com",
-      "realtor.com"
+      "forbes.com",
+      "wsj.com",
+      "etsy.com"
     ],
-    "adtags.pro": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "adtdp.com": [
-      "biglobe.ne.jp"
+    "adtng.com": [
+      "pornhub.com"
     ],
     "advertising.com": [
-      "amazon.com",
-      "sourceforge.net",
-      "dropbox.com",
-      "wsj.com",
-      "home.pl",
-      "walgreens.com"
-    ],
-    "advertur.ru": [
-      "radikal.ru"
-    ],
-    "adwstats.com": [
-      "cisco.com"
+      "yahoo.com",
+      "nytimes.com",
+      "msn.com"
     ],
     "adx.com.ru": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "adx1.com": [
-      "venturebeat.com",
-      "livescience.com",
-      "space.com"
+      "rambler.ru"
     ],
     "adzerk.net": [
       "asp.net"
@@ -4096,103 +7072,88 @@
     "aetnd.com": [
       "history.com"
     ],
-    "afilio.com.br": [
-      "mcafee.com"
+    "afkp.net": [
+      "autodesk.com"
     ],
     "agkn.com": [
-      "amazon.com",
-      "t-online.de",
+      "imdb.com",
       "bloomberg.com",
-      "cnet.com",
-      "bankrate.com",
-      "gizmodo.com"
-    ],
-    "aid-ad.jp": [
-      "shinobi.jp"
-    ],
-    "aidata.io": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
-    ],
-    "aili.com": [
-      "sina.com.cn"
-    ],
-    "ajx130.online": [
-      "radikal.ru"
+      "cnet.com"
     ],
     "akamaihd.net": [
-      "voanews.com",
-      "repubblica.it",
-      "iyfubh.com",
-      "forbes.com"
+      "forbes.com",
+      "voanews.com"
     ],
     "akamaized.net": [
       "tamu.edu",
       "microsoft.com",
-      "nbc.com"
+      "xbox.com"
     ],
     "albacross.com": [
       "rebelmouse.com"
     ],
     "alibaba.com": [
-      "youku.com",
-      "taobao.com",
+      "tmall.com",
       "aliexpress.com",
-      "tmall.com"
+      "alibabacloud.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
-      "alibaba.com",
       "youku.com",
-      "aliexpress.com",
-      "1688.com",
-      "2345.com"
+      "sohu.com"
     ],
     "alipay.com": [
-      "alibaba.com",
       "youku.com"
     ],
     "aliyun.com": [
-      "alibabacloud.com"
+      "alibabacloud.com",
+      "gmw.cn"
     ],
     "allure.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
-    "am15.net": [
-      "radikal.ru"
-    ],
-    "amap.com": [
-      "zhaopin.com"
-    ],
     "amazon-adsystem.com": [
-      "amazon.com",
-      "nytimes.com",
-      "reddit.com",
-      "cnn.com",
-      "mentalfloss.com",
-      "bostonherald.com"
+      "forbes.com",
+      "imdb.com",
+      "washingtonpost.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
     ],
     "amazon.com": [
-      "qq.com",
       "imdb.com",
       "amazon.co.uk",
       "amazon.de",
-      "amazon.co.jp"
+      "amazon.es"
     ],
     "ameba.jp": [
       "ameblo.jp"
     ],
-    "analytics-egain.com": [
-      "virginmedia.com"
+    "ancestry.ca": [
+      "ancestry.com"
+    ],
+    "ancestry.co.uk": [
+      "ancestry.com"
+    ],
+    "ancestry.com.au": [
+      "ancestry.com"
+    ],
+    "ancestry.de": [
+      "ancestry.com"
+    ],
+    "ancestry.fr": [
+      "ancestry.com"
+    ],
+    "ancestry.it": [
+      "ancestry.com"
+    ],
+    "ancestry.mx": [
+      "ancestry.com"
+    ],
+    "ancestry.se": [
+      "ancestry.com"
     ],
     "and.co.uk": [
       "dailymail.co.uk"
@@ -4201,136 +7162,72 @@
       "answers.com"
     ],
     "answerscloud.com": [
-      "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "nintendo.com",
-      "realtor.com"
-    ],
-    "antdsp.com": [
-      "hc360.com"
+      "uscourts.gov"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
-    "aol.com": [
-      "engadget.com",
-      "indiatimes.com",
-      "autoblog.com",
-      "techcrunch.com"
-    ],
-    "ap.org": [
-      "post-gazette.com"
-    ],
     "apester.com": [
-      "deadline.com",
-      "searchenginewatch.com",
       "nme.com"
     ],
     "apn.co.nz": [
       "nzherald.co.nz"
     ],
     "app.link": [
-      "foursquare.com",
-      "history.com",
-      "nbc.com",
-      "allrecipes.com",
-      "strava.com"
-    ],
-    "appdynamics.com": [
-      "nfl.com"
+      "medium.com",
+      "buzzfeed.com",
+      "foursquare.com"
     ],
     "apple.com": [
       "digitaltrends.com",
       "icloud.com",
-      "softpedia.com",
       "thinkgeek.com"
-    ],
-    "aqtracker.com": [
-      "nikkei.com"
-    ],
-    "arcgis.com": [
-      "chron.com"
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
     ],
-    "areyouahuman.com": [
-      "reuters.com",
-      "merriam-webster.com",
-      "accuweather.com"
-    ],
-    "arrivalist.com": [
-      "philly.com"
-    ],
     "art19.com": [
       "coindesk.com"
     ],
-    "asos-media.com": [
-      "asos.com"
-    ],
     "atdmt.com": [
       "facebook.com",
-      "yahoo.com",
-      "msn.com",
-      "upwork.com"
+      "shutterfly.com",
+      "xbox.com"
     ],
     "atemda.com": [
       "springer.com",
       "home.pl"
     ],
-    "atgsvcs.com": [
-      "oracle.com",
-      "xerox.com"
-    ],
     "ati-host.net": [
+      "bbc.com",
       "straitstimes.com"
     ],
     "att.com": [
       "att.net"
     ],
     "audtd.com": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "autoimg.cn": [
-      "autohome.com.cn"
+      "rambler.ru"
     ],
     "autopilothq.com": [
-      "bitbucket.org",
-      "rfc-editor.org",
       "typeform.com"
-    ],
-    "b1img.com": [
-      "threadless.com"
     ],
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com",
-      "sohu.com",
-      "2345.com"
+      "sohu.com"
     ],
     "bam-x.com": [
       "gq.com"
     ],
-    "bazaarvoice.com": [
-      "target.com",
-      "lenovo.com",
-      "motorola.com"
-    ],
-    "bbb.org": [
-      "penders.com",
-      "afternic.com",
-      "sedo.com"
+    "baur.de": [
+      "t-online.de"
     ],
     "bbbpromos.org": [
       "bbb.org"
@@ -4338,115 +7235,61 @@
     "bbc.co.uk": [
       "bbc.com"
     ],
-    "bbelements.com": [
-      "idnes.cz"
-    ],
-    "beatport.com": [
-      "tmall.com"
-    ],
     "beemray.com": [
       "telegraph.co.uk",
       "mirror.co.uk"
     ],
     "beian.gov.cn": [
       "dzwww.com",
-      "ku6.com"
-    ],
-    "benchtag2.co": [
-      "sbs.com.au"
-    ],
-    "betweendigital.com": [
-      "tomsk.ru",
-      "radikal.ru"
+      "qianlong.com"
     ],
     "bfmio.com": [
-      "symantec.com",
       "tinypic.com",
-      "venturebeat.com",
       "livescience.com",
-      "dailydot.com"
-    ],
-    "bfmtv.com": [
-      "liberation.fr",
-      "lexpress.fr"
+      "space.com"
     ],
     "biddingx.com": [
       "sina.com.cn"
     ],
     "bidr.io": [
       "adobe.com",
-      "dailymotion.com",
-      "hootsuite.com",
       "hp.com",
-      "upwork.com"
+      "dailymotion.com"
     ],
     "bidswitch.net": [
-      "yahoo.com",
-      "google.com",
-      "amazon.com",
-      "dropbox.com",
-      "thehindu.com",
-      "radikal.ru"
-    ],
-    "bigmining.com": [
-      "hatena.ne.jp"
-    ],
-    "bigmir.net": [
-      "kharkov.ua",
-      "kh.ua"
+      "forbes.com",
+      "tinyurl.com",
+      "imdb.com"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
-      "weebly.com",
-      "msn.com",
-      "motorola.com",
-      "microsoft.com",
-      "pingdom.com"
-    ],
-    "bitbucket.org": [
-      "atlassian.com"
+      "weebly.com"
     ],
     "bizible.com": [
-      "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com",
       "ibm.com",
-      "here.com",
-      "gitlab.com"
-    ],
-    "bizibly.com": [
-      "eventbrite.com",
-      "cloudflare.com"
+      "shutterstock.com"
     ],
     "bizographics.com": [
-      "zend.com",
-      "nginx.com",
-      "oreilly.com",
-      "jimdo.com"
+      "jimdo.com",
+      "surveymonkey.com",
+      "economist.com"
     ],
     "bizrate.com": [
+      "time.com",
       "fortune.com",
-      "people.com",
-      "ew.com",
-      "time.com"
-    ],
-    "blogos.com": [
-      "livedoor.com"
-    ],
-    "bloomberg.com": [
-      "macrumors.com"
+      "people.com"
     ],
     "bluecava.com": [
-      "history.com",
-      "biography.com"
+      "wsj.com",
+      "giphy.com",
+      "active.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
-      "theatlantic.com",
       "sfgate.com",
-      "chron.com",
-      "ajc.com"
+      "chron.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -4455,20 +7298,20 @@
       "variety.com"
     ],
     "bnidx.com": [
-      "jigsy.com",
-      "bravenet.com"
+      "bravenet.com",
+      "jigsy.com"
+    ],
+    "bobo.com": [
+      "163.com"
     ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org",
-      "networksolutions.com"
+      "cancer.org"
     ],
     "bonappetit.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "boston.com": [
@@ -4477,62 +7320,43 @@
     "bostonglobemedia.com": [
       "boston.com"
     ],
-    "botradar.tech": [
-      "radikal.ru"
-    ],
-    "boudja.com": [
-      "4shared.com"
-    ],
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com",
-      "usatoday.com",
-      "allrecipes.com",
-      "pitchfork.com"
+      "usatoday.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
     ],
     "brides.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "brightcove.com": [
-      "scholastic.com",
-      "si.com",
-      "federalreserve.gov",
+      "aarp.org",
       "theaustralian.com.au",
-      "informationweek.com",
-      "straitstimes.com"
+      "informationweek.com"
     ],
     "brightcove.net": [
-      "lefigaro.fr",
-      "politico.com",
-      "bostonglobe.com",
-      "aljazeera.com"
+      "lonelyplanet.com",
+      "thetimes.co.uk",
+      "thenational.ae"
+    ],
+    "bshare.cn": [
+      "qianlong.com"
     ],
     "bttrack.com": [
-      "yahoo.com",
-      "independent.co.uk",
-      "zendesk.com",
-      "nypost.com",
-      "dailydot.com"
+      "livescience.com",
+      "variety.com",
+      "hpe.com"
     ],
     "btttag.com": [
       "samsung.com",
-      "marriott.com",
-      "ihg.com"
-    ],
-    "bumlam.com": [
-      "rambler.ru"
+      "marriott.com"
     ],
     "c-ctrip.com": [
-      "ctrip.com",
-      "qunar.com"
+      "ctrip.com"
     ],
     "c212.net": [
       "prnewswire.com"
@@ -4543,36 +7367,18 @@
     "cadreon.com": [
       "economist.com"
     ],
-    "caltat.com": [
-      "live4fun.ru",
-      "radikal.ru"
-    ],
-    "candlewoodsuites.com": [
-      "ihg.com"
-    ],
-    "capturehighered.net": [
-      "ku.edu",
-      "unm.edu"
-    ],
     "carambo.la": [
-      "accuweather.com",
-      "salon.com"
+      "accuweather.com"
     ],
     "casalemedia.com": [
-      "amazon.com",
-      "dropbox.com",
-      "myspace.com",
+      "imdb.com",
       "washingtonpost.com",
-      "thehindu.com",
-      "pitchfork.com"
+      "bloomberg.com"
     ],
     "cbsi.com": [
-      "zdnet.com",
-      "last.fm",
-      "gamespot.com",
       "cnet.com",
       "cbsnews.com",
-      "cbssports.com"
+      "zdnet.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -4581,72 +7387,37 @@
       "softonic.com",
       "biography.com"
     ],
-    "cdn-apple.com": [
-      "icloud.com"
-    ],
-    "cdn-hotels.com": [
-      "hotels.com"
-    ],
-    "cdn-net.com": [
-      "hotels.com",
-      "americanexpress.com"
-    ],
     "cdnwidget.com": [
       "photoshelter.com"
-    ],
-    "cedexis-test.com": [
-      "tumblr.com"
     ],
     "cern.ch": [
       "home.cern"
     ],
-    "changeagain.me": [
-      "iconosquare.com"
-    ],
-    "charitynavigator.org": [
-      "heart.org"
-    ],
     "chei.com.cn": [
       "chsi.com.cn"
     ],
-    "chicagotribune.com": [
-      "wikipedia.org"
-    ],
-    "chinajob.com": [
-      "china.org.cn"
-    ],
     "chinaso.com": [
-      "weather.com.cn"
-    ],
-    "chinavivaki.com": [
-      "bshare.cn"
+      "weather.com.cn",
+      "chinanews.com"
     ],
     "choozle.com": [
-      "denverpost.com",
-      "photobucket.com"
+      "photobucket.com",
+      "denverpost.com"
     ],
     "circularhub.com": [
       "suntimes.com",
       "tampabay.com",
-      "bostonherald.com"
+      "stltoday.com"
     ],
     "civicscience.com": [
-      "post-gazette.com",
-      "knowyourmeme.com",
-      "ebaumsworld.com"
+      "post-gazette.com"
     ],
     "ckies.net": [
       "abril.com.br"
     ],
     "clickability.com": [
-      "prnewswire.com",
       "philly.com",
       "proquest.com"
-    ],
-    "clicktale.net": [
-      "xbox.com",
-      "office.com",
-      "microsoft.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
@@ -4656,11 +7427,9 @@
       "indiatimes.com"
     ],
     "cloudflare.com": [
-      "uci.edu",
-      "nbcnews.com",
+      "redhat.com",
       "sciencemag.org",
-      "nginx.com",
-      "allaboutcookies.org"
+      "uci.edu"
     ],
     "cnet.com": [
       "zdnet.com"
@@ -4670,65 +7439,35 @@
     ],
     "cntraveler.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
-    ],
-    "cnzz.com": [
-      "zol.com.cn"
     ],
     "cobaltgroup.com": [
       "edmunds.com"
     ],
-    "coherentpath.com": [
-      "staples.com"
-    ],
     "cohesionapps.com": [
-      "americanexpress.com",
-      "admin.ch",
       "bankrate.com"
     ],
     "collegenet.com": [
-      "gmu.edu",
-      "ku.edu"
-    ],
-    "comm100.com": [
-      "hobbyking.com"
+      "gmu.edu"
     ],
     "commander1.com": [
       "ovh.com",
-      "ubisoft.com",
-      "arte.tv"
+      "ovh.co.uk",
+      "ubisoft.com"
     ],
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com",
-      "hp.com",
-      "upwork.com",
-      "box.com"
-    ],
-    "complex.com": [
-      "knowyourmeme.com",
-      "dailydot.com",
-      "ebaumsworld.com"
-    ],
-    "conative.de": [
-      "focus.de"
+      "hp.com"
     ],
     "condenastdigital.com": [
       "wired.com",
-      "arstechnica.com",
-      "nj.com",
       "newyorker.com",
-      "nola.com",
-      "pitchfork.com"
-    ],
-    "conductrics.com": [
-      "nginx.com"
+      "arstechnica.com"
     ],
     "connatix.com": [
+      "jpost.com",
       "alternet.org",
       "dailydot.com"
     ],
@@ -4736,114 +7475,52 @@
       "sourceforge.net"
     ],
     "consensu.org": [
-      "rollingstone.com",
-      "variety.com",
-      "adweek.com",
-      "independent.co.uk",
-      "nme.com"
+      "pcworld.com",
+      "us.org",
+      "rollingstone.com"
     ],
-    "consumable.com": [
-      "xfinity.com"
-    ],
-    "contentabc.com": [
-      "pornhub.com"
+    "content.ad": [
+      "tinypic.com"
     ],
     "contextweb.com": [
       "sourceforge.net",
-      "myspace.com",
-      "bloomberg.com",
       "forbes.com",
-      "thehindu.com",
-      "coindesk.com"
-    ],
-    "convertful.com": [
-      "lifehack.org"
+      "imdb.com"
     ],
     "convertro.com": [
-      "ibm.com",
-      "logitech.com",
       "slack.com"
-    ],
-    "convio.net": [
-      "diabetes.org"
     ],
     "cornell.edu": [
       "arxiv.org"
     ],
-    "cox.net": [
-      "cox.com"
-    ],
-    "coxbusiness.com": [
-      "cox.com"
-    ],
     "coxmediagroup.com": [
       "ajc.com"
     ],
-    "cpex.cz": [
-      "idnes.cz"
-    ],
     "cpx.to": [
-      "express.co.uk",
-      "digitaltrends.com",
-      "techradar.com",
       "independent.co.uk",
-      "allmusic.com",
-      "rfi.fr"
-    ],
-    "cquotient.com": [
-      "gopro.com"
-    ],
-    "cr-nielsen.com": [
-      "youku.com"
+      "mirror.co.uk",
+      "express.co.uk"
     ],
     "creativecdn.com": [
-      "ria.ru",
-      "udn.com"
-    ],
-    "creativecommons.org": [
-      "perl.com"
+      "ria.ru"
     ],
     "criteo.com": [
-      "tinyurl.com",
-      "washingtonpost.com",
-      "dailymail.co.uk",
       "dropbox.com",
-      "newegg.com",
-      "sedo.com"
-    ],
-    "croissed.info": [
-      "4shared.com"
-    ],
-    "crowneplaza.com": [
-      "ihg.com"
+      "forbes.com",
+      "reuters.com"
     ],
     "crsspxl.com": [
       "sourceforge.net",
-      "slashdot.org",
-      "bartleby.com"
-    ],
-    "crwdcntrl.net": [
-      "wunderground.com"
+      "slashdot.org"
     ],
     "cssrvsync.com": [
       "springer.com",
       "home.pl"
     ],
-    "ctv.ca": [
-      "ctvnews.ca"
-    ],
-    "curse.com": [
-      "wowdb.com"
-    ],
-    "custhelp.com": [
-      "oracle.com"
-    ],
     "cxense.com": [
-      "opera.com",
-      "talktalk.co.uk",
-      "gizmodo.com",
       "wsj.com",
-      "allafrica.com"
+      "opera.com",
+      "talktalk.co.uk"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -4851,14 +7528,10 @@
     "d1rv23qj5kas56.cloudfront.net": [
       "webnode.com"
     ],
-    "d2-apps.net": [
-      "rakuten.co.jp",
-      "yahoo.co.jp"
-    ],
     "d41.co": [
+      "hp.com",
       "intel.com",
-      "hpe.com",
-      "hp.com"
+      "hpe.com"
     ],
     "da-ads.com": [
       "deviantart.com"
@@ -4866,76 +7539,30 @@
     "dailymail.co.uk": [
       "metro.co.uk"
     ],
-    "dailymotion.com": [
-      "google.com"
-    ],
     "datamind.ru": [
-      "novostimira.com",
       "rambler.ru",
-      "kharkov.ua",
-      "radikal.ru"
-    ],
-    "datasteam.io": [
-      "ama-assn.org"
-    ],
-    "datpix.net": [
-      "radikal.ru"
-    ],
-    "daum.net": [
-      "shutterstock.com",
-      "tistory.com"
-    ],
-    "daumcdn.net": [
-      "daum.net"
-    ],
-    "daumdn.com": [
-      "shutterstock.com"
+      "novostimira.com"
     ],
     "dc-storm.com": [
       "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com"
+      "alibabacloud.com",
+      "coursera.org"
     ],
-    "deep.bi": [
-      "hrw.org"
-    ],
-    "deepintent.com": [
-      "infoplease.com"
-    ],
-    "dell.com": [
-      "rsa.com"
+    "decajo.ru": [
+      "radikal.ru"
     ],
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "amazon.com",
-      "soundcloud.com",
-      "thehindu.com",
-      "skynet.be"
-    ],
-    "departapp.com": [
-      "liveuamap.com"
+      "soundcloud.com"
     ],
     "deployads.com": [
       "tinyurl.com",
-      "lycos.com",
       "sciencedaily.com",
       "zerohedge.com"
     ],
-    "deqwas.net": [
-      "rakuten.co.jp"
-    ],
-    "developermedia.com": [
-      "codeproject.com"
-    ],
     "dezeenjobs.com": [
       "dezeen.com"
-    ],
-    "df-srv.de": [
-      "focus.de"
-    ],
-    "dhs.gov": [
-      "fema.gov"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
@@ -4944,58 +7571,33 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com",
       "zerohedge.com"
     ],
-    "dictionary.com": [
-      "thesaurus.com"
-    ],
-    "digitaladsystems.com": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
     "digitaltarget.ru": [
-      "liveinternet.ru",
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
+      "rambler.ru"
     ],
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk",
-      "gizmodo.com",
-      "bostonherald.com"
-    ],
-    "disney.com": [
-      "starwars.com"
+      "express.co.uk"
     ],
     "disqus.com": [
-      "pnas.org",
+      "rollingstone.com",
       "dyn.com",
-      "mercurynews.com",
-      "rollingstone.com"
+      "mercurynews.com"
     ],
     "distiltag.com": [
       "reuters.com",
-      "merriam-webster.com"
+      "merriam-webster.com",
+      "washingtontimes.com"
     ],
     "districtm.io": [
+      "forbes.com",
       "barnesandnoble.com",
-      "urbandictionary.com",
-      "axs.com",
-      "thehindu.com",
-      "newatlas.com"
-    ],
-    "djv99sxoqpv11.cloudfront.net": [
-      "4shared.com"
+      "timeanddate.com"
     ],
     "dmxleo.com": [
       "dailymotion.com"
-    ],
-    "dnnapi.com": [
-      "zenfolio.com",
-      "gob.es"
     ],
     "dol.gov": [
       "osha.gov"
@@ -5003,16 +7605,12 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com",
-      "slashdot.org"
+      "wsj.com"
     ],
     "dotomi.com": [
-      "tinyurl.com",
-      "samsung.com",
-      "webmd.com",
       "forbes.com",
-      "thehindu.com",
-      "walgreens.com"
+      "samsung.com",
+      "economist.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -5020,52 +7618,26 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com",
-      "sourceforge.net",
-      "haaretz.com",
-      "focus.de"
-    ],
-    "doublemax.net": [
-      "udn.com"
+      "linkedin.com"
     ],
     "doublepimpssl.com": [
       "pornhub.com"
     ],
-    "doubleverify.com": [
-      "military.com",
-      "allafrica.com"
-    ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com",
       "adweek.com"
-    ],
-    "dxpmedia.com": [
-      "sina.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
-      "t-online.de",
       "cnbc.com",
-      "nbcnews.com",
+      "norton.com",
       "washingtonexaminer.com"
     ],
-    "dynatrace-managed.com": [
-      "delta.com"
-    ],
     "dyntrk.com": [
-      "dailymotion.com",
-      "infoplease.com"
-    ],
-    "ebay-us.com": [
-      "ebay.com.au",
-      "ebay.com"
-    ],
-    "ebay.co.uk": [
-      "synacor.com"
+      "dailymotion.com"
     ],
     "ebay.com": [
       "ebay.co.uk",
@@ -5075,44 +7647,25 @@
     "ebayrtm.com": [
       "ebay.co.uk",
       "ebay.de",
-      "ebay.com",
       "ebay.com.au"
     ],
-    "ebdr3.com": [
-      "springer.com"
-    ],
     "ebis.ne.jp": [
-      "exblog.jp",
-      "xrea.com"
-    ],
-    "econda-monitor.de": [
-      "expedia.com"
-    ],
-    "ecustomeropinions.com": [
-      "skysports.com"
+      "exblog.jp"
     ],
     "edge-cdn.net": [
       "biomedcentral.com"
     ],
-    "edmunds.com": [
-      "unenvironment.org"
-    ],
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com",
-      "goal.com"
+      "gulfnews.com"
     ],
     "eloqua.com": [
       "intel.com",
-      "cisco.com",
-      "prnewswire.com",
-      "redhat.com",
-      "infoworld.com",
-      "eset.com"
+      "siemens.com",
+      "redhat.com"
     ],
     "elsevier.com": [
-      "sciencedirect.com",
       "thelancet.com",
       "cell.com"
     ],
@@ -5120,80 +7673,33 @@
       "thelancet.com",
       "cell.com"
     ],
-    "emc.com": [
-      "rsa.com"
-    ],
     "emlgrid.com": [
       "home.pl"
     ],
-    "emxdgt.com": [
-      "springer.com",
-      "home.pl"
-    ],
-    "envato.com": [
-      "codecanyon.net"
-    ],
     "epicurious.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
-    ],
-    "epital.gdn": [
-      "4shared.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
     ],
-    "espn.com": [
-      "fivethirtyeight.com"
-    ],
-    "estara.com": [
-      "xerox.com"
-    ],
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "lefigaro.fr",
       "tomshardware.com"
-    ],
-    "etracker.de": [
-      "sedo.com"
-    ],
-    "etsystudio.com": [
-      "etsy.com"
-    ],
-    "evenhotels.com": [
-      "ihg.com"
-    ],
-    "eventsabout.com": [
-      "sacbee.com"
     ],
     "everesttech.net": [
       "adobe.com",
-      "yahoo.com",
       "sourceforge.net",
-      "dropbox.com",
-      "thehindu.com",
-      "newatlas.com"
-    ],
-    "everyaction.com": [
-      "greenpeace.org"
+      "nytimes.com"
     ],
     "evise.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
-    "evolok.net": [
-      "scotsman.com"
-    ],
-    "evyy.net": [
-      "office.com"
-    ],
-    "ew3.io": [
-      "liberation.fr"
+    "evvnt-api.global.ssl.fastly.net": [
+      "seattlepi.com"
     ],
     "exactag.com": [
       "t-online.de"
@@ -5201,38 +7707,21 @@
     "excite.co.jp": [
       "exblog.jp"
     ],
-    "exe.bid": [
-      "rambler.ru"
-    ],
     "exelator.com": [
       "soundcloud.com",
       "forbes.com",
-      "bloomberg.com",
-      "businessinsider.com",
-      "genius.com",
-      "gizmodo.com"
-    ],
-    "exosrv.com": [
-      "pornhub.com"
-    ],
-    "expedia.com": [
-      "excite.com"
+      "businessinsider.com"
     ],
     "eyeota.net": [
       "sourceforge.net",
-      "forbes.com",
-      "bloomberg.com",
-      "gizmodo.com",
-      "heraldsun.com.au"
+      "wsj.com",
+      "npr.org"
     ],
     "eyereturn.com": [
-      "thestar.com",
-      "queensu.ca"
+      "thestar.com"
     ],
     "eyeviewads.com": [
-      "staples.com",
-      "nypost.com",
-      "walgreens.com"
+      "boingboing.net"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -5240,40 +7729,17 @@
     ],
     "facebook.com": [
       "instagram.com",
-      "wordpress.org",
       "adobe.com",
-      "nytimes.com",
-      "haaretz.com",
-      "focus.de"
+      "apple.com"
     ],
-    "facetz.net": [
-      "novostimira.com",
-      "rambler.ru",
-      "kharkov.ua"
-    ],
-    "faggrim.com": [
-      "radikal.ru"
-    ],
-    "fairfax.com.au": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "fastcompany.com": [
-      "fastcodesign.com"
+    "fastapi.net": [
+      "sohu.com"
     ],
     "fdlstatic.com": [
       "cnet.com"
     ],
     "feathr.co": [
-      "informationweek.com",
-      "eurogamer.net"
-    ],
-    "ffx.io": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "fidelity-media.com": [
-      "home.pl"
+      "informationweek.com"
     ],
     "filepicker.io": [
       "enlightenment.org",
@@ -5281,245 +7747,123 @@
     ],
     "firstimpression.io": [
       "jpost.com",
-      "serverwatch.com",
       "haaretz.com"
     ],
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu"
+      "monster.com"
     ],
     "flickr.com": [
-      "state.gov",
       "oecd.org",
-      "enable-javascript.com"
+      "enable-javascript.com",
+      "cia.gov"
     ],
     "flipboard.com": [
       "venturebeat.com",
-      "autoblog.com",
-      "popsugar.com"
-    ],
-    "flyercity.ca": [
-      "canada.com"
+      "popsugar.com",
+      "autoblog.com"
     ],
     "flyertown.ca": [
-      "canada.com",
-      "globalnews.ca",
       "nationalpost.com",
+      "globalnews.ca",
       "vancouversun.com"
     ],
-    "fontawesome.com": [
-      "socarrao.com.br",
-      "clinicaltrials.gov",
-      "moonfruit.com",
-      "webex.com",
-      "ucsc.edu",
-      "sitepoint.com"
+    "force.com": [
+      "constantcontact.com",
+      "salesforce.com"
     ],
     "foresee.com": [
       "epa.gov",
-      "si.edu",
-      "theglobeandmail.com",
-      "sec.gov",
-      "worldcat.org"
+      "ieee.org",
+      "theglobeandmail.com"
     ],
     "formstack.com": [
       "in.gov"
     ],
     "fout.jp": [
       "economist.com",
-      "hatena.ne.jp"
-    ],
-    "fox.com": [
-      "nationalgeographic.com",
-      "foxnews.com",
-      "foxbusiness.com"
-    ],
-    "foxbusiness.com": [
-      "fox.com"
-    ],
-    "foxnews.com": [
-      "foxbusiness.com",
-      "fox.com"
-    ],
-    "foxsports.com": [
-      "fox.com"
+      "exblog.jp",
+      "biglobe.ne.jp"
     ],
     "foxycart.com": [
       "brookings.edu"
     ],
-    "freeskreen.com": [
-      "nationalpost.com",
-      "wattpad.com"
-    ],
     "freshdesk.com": [
       "podbean.com"
     ],
-    "friendbuy.com": [
-      "lulu.com"
-    ],
-    "funcaptcha.com": [
-      "axs.com"
-    ],
-    "funnyordie.com": [
-      "deadline.com",
-      "videojs.com"
-    ],
     "fwmrm.net": [
-      "yahoo.com",
-      "mlb.com",
-      "xfinity.com",
+      "go.com",
       "discovery.com",
-      "hgtv.com"
-    ],
-    "g2crowd.com": [
-      "prezi.com",
-      "teamviewer.us",
-      "wpengine.com"
-    ],
-    "gakogedifoda.ru": [
-      "radikal.ru"
-    ],
-    "gamer-network.net": [
-      "eurogamer.net"
+      "foodnetwork.com"
     ],
     "gemius.pl": [
       "sapo.pt",
-      "interia.pl",
       "ria.ru"
     ],
-    "gentags.net": [
-      "sina.com.cn"
-    ],
     "getclicky.com": [
-      "icio.us",
       "newatlas.com",
       "cyberchimps.com"
-    ],
-    "getdrip.com": [
-      "dreamhost.com"
-    ],
-    "getpocket.com": [
-      "cronolog.org"
-    ],
-    "getsmartcontent.com": [
-      "pcworld.com",
-      "computerworld.com",
-      "hpe.com",
-      "networkworld.com"
-    ],
-    "gfycat.com": [
-      "reddit.com"
     ],
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au",
-      "cbslocal.com",
-      "abc.es",
-      "hgtv.com"
+      "abc.net.au"
     ],
     "giphy.com": [
-      "urbandictionary.com",
-      "liberation.fr",
-      "webshots.com"
-    ],
-    "github.com": [
-      "wsj.com"
+      "urbandictionary.com"
     ],
     "glamour.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com",
-      "si.com"
-    ],
-    "gmossp-sp.jp": [
-      "shinobi.jp",
-      "shop-pro.jp"
+      "fortune.com"
     ],
     "go.com": [
       "disney.com",
-      "espn.com",
       "starwars.com",
       "fivethirtyeight.com"
     ],
     "golfdigest.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
-    "google.co.jp": [
-      "forumotion.com"
-    ],
     "google.com": [
       "youtube.com",
-      "linkedin.com",
-      "google.de",
-      "sourceforge.net",
-      "scmp.com",
-      "sendspace.com",
-      "chromium.org",
-      "focus.de"
+      "vimeo.com",
+      "goo.gl"
     ],
     "gq.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "gridsumdissector.com": [
-      "qq.com",
-      "www.gov.cn",
-      "autohome.com.cn"
+      "www.gov.cn"
     ],
     "groupondata.com": [
       "groupon.com"
     ],
-    "gsimedia.net": [
-      "acehardware.com"
-    ],
-    "gssprt.jp": [
-      "dropbox.com",
-      "biglobe.ne.jp"
-    ],
     "gtags.net": [
-      "sina.com.cn",
       "ctrip.com"
     ],
     "gumgum.com": [
-      "liveuamap.com",
-      "colourlovers.com",
-      "infoplease.com",
+      "snopes.com",
       "thehindu.com",
-      "coindesk.com"
-    ],
-    "guoshipartners.com": [
-      "udn.com"
+      "home.pl"
     ],
     "gwallet.com": [
-      "adobe.com",
-      "ox.ac.uk",
-      "ihg.com",
       "economist.com",
-      "business2community.com"
-    ],
-    "gwmtracking.com": [
-      "proofpoint.com"
-    ],
-    "hadcs.de": [
-      "t-online.de"
+      "ox.ac.uk",
+      "smithsonianmag.com"
     ],
     "hatena.com": [
       "hatena.ne.jp"
@@ -5529,7 +7873,6 @@
       "cronolog.org"
     ],
     "healte.de": [
-      "spiegel.de",
       "reuters.com"
     ],
     "hearstnp.com": [
@@ -5538,20 +7881,7 @@
       "seattlepi.com"
     ],
     "help.com": [
-      "comodo.com",
-      "couchsurfing.com"
-    ],
-    "hgbn.rocks": [
-      "radikal.ru"
-    ],
-    "hgbnr.com": [
-      "radikal.ru"
-    ],
-    "hiexpress.com": [
-      "ihg.com"
-    ],
-    "highwire.org": [
-      "pnas.org"
+      "comodo.com"
     ],
     "hitslink.com": [
       "webstarts.com"
@@ -5559,40 +7889,16 @@
     "hive.co": [
       "complex.com"
     ],
-    "hlserve.com": [
-      "bestbuy.com",
-      "macys.com",
-      "kohls.com"
-    ],
-    "holidayinn.com": [
-      "ihg.com"
-    ],
-    "holidayinnresorts.com": [
-      "ihg.com"
-    ],
     "horyzon-media.com": [
       "skyrock.com"
     ],
-    "hotelindigo.com": [
-      "ihg.com"
-    ],
-    "hotelsapi.io": [
-      "ovh.net"
-    ],
-    "htmedia.in": [
-      "hindustantimes.com"
-    ],
     "hubspot.com": [
-      "wpengine.com",
-      "shopify.com",
-      "technologyreview.com",
-      "scoop.it"
+      "scoop.it",
+      "500px.com",
+      "thelancet.com"
     ],
-    "huffingtonpost.co.uk": [
-      "oath.com"
-    ],
-    "huffingtonpost.com": [
-      "huffingtonpost.co.uk"
+    "hugedata.com.cn": [
+      "miit.gov.cn"
     ],
     "huihui.cn": [
       "youdao.com"
@@ -5601,57 +7907,35 @@
       "boingboing.net"
     ],
     "hybrid.ai": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
+      "rambler.ru"
     ],
-    "hypemarks.com": [
-      "uchicago.edu",
-      "purdue.edu",
-      "brown.edu"
-    ],
-    "i.ua": [
-      "kharkov.ua",
-      "kh.ua"
-    ],
-    "i1img.com": [
-      "excite.com"
-    ],
-    "ib-ibi.com": [
-      "globo.com"
+    "iasds01.com": [
+      "discovery.com"
     ],
     "ibclick.stream": [
-      "webmd.com",
-      "wikitravel.org",
-      "inhabitat.com"
+      "webmd.com"
     ],
     "ibillboard.com": [
+      "t-online.de",
       "springer.com",
-      "home.pl",
-      "idnes.cz"
+      "home.pl"
     ],
     "ibt.com": [
       "newsweek.com",
       "ibtimes.com"
     ],
     "id5-sync.com": [
-      "bloomberg.com",
-      "venturebeat.com",
       "dailymotion.com",
       "livescience.com",
-      "xda-developers.com"
+      "skyrock.com"
     ],
     "idealmedia.com": [
-      "alternet.org",
       "thehill.com"
     ],
     "ign.com": [
       "videojs.com"
     ],
     "igodigital.com": [
-      "apa.org",
-      "adidas.com",
       "motorola.com",
       "nintendo.com"
     ],
@@ -5660,109 +7944,63 @@
     ],
     "im-apps.net": [
       "exblog.jp",
-      "rakuten.co.jp",
       "biglobe.ne.jp",
-      "economist.com"
-    ],
-    "imagetopng.club": [
-      "4shared.com"
-    ],
-    "imedia.cz": [
-      "idnes.cz"
-    ],
-    "imgfarm.com": [
-      "excite.com"
+      "goo.ne.jp"
     ],
     "imgur.com": [
       "stackoverflow.com",
-      "stackexchange.com",
-      "unm.edu"
+      "stackexchange.com"
     ],
     "impact-ad.jp": [
-      "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp",
-      "economist.com",
-      "ocn.ne.jp"
+      "hatena.ne.jp",
+      "goo.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com",
-      "wsj.com",
-      "popsugar.com",
-      "gizmodo.com"
+      "wsj.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
       "gartner.com"
     ],
-    "infolinks.com": [
-      "infoplease.com"
-    ],
-    "innovid.com": [
-      "nationalreview.com"
-    ],
     "inq.com": [
-      "att.com",
-      "shutterstock.com",
       "ups.com"
-    ],
-    "inquisitr.com": [
-      "www.poznan.pl",
-      "flipboard.com"
-    ],
-    "inside-graph.com": [
-      "staples.com"
     ],
     "insightexpressai.com": [
       "unsplash.com",
-      "standard.co.uk",
-      "motorola.com",
-      "giphy.com",
-      "gopro.com"
+      "philly.com"
     ],
     "instagram.com": [
-      "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
       "arizona.edu"
     ],
     "instinctiveads.com": [
-      "variety.com",
-      "dp.ua",
-      "blackberry.com",
-      "rollingstone.com"
+      "rollingstone.com",
+      "variety.com"
     ],
     "intentiq.com": [
-      "sourceforge.net",
-      "symantec.com",
-      "slashdot.org"
+      "thinkgeek.com",
+      "active.com"
     ],
     "intentmedia.net": [
-      "hotels.com",
-      "tripadvisor.com",
-      "expedia.com"
+      "tripadvisor.com"
     ],
     "intercom.io": [
-      "themeforest.net",
-      "ft.com",
-      "elegantthemes.com",
-      "codecanyon.net",
-      "iconfinder.com"
+      "themegrill.com",
+      "emarketer.com",
+      "diabetes.org"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
-      "wikitravel.org",
-      "inhabitat.com"
+      "wikitravel.org"
     ],
     "investingchannel.com": [
       "zerohedge.com"
-    ],
-    "investis.com": [
-      "ge.com"
     ],
     "invoc.us": [
       "prweb.com"
@@ -5770,86 +8008,57 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com",
-      "focus.de"
+      "xing.com"
     ],
     "iolam.it": [
       "virgilio.it"
     ],
     "iperceptions.com": [
-      "ford.com",
-      "seagate.com",
-      "honeywell.com",
       "boeing.com"
     ],
-    "ipinyou.com": [
-      "autohome.com.cn"
-    ],
     "ipredictive.com": [
+      "imdb.com",
       "myspace.com",
       "dailymotion.com"
     ],
     "irs01.com": [
-      "youku.com"
-    ],
-    "izooto.com": [
-      "indianexpress.com"
+      "youku.com",
+      "sohu.com"
     ],
     "janrainsso.com": [
       "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
-      "ifeng.com",
       "sohu.com"
     ],
     "jquery.com": [
-      "dyn.com",
-      "fujitsu.com",
-      "liveleak.com",
-      "lemonde.fr"
+      "opensource.org",
+      "lemonde.fr",
+      "businessinsider.com"
     ],
     "jrs5.com": [
       "nike.com",
-      "shutterstock.com",
+      "coursera.org",
       "bostonglobe.com"
     ],
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com",
-      "vancouversun.com"
-    ],
-    "justpremium.com": [
-      "tvtropes.org"
+      "dallasnews.com"
     ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com",
-      "zenfolio.com",
-      "gopro.com"
-    ],
-    "jword.jp": [
-      "excite.co.jp"
-    ],
-    "jyxo.com": [
-      "blog.cz"
-    ],
-    "kakao.com": [
-      "tistory.com",
-      "daum.net"
+      "searchengineland.com"
     ],
     "kameleoon.eu": [
       "welt.de",
       "orange.fr"
     ],
     "keywee.co": [
-      "latimes.com",
-      "nationalgeographic.com",
-      "chicagotribune.com",
       "nytimes.com",
-      "complex.com",
-      "zappos.com"
+      "latimes.com",
+      "nationalgeographic.com"
     ],
     "kinja.com": [
       "gizmodo.com",
@@ -5859,105 +8068,66 @@
     "kiwiirc.com": [
       "enlightenment.org"
     ],
-    "krxd.net": [
-      "inhabitat.com",
-      "bgr.com",
-      "jalopnik.com",
-      "cnn.com",
-      "allrecipes.com",
-      "gizmodo.com"
+    "knet.cn": [
+      "dzwww.com"
     ],
-    "ladsp.com": [
-      "exblog.jp",
-      "biglobe.ne.jp",
-      "shop-pro.jp"
+    "krxd.net": [
+      "cnn.com",
+      "theguardian.com",
+      "usatoday.com"
     ],
     "leadintel.io": [
       "nme.com"
     ],
-    "leaf.io": [
-      "ehow.com",
-      "livestrong.com"
+    "leadlander.com": [
+      "panasonic.com"
     ],
     "legocdn.com": [
       "lego.com"
     ],
-    "lejwaengv.com": [
-      "rd.com"
-    ],
     "liadm.com": [
-      "webmd.com",
-      "nj.com",
-      "patch.com",
       "bloomberg.com",
-      "cbssports.com",
-      "washingtonexaminer.com"
-    ],
-    "libero.it": [
-      "virgilio.it"
+      "time.com",
+      "economist.com"
     ],
     "licasd.com": [
-      "nj.com",
-      "cbssports.com"
-    ],
-    "licdn.com": [
-      "linkedin.com"
+      "time.com"
     ],
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "home.pl",
-      "orange.fr"
+      "lefigaro.fr"
     ],
     "lightboxcdn.com": [
+      "gizmodo.com",
       "zdnet.com",
-      "fastcompany.com",
-      "adweek.com",
-      "mashable.com",
-      "dailycaller.com"
+      "fastcompany.com"
     ],
     "lijit.com": [
       "sourceforge.net",
-      "bloomberg.com",
-      "deviantart.com",
-      "uci.edu",
-      "zimbio.com",
-      "infoplease.com"
-    ],
-    "lincoln.com": [
-      "ford.com"
+      "wsj.com",
+      "bloomberg.com"
     ],
     "link-page.info": [
-      "netvibes.com",
-      "icq.com"
+      "netvibes.com"
     ],
     "linkedin.com": [
-      "adobe.com",
       "vimeo.com",
-      "sourceforge.net",
-      "dropbox.com",
-      "mentalfloss.com",
-      "lexisnexis.com"
+      "adobe.com",
+      "sourceforge.net"
     ],
     "linksynergy.com": [
-      "rakuten.co.jp",
-      "pcworld.com",
       "nike.com",
-      "infoworld.com"
-    ],
-    "list-manage.com": [
-      "boingboing.net"
+      "alibabacloud.com",
+      "coursera.org"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "paypal.com",
-      "skype.com",
-      "msn.com",
       "microsoft.com",
-      "bing.com",
-      "office.com"
+      "msn.com",
+      "bing.com"
     ],
     "livechatinc.com": [
       "ning.com",
@@ -5965,34 +8135,27 @@
       "sophos.com",
       "nazwa.pl"
     ],
-    "livedoor.jp": [
-      "livedoor.com"
-    ],
     "livejournal.net": [
       "livejournal.com"
     ],
     "liveperson.net": [
-      "apache.org",
-      "prnewswire.com",
-      "ibm.com",
-      "thetimes.co.uk",
-      "lexisnexis.com"
-    ],
-    "lkqd.net": [
-      "allafrica.com"
+      "talktalk.co.uk",
+      "earthlink.net",
+      "trendmicro.com"
     ],
     "loc.gov": [
-      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
-      "infoplease.com",
-      "coindesk.com",
-      "edmunds.com"
+      "jpost.com",
+      "infoplease.com"
     ],
     "logly.co.jp": [
       "goo.ne.jp",
       "nifty.com"
+    ],
+    "lp1block.com": [
+      "radikal.ru"
     ],
     "lqm.io": [
       "lefigaro.fr"
@@ -6001,229 +8164,141 @@
       "cbc.ca",
       "arte.tv"
     ],
-    "lucklayed.info": [
-      "4shared.com"
-    ],
-    "lwcal.com": [
-      "sfu.ca"
-    ],
     "lytics.io": [
-      "adweek.com",
+      "economist.com",
       "digitaltrends.com",
-      "fool.com",
-      "economist.com"
+      "adweek.com"
     ],
     "m6r.eu": [
       "t-online.de",
       "statista.com"
     ],
-    "madeleine.de": [
-      "t-online.de"
-    ],
     "mail.ru": [
       "vk.com",
-      "novostimira.com",
-      "google.com",
       "yandex.ru",
-      "ria.ru",
-      "ok.ru",
-      "radikal.ru"
-    ],
-    "mailchimp.com": [
-      "colorlib.com",
-      "fas.org",
-      "tias.com",
-      "nap.edu"
-    ],
-    "mantisadnetwork.com": [
-      "tvtropes.org"
+      "icq.com"
     ],
     "marinsm.com": [
-      "eventbrite.com",
       "webs.com",
-      "hootsuite.com",
-      "smugmug.com"
+      "smugmug.com",
+      "wufoo.com"
     ],
     "marketlinc.com": [
-      "kaspersky.com",
+      "teamviewer.us",
       "norton.com",
-      "eset.com",
-      "teamviewer.us"
+      "eset.com"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
-      "dyn.com",
-      "searchengineland.com",
-      "domaintools.com"
+      "dyn.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
       "thestar.com",
-      "seattletimes.com",
-      "ajc.com"
+      "mercurynews.com"
     ],
     "mathtag.com": [
-      "adobe.com",
-      "vimeo.com",
       "sourceforge.net",
-      "forbes.com",
-      "thehindu.com",
-      "walgreens.com"
+      "nytimes.com",
+      "forbes.com"
     ],
     "media.net": [
       "nytimes.com",
-      "dropbox.com",
       "forbes.com",
-      "reuters.com",
-      "medicinenet.com",
-      "cracked.com"
+      "reuters.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
       "uci.edu",
-      "autodesk.com",
-      "box.com"
+      "autodesk.com"
     ],
     "mediaforge.com": [
       "nike.com",
-      "shutterstock.com",
+      "coursera.org",
       "bostonglobe.com"
     ],
-    "medialand.ru": [
-      "rbc.ru"
-    ],
     "mediaplex.com": [
-      "dell.com",
-      "shutterfly.com",
-      "military.com"
+      "t-online.de",
+      "economist.com",
+      "dell.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
-      "lynda.com",
-      "liberation.fr",
       "leparisien.fr"
     ],
     "mediav.com": [
+      "so.com",
       "ctrip.com",
-      "2345.com",
-      "so.com"
+      "toutiao.com"
     ],
     "mediawallahscript.com": [
-      "sourceforge.net",
-      "photobucket.com",
-      "shopko.com"
-    ],
-    "medscape.com": [
-      "medicinenet.com"
+      "sourceforge.net"
     ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
     "metadsp.co.uk": [
-      "nypost.com",
-      "standard.co.uk",
-      "variety.com"
+      "boingboing.net",
+      "standard.co.uk"
     ],
     "mfadsrvr.com": [
-      "infoplease.com"
+      "forbes.com"
     ],
     "mg2connext.com": [
-      "mercurynews.com",
       "philly.com",
-      "denverpost.com",
       "ajc.com"
     ],
     "mgid.com": [
-      "liveleak.com",
-      "radikal.ru"
-    ],
-    "miamiherald.com": [
-      "sacbee.com",
-      "kansascity.com"
+      "liveleak.com"
     ],
     "miaozhen.com": [
       "sina.com.cn",
-      "163.com",
-      "dzwww.com",
-      "autohome.com.cn"
+      "pconline.com.cn",
+      "qq.com"
     ],
     "microad.jp": [
-      "rakuten.co.jp",
       "sakura.ne.jp",
-      "biglobe.ne.jp"
+      "hatena.ne.jp"
     ],
     "microsoft.com": [
       "live.com",
       "skype.com",
-      "or.kr",
-      "msn.com",
-      "office.com",
-      "xbox.com",
-      "complex.com"
-    ],
-    "microsoftonline.com": [
-      "microsoft.com",
       "office.com"
     ],
-    "mirtesen.ru": [
-      "rbc.ru"
+    "microsoftonline.com": [
+      "office.com",
+      "microsoft.com"
     ],
     "mktoresp.com": [
       "parallels.com",
-      "prnewswire.com",
       "zend.com",
-      "oreilly.com",
-      "ebsco.com",
-      "pingdom.com"
+      "prweb.com"
     ],
     "ml314.com": [
       "sourceforge.net",
-      "forbes.com",
-      "bloomberg.com",
       "wsj.com",
-      "networkworld.com",
-      "zerohedge.com"
-    ],
-    "mlb.com": [
-      "nhl.com"
-    ],
-    "mlive.com": [
-      "nola.com"
+      "bloomberg.com"
     ],
     "mmstat.com": [
-      "alibaba.com",
       "youku.com",
-      "taobao.com",
-      "aliexpress.com"
-    ],
-    "mmtro.com": [
-      "upwork.com"
-    ],
-    "molefefiseranis.ru": [
-      "radikal.ru"
+      "sohu.com",
+      "taobao.com"
     ],
     "monetate.net": [
       "nationalgeographic.com",
-      "marriott.com",
-      "ticketmaster.com"
-    ],
-    "monster.com": [
-      "military.com"
+      "marriott.com"
     ],
     "mookie1.com": [
       "t-online.de",
-      "nbcnews.com",
-      "theglobeandmail.com",
-      "businessinsider.com"
+      "businessinsider.com",
+      "npr.org"
     ],
     "mouseflow.com": [
-      "bbb.org",
       "nintendo.com"
     ],
     "mpnrs.com": [
@@ -6232,118 +8307,63 @@
     ],
     "mrpfd.com": [
       "symantec.com",
-      "gouv.fr",
       "hpe.com"
     ],
     "msgapp.com": [
-      "post-gazette.com",
-      "odin.com"
+      "post-gazette.com"
     ],
     "msn.com": [
       "w3.org",
-      "marketwatch.com",
-      "google.com"
-    ],
-    "mthsense.com": [
-      "alternet.org"
-    ],
-    "mtty.com": [
-      "163.com"
+      "marketwatch.com"
     ],
     "mtvnservices.com": [
       "mtv.com",
       "cc.com"
     ],
-    "multiview.com": [
-      "symantec.com",
-      "nutrition.org"
-    ],
     "musthird.com": [
       "airbnb.com"
-    ],
-    "muumuu-domain.com": [
-      "shop-pro.jp"
-    ],
-    "mybuys.com": [
-      "shopko.com"
-    ],
-    "myhard.com": [
-      "yesky.com"
     ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
-    ],
-    "myregistry.com": [
-      "shopko.com"
     ],
     "myspacecdn.com": [
       "myspace.com"
     ],
     "myvisualiq.net": [
       "soundcloud.com",
-      "surveymonkey.com",
-      "spotify.com",
       "paypal.com",
-      "redbubble.com"
+      "surveymonkey.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
-      "overstock.com",
-      "squareup.com",
-      "zappos.com"
+      "yellowpages.com"
     ],
     "narrative.io": [
-      "sourceforge.net",
-      "gizmodo.com"
+      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
     ],
     "nationalgeographic.com": [
-      "foxnews.com",
-      "foxbusiness.com",
-      "fox.com"
+      "foxnews.com"
     ],
     "native.ai": [
-      "rollingstone.com"
+      "cbslocal.com"
     ],
     "nativendo.de": [
-      "t-online.de",
-      "gnu.org",
-      "focus.de"
+      "t-online.de"
     ],
     "naver.com": [
-      "unity3d.com",
-      "cafe24.com",
-      "yonhapnews.co.kr"
+      "unity3d.com"
     ],
     "naver.jp": [
-      "line.me",
-      "livedoor.com"
-    ],
-    "nbcnews.com": [
-      "today.com",
-      "msnbc.com"
+      "line.me"
     ],
     "nbcuni.com": [
       "cnbc.com",
-      "msnbc.com",
-      "nbc.com",
-      "nbcnews.com"
-    ],
-    "netdna-ssl.com": [
-      "alternet.org"
-    ],
-    "netmng.com": [
-      "lenovo.com",
-      "theknot.com",
-      "shopko.com",
-      "usatoday.com",
-      "thehindu.com"
-    ],
-    "newatlas.com": [
-      "flipboard.com"
+      "nbcnews.com",
+      "today.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -6363,20 +8383,14 @@
       "heraldsun.com.au"
     ],
     "newscgp.com": [
-      "marketwatch.com",
-      "nypost.com",
-      "thesun.co.uk",
       "wsj.com",
-      "heraldsun.com.au"
+      "marketwatch.com",
+      "nypost.com"
     ],
     "newsinc.com": [
       "latimes.com",
-      "nydailynews.com",
       "hollywoodreporter.com",
-      "ajc.com"
-    ],
-    "newsmemory.com": [
-      "cleveland.com"
+      "thehill.com"
     ],
     "newsvine.com": [
       "nbcnews.com",
@@ -6388,9 +8402,7 @@
     ],
     "newyorker.com": [
       "wired.com",
-      "vanityfair.com",
       "vogue.com",
-      "gq.com",
       "pitchfork.com"
     ],
     "nexac.com": [
@@ -6399,66 +8411,24 @@
     "ngpvan.com": [
       "greenpeace.org"
     ],
-    "nih.gov": [
-      "medlineplus.gov",
-      "clinicaltrials.gov"
-    ],
     "nokia.com": [
       "bell-labs.com"
-    ],
-    "norton.com": [
-      "namejet.com"
     ],
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com",
-      "huffingtonpost.com",
-      "allrecipes.com",
-      "helsinki.fi"
-    ],
-    "nsaudience.pl": [
-      "interia.pl"
-    ],
-    "nscontext.eu": [
-      "interia.pl",
-      "home.pl"
+      "huffingtonpost.com"
     ],
     "nuggad.net": [
-      "t-online.de",
-      "liberation.fr",
-      "lexpress.fr"
+      "t-online.de"
     ],
     "nxtck.com": [
       "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com",
-      "orange.fr"
-    ],
-    "nymag.com": [
-      "vulture.com"
-    ],
-    "nzaza.com": [
-      "upwork.com"
+      "coursera.org",
+      "bostonglobe.com"
     ],
     "o0bg.com": [
       "bostonglobe.com"
-    ],
-    "oath.com": [
-      "tumblr.com",
-      "huffingtonpost.co.uk",
-      "techradar.com",
-      "autoblog.com"
-    ],
-    "ocdn.eu": [
-      "onet.pl",
-      "brightcove.net"
-    ],
-    "oclc.org": [
-      "worldcat.org"
-    ],
-    "ofapes.com": [
-      "radikal.ru"
     ],
     "office.com": [
       "microsoftonline.com"
@@ -6467,13 +8437,13 @@
       "microsoftonline.com"
     ],
     "ojrq.net": [
-      "office.com"
+      "autodesk.com"
     ],
     "ok.ru": [
-      "ria.ru",
-      "mail.ru"
+      "ria.ru"
     ],
     "olark.com": [
+      "texas.gov",
       "webstarts.com"
     ],
     "olympicchannel.com": [
@@ -6486,38 +8456,25 @@
       "rambler.ru"
     ],
     "omnitagjs.com": [
-      "springer.com",
+      "variety.com",
       "standard.co.uk",
-      "home.pl",
-      "variety.com"
+      "home.pl"
     ],
     "omtrdc.net": [
       "adobe.com",
-      "amazon.com",
       "telegraph.co.uk",
-      "marriott.com",
-      "ancestry.com",
-      "eset.com"
-    ],
-    "onclickmega.com": [
-      "brothersoft.com"
+      "amazon.com"
     ],
     "onecount.net": [
       "foreignpolicy.com"
     ],
-    "onet.tv": [
-      "onet.pl"
+    "oneroof.co.nz": [
+      "nzherald.co.nz"
     ],
     "onetrust.com": [
-      "themeisle.com",
-      "bitbucket.org",
-      "namecheap.com",
       "cnn.com",
-      "haaretz.com",
-      "active.com"
-    ],
-    "onevision.com.tw": [
-      "udn.com"
+      "thesun.co.uk",
+      "themeisle.com"
     ],
     "online-metrix.net": [
       "gotomeeting.com"
@@ -6527,29 +8484,23 @@
     ],
     "onthe.io": [
       "indiatimes.com",
-      "wn.com",
       "express.co.uk",
       "rbc.ru"
     ],
     "ooyala.com": [
       "accuweather.com",
-      "technologyreview.com",
-      "bizjournals.com"
+      "fedex.com"
     ],
     "openhub.net": [
       "mariadb.org"
     ],
     "openstat.net": [
-      "novostimira.com",
-      "kharkov.ua"
+      "novostimira.com"
     ],
     "openx.net": [
       "yahoo.com",
-      "amazon.com",
       "nytimes.com",
-      "dropbox.com",
-      "thehindu.com",
-      "active.com"
+      "forbes.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -6558,244 +8509,133 @@
       "sohu.com"
     ],
     "optimix.asia": [
-      "bshare.cn"
+      "bshare.cn",
+      "qianlong.com"
     ],
     "optimizely.com": [
-      "cnn.com",
+      "nytimes.com",
       "creativecommons.org",
       "webs.com",
-      "bbc.com",
-      "live.com",
-      "ibm.com",
-      "hp.com",
-      "wiley.com",
-      "npr.org",
-      "springer.com",
-      "cbsnews.com",
-      "foxnews.com",
-      "imageshack.us",
-      "wikihow.com",
-      "newyorker.com",
-      "evernote.com",
-      "box.com",
-      "prezi.com",
-      "prweb.com",
-      "dictionary.com",
-      "ehow.com",
-      "bitbucket.org",
-      "gotomeeting.com",
-      "accorhotels.com",
-      "uber.com",
-      "xbox.com",
-      "history.com",
-      "bestbuy.com",
-      "jamanetwork.com",
-      "imageshack.com",
-      "dallasnews.com",
-      "metmuseum.org",
-      "blizzard.com",
-      "intuit.com",
-      "starbucks.com",
-      "squareup.com",
-      "justgiving.com",
-      "dreamhost.com",
-      "edx.org",
-      "microsoft.com",
-      "cbssports.com",
-      "bartleby.com",
-      "theknot.com",
-      "zenfolio.com",
-      "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
+      "imageshack.com",
+      "box.com",
       "fox.com"
-    ],
-    "optimove.events": [
-      "bhphotovideo.com"
     ],
     "ora.tv": [
       "cheezburger.com",
       "alternet.org"
     ],
-    "oracleimg.com": [
-      "dyn.com"
-    ],
     "orangeads.fr": [
       "orange.fr"
-    ],
-    "oreilly.com": [
-      "onlamp.com",
-      "ora.com"
-    ],
-    "otm-r.com": [
-      "tomsk.ru",
-      "radikal.ru",
-      "diary.ru"
     ],
     "otto.de": [
       "t-online.de"
     ],
     "outbrain.com": [
-      "nature.com",
-      "scribd.com",
-      "foxnews.com",
       "cnn.com",
-      "globalnews.ca",
-      "focus.de"
+      "msn.com",
+      "wsj.com"
     ],
     "ovh.com": [
       "ovh.co.uk"
     ],
     "owneriq.net": [
-      "lycos.com",
       "lg.com",
       "washingtontimes.com",
-      "thehindu.com",
-      "pitchfork.com"
+      "acer.com"
     ],
     "owox.com": [
-      "simplesite.com"
-    ],
-    "paddle.com": [
-      "snapwidget.com"
+      "boredpanda.com"
     ],
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org",
-      "propublica.org"
+      "ap.org"
     ],
     "parsely.com": [
-      "time.com",
-      "wired.com",
-      "wikia.com",
       "wsj.com",
-      "nola.com",
-      "dezeen.com"
+      "huffingtonpost.com",
+      "bloomberg.com"
     ],
     "paypal.com": [
       "paypal.me"
     ],
     "paypalobjects.com": [
       "paypal.com",
-      "freetype.org",
-      "paypal.me"
+      "paypal.me",
+      "freetype.org"
     ],
     "payroll.com": [
       "intuit.com"
-    ],
-    "pbskids.org": [
-      "pbs.org"
-    ],
-    "pcmag.com": [
-      "macrumors.com",
-      "extremetech.com"
-    ],
-    "pdmp.jp": [
-      "shop-pro.jp"
     ],
     "performgroup.com": [
       "goal.com"
     ],
     "perimeterx.net": [
-      "bloomberg.com",
-      "pixnet.net",
-      "macrumors.com",
-      "upwork.com"
+      "udemy.com",
+      "zillow.com",
+      "vogue.com"
     ],
-    "pewresearch.org": [
-      "pewinternet.org"
+    "photobucket.com": [
+      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
     ],
     "pinterest.com": [
-      "huffingtonpost.com",
-      "dailymail.co.uk",
       "nytimes.com",
-      "themeforest.net",
-      "popsugar.com"
+      "huffingtonpost.com",
+      "dailymail.co.uk"
     ],
     "pitchfork.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
-      "epicurious.com"
-    ],
-    "pixanalytics.com": [
-      "pixnet.net"
+      "vogue.com"
     ],
     "piximedia.com": [
       "orange.fr"
     ],
-    "pixnet.cc": [
-      "pixnet.net"
-    ],
-    "placed.com": [
-      "imdb.com"
-    ],
     "placelocal.com": [
       "gopro.com"
-    ],
-    "playwire.com": [
-      "infoplease.com",
-      "zotero.org"
     ],
     "plista.com": [
       "express.co.uk"
     ],
     "po.st": [
       "smithsonianmag.com",
-      "wnd.com",
-      "business2community.com",
       "nme.com"
-    ],
-    "polymorphicads.jp": [
-      "shinobi.jp"
-    ],
-    "popin.cc": [
-      "infoseek.co.jp"
     ],
     "popsugar-assets.com": [
       "popsugar.com"
     ],
     "postrelease.com": [
-      "reuters.com",
-      "independent.co.uk",
-      "chicagotribune.com",
       "wsj.com",
-      "ajc.com",
-      "bostonherald.com"
+      "reuters.com",
+      "independent.co.uk"
     ],
     "powerlinks.com": [
-      "lemonde.fr",
-      "livescience.com",
-      "standard.co.uk",
       "variety.com",
-      "orange.fr"
+      "lemonde.fr",
+      "howtogeek.com"
     ],
     "pressboard.ca": [
-      "observer.com"
+      "thestar.com"
     ],
     "prfct.co": [
-      "smugmug.com",
-      "marthastewart.com",
-      "business2community.com"
+      "smugmug.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
-      "symantec.com",
       "slashdot.org",
-      "business2community.com"
+      "thinkgeek.com"
+    ],
+    "prod-cmg-proxy-connext.azurewebsites.net": [
+      "ajc.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
       "denverpost.com",
       "ocregister.com"
-    ],
-    "proparm.jp": [
-      "biglobe.ne.jp"
     ],
     "provenpixel.com": [
       "shopify.com"
@@ -6803,32 +8643,19 @@
     "providesupport.com": [
       "jigsy.com"
     ],
-    "proximustv.be": [
+    "proximus.be": [
       "skynet.be"
     ],
-    "pscp.tv": [
-      "ey.com",
-      "ria.ru",
-      "nasa.gov"
-    ],
     "pub.network": [
-      "metacafe.com",
       "coindesk.com"
     ],
-    "publishme.se": [
-      "blogg.se"
-    ],
     "pubmatic.com": [
-      "dropbox.com",
-      "tinyurl.com",
+      "forbes.com",
       "bloomberg.com",
-      "usatoday.com",
-      "thehindu.com",
-      "walgreens.com"
+      "usatoday.com"
     ],
     "pubmine.com": [
-      "foreignpolicy.com",
-      "onecount.net"
+      "foreignpolicy.com"
     ],
     "pulpix.com": [
       "variety.com"
@@ -6841,58 +8668,29 @@
     "purechat.com": [
       "byu.edu"
     ],
-    "pxf.io": [
-      "namecheap.com",
-      "udemy.com"
+    "pushanert.com": [
+      "4shared.com"
     ],
-    "pxtres.com": [
-      "howstuffworks.com"
-    ],
-    "pxuno.com": [
-      "howstuffworks.com"
-    ],
-    "pxzwei.com": [
-      "howstuffworks.com"
+    "pxi.pub": [
+      "mentalfloss.com"
     ],
     "pymx5.com": [
-      "seattletimes.com",
-      "seattlepi.com",
       "sfgate.com",
-      "cracked.com"
-    ],
-    "qnsr.com": [
-      "serverwatch.com"
+      "seattletimes.com",
+      "seattlepi.com"
     ],
     "qq.com": [
-      "sina.com.cn",
-      "ctrip.com",
-      "weather.com.cn",
       "tencent.com"
     ],
-    "qsstats.com": [
-      "serverwatch.com",
-      "eweek.com"
-    ],
-    "qtmojo.com": [
-      "dzwww.com"
-    ],
     "qualtrics.com": [
-      "adidas.com",
+      "nintendo.com",
       "cnet.com",
-      "babycenter.com",
-      "cbssports.com",
       "mayoclinic.org"
     ],
     "quantserve.com": [
       "wordpress.org",
-      "vimeo.com",
       "reddit.com",
-      "soundcloud.com",
-      "thehindu.com",
-      "gizmodo.com"
-    ],
-    "quantummetric.com": [
-      "macys.com"
+      "soundcloud.com"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -6903,10 +8701,7 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com",
-      "nypost.com",
-      "thehindu.com",
-      "eset.com"
+      "ning.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -6914,56 +8709,26 @@
     "radiotime.com": [
       "tunein.com"
     ],
-    "rakuten.co.jp": [
-      "infoseek.co.jp"
-    ],
     "rambler.ru": [
       "livejournal.com",
-      "washingtonpost.com",
       "novostimira.com",
-      "ria.ru",
-      "radikal.ru",
-      "kharkov.ua"
-    ],
-    "rbnt.org": [
-      "radikal.ru"
-    ],
-    "rcsmetrics.it": [
-      "corriere.it"
+      "ria.ru"
     ],
     "reachmax.cn": [
-      "sina.com.cn",
-      "autohome.com.cn",
-      "bshare.cn"
+      "qq.com"
     ],
     "reddit.com": [
       "acm.org",
       "perl.com"
     ],
-    "redditmedia.com": [
-      "reddit.com"
-    ],
     "redlink.com": [
-      "jamanetwork.com",
-      "ccc.de"
-    ],
-    "reference.com": [
-      "thesaurus.com"
+      "jamanetwork.com"
     ],
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
-    "relap.io": [
-      "diary.ru",
-      "radikal.ru"
-    ],
     "republer.com": [
-      "tomsk.ru",
-      "radikal.ru",
       "rambler.ru"
-    ],
-    "researchintel.com": [
-      "intel.com"
     ],
     "reson8.com": [
       "startribune.com",
@@ -6976,13 +8741,11 @@
       "reuters.com"
     ],
     "revcontent.com": [
-      "liveuamap.com",
-      "wnd.com",
-      "jpost.com"
+      "jpost.com",
+      "breitbart.com",
+      "bostonherald.com"
     ],
     "revjet.com": [
-      "homedepot.com",
-      "expedia.com",
       "bankrate.com"
     ],
     "rezync.com": [
@@ -6990,12 +8753,9 @@
       "investopedia.com"
     ],
     "rfihub.com": [
-      "dropbox.com",
-      "tinyurl.com",
-      "npr.org",
       "forbes.com",
-      "yellowpages.com",
-      "gopro.com"
+      "npr.org",
+      "economist.com"
     ],
     "rhombusads.com": [
       "adweek.com"
@@ -7006,120 +8766,75 @@
     "richmetrics.com": [
       "nj.com",
       "oregonlive.com",
-      "mlive.com",
-      "nola.com"
+      "cleveland.com"
     ],
     "richrelevance.com": [
-      "hbr.org",
-      "kohls.com"
-    ],
-    "rightnowtech.com": [
-      "oracle.com"
+      "hbr.org"
     ],
     "rkdms.com": [
-      "time.com",
       "wired.com",
-      "cbsnews.com",
-      "zdnet.com",
-      "thebalance.com",
-      "gizmodo.com"
+      "npr.org",
+      "cbsnews.com"
     ],
     "rlcdn.com": [
       "adobe.com",
-      "yahoo.com",
       "sourceforge.net",
-      "reddit.com",
-      "thehindu.com",
-      "box.com"
+      "reddit.com"
     ],
     "rnengage.com": [
-      "oracle.com",
       "thinkgeek.com"
     ],
     "rockyou.net": [
       "springer.com"
     ],
-    "roomkey.com": [
-      "hilton.com",
-      "ihg.com"
-    ],
-    "roymorgan.com": [
-      "smh.com.au"
-    ],
     "rqtrk.eu": [
-      "dropbox.com"
-    ],
-    "rtb.com.ru": [
-      "radikal.ru",
-      "diary.ru"
+      "npr.org"
     ],
     "rtk.io": [
-      "post-gazette.com",
-      "azcentral.com",
-      "freep.com"
+      "seattletimes.com",
+      "startribune.com",
+      "azcentral.com"
     ],
     "ru4.com": [
-      "dropbox.com",
       "bloomberg.com",
-      "uci.edu"
+      "npr.org"
     ],
     "rubiconproject.com": [
-      "yahoo.com",
-      "amazon.com",
-      "sourceforge.net",
-      "cnn.com",
-      "thehindu.com",
-      "pitchfork.com"
-    ],
-    "rundsp.com": [
-      "hpe.com",
-      "alternet.org"
+      "nytimes.com",
+      "forbes.com",
+      "wsj.com"
     ],
     "rutarget.ru": [
       "rambler.ru",
-      "radikal.ru"
+      "ria.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "codepen.io",
-      "tvtropes.org"
-    ],
-    "s3xified.com": [
-      "venturebeat.com",
-      "livescience.com",
-      "lycos.com"
+      "bell-labs.com",
+      "hwg.org"
     ],
     "sabavision.com": [
       "mihanblog.com"
     ],
     "salesforceliveagent.com": [
-      "constantcontact.com",
       "marriott.com",
-      "prweb.com",
       "teamviewer.us",
-      "salesforce.com",
-      "eset.com"
+      "prweb.com"
     ],
     "salesloft.com": [
+      "wpengine.com",
       "techtarget.com",
-      "upwork.com",
-      "wpengine.com"
+      "upwork.com"
     ],
     "salesmanago.pl": [
       "home.pl"
     ],
     "samba.tv": [
-      "imdb.com",
       "gizmodo.com",
-      "lifehacker.com"
+      "lifehacker.com",
+      "history.com"
     ],
-    "sape.ru": [
-      "radikal.ru"
-    ],
-    "sbal4kp.com": [
-      "dropbox.com"
-    ],
-    "scarabresearch.com": [
-      "tate.org.uk"
+    "samplicio.us": [
+      "go.com"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -7132,210 +8847,133 @@
       "sciencedirect.com"
     ],
     "sciverse.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
-    ],
-    "scoop.it": [
-      "investorseurope.technology"
+      "thelancet.com",
+      "cell.com"
     ],
     "scopus.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
     "scorecardresearch.com": [
-      "linkedin.com",
       "yahoo.com",
       "tumblr.com",
-      "nytimes.com",
-      "thehindu.com",
-      "gizmodo.com"
+      "flickr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
-      "startribune.com",
-      "ctvnews.ca"
+      "startribune.com"
     ],
-    "sddan.com": [
-      "upwork.com"
+    "scribd.com": [
+      "macrumors.com"
     ],
-    "seadform.net": [
-      "bloomberg.com"
-    ],
-    "searchmarketing.com": [
-      "macys.com"
+    "sdp-campaign.de": [
+      "t-online.de"
     ],
     "securedvisit.com": [
-      "cafepress.com",
-      "staples.com"
-    ],
-    "seekingalpha.com": [
-      "ytimg.com"
+      "cafepress.com"
     ],
     "sekindo.com": [
       "allafrica.com"
     ],
     "selectablemedia.com": [
-      "fortune.com",
-      "people.com",
-      "ew.com",
       "time.com",
-      "allrecipes.com"
+      "fortune.com",
+      "people.com"
     ],
     "self.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
-    "semasio.net": [
-      "bloomberg.com"
-    ],
     "sendtonews.com": [
-      "canada.com",
       "bostonherald.com"
     ],
     "servebom.com": [
-      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "xda-developers.com",
-      "dailydot.com"
-    ],
-    "servedby-buysellads.com": [
-      "dribbble.com"
+      "howtogeek.com"
     ],
     "serverbid.com": [
-      "coindesk.com"
+      "sciencedaily.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
-      "t-online.de",
-      "nbcnews.com",
       "businessinsider.com",
-      "nintendo.com",
-      "hgtv.com"
+      "npr.org"
     ],
     "sessioncam.com": [
       "ama-assn.org",
       "fitbit.com"
     ],
+    "sf14g.com": [
+      "panasonic.com"
+    ],
     "shareaholic.com": [
-      "washingtontimes.com",
-      "turnerpublishing.com"
+      "washingtontimes.com"
     ],
     "sharethis.com": [
-      "www.uk.com",
-      "whatsapp.com",
-      "lycos.com",
-      "uci.edu",
-      "dailycaller.com"
+      "uk.com",
+      "us.org",
+      "www.vic.gov.au"
     ],
     "sharethrough.com": [
-      "yahoo.com",
-      "cnn.com",
+      "cnet.com",
       "time.com",
-      "forbes.com",
-      "home.pl",
-      "walgreens.com"
-    ],
-    "sheego.de": [
-      "t-online.de"
+      "wired.com"
     ],
     "shop.pe": [
-      "dyn.com",
-      "bluehost.com",
-      "fourseasons.com"
+      "dyn.com"
     ],
-    "shopify.com": [
-      "codepen.io",
-      "raspberrypi.org"
-    ],
-    "simplereach.com": [
-      "theatlantic.com"
+    "siftscience.com": [
+      "kickstarter.com",
+      "flickr.com",
+      "shutterstock.com"
     ],
     "simpli.fi": [
-      "symantec.com",
       "washingtontimes.com",
-      "thinkgeek.com"
+      "thinkgeek.com",
+      "tampabay.com"
     ],
     "sina.cn": [
       "sina.com.cn"
     ],
     "sina.com.cn": [
-      "weibo.com",
-      "dzwww.com",
-      "sina.com"
-    ],
-    "sinoptik.ua": [
-      "kharkov.ua",
-      "kh.ua"
-    ],
-    "sitehelix.com": [
-      "overstock.com"
+      "weibo.com"
     ],
     "siteimprove.com": [
-      "usda.gov",
-      "verisign.com",
-      "udel.edu",
       "berkeley.edu",
-      "emory.edu",
-      "ucsc.edu",
-      "helsinki.fi",
-      "case.edu",
-      "oclc.org"
+      "verisign.com",
+      "udel.edu"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
     ],
-    "sitelabweb.com": [
-      "lenovo.com",
-      "upwork.com"
-    ],
     "sitelock.com": [
-      "joomla.org",
-      "netfirms.com"
+      "joomla.org"
     ],
     "sitescout.com": [
-      "barnesandnoble.com",
-      "tinypic.com",
-      "seattletimes.com",
-      "usatoday.com",
-      "thehindu.com",
-      "networksolutions.com"
+      "forbes.com",
+      "tinyurl.com",
+      "time.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com",
-      "fastcompany.com",
-      "mentalfloss.com",
-      "coindesk.com"
+      "gizmodo.com"
     ],
     "sky.com": [
-      "skygroup.sky",
-      "skysports.com"
+      "skygroup.sky"
     ],
     "slashdotmedia.com": [
       "slashdot.org"
     ],
     "smartadserver.com": [
       "springer.com",
-      "skyrock.com",
-      "sapo.pt",
       "elpais.com",
-      "home.pl"
-    ],
-    "smartclip.net": [
-      "infoplease.com"
+      "skyrock.com"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
-    ],
-    "smi2.net": [
-      "rbc.ru"
     ],
     "smi2.ru": [
       "rbc.ru"
@@ -7344,30 +8982,15 @@
       "si.edu",
       "smithsonianmag.com"
     ],
-    "smyte.com": [
-      "indiegogo.com",
-      "zendesk.com"
-    ],
     "snapchat.com": [
-      "jimdo.com",
-      "overstock.com",
-      "complex.com",
       "wsj.com",
-      "redbubble.com",
-      "zappos.com"
-    ],
-    "snapwidget.com": [
-      "udel.edu"
-    ],
-    "snplow.net": [
-      "wetransfer.com"
+      "giphy.com",
+      "walmart.com"
     ],
     "so.com": [
       "360.cn"
     ],
     "socdm.com": [
-      "rakuten.co.jp",
-      "biglobe.ne.jp",
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
@@ -7378,71 +9001,31 @@
     "soflopxl.com": [
       "howstuffworks.com"
     ],
-    "softonic-analytics.net": [
-      "softonic.com"
-    ],
     "sogou.com": [
-      "soso.com"
-    ],
-    "sohu.com": [
       "ifeng.com",
-      "ctrip.com",
-      "focus.cn"
-    ],
-    "sojern.com": [
-      "ihg.com",
-      "hyatt.com",
-      "gopro.com"
+      "soso.com"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
-    "soliditet.se": [
-      "jalbum.net"
-    ],
-    "solocpm.com": [
-      "edx.org"
-    ],
     "sonobi.com": [
-      "photobucket.com",
-      "deviantart.com",
-      "springer.com",
       "myspace.com",
-      "home.pl",
-      "detroitnews.com"
-    ],
-    "sonyentertainmentnetwork.com": [
-      "playstation.com"
+      "cnet.com",
+      "usatoday.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
-      "spiegel.de",
       "bmj.com",
+      "ea.com",
       "mo.gov"
-    ],
-    "sourceforge.net": [
-      "libpng.org"
-    ],
-    "sp.global.ssl.fastly.net": [
-      "theglobeandmail.com"
-    ],
-    "spectate.com": [
-      "emory.edu"
     ],
     "sphereup.com": [
       "jpost.com"
     ],
     "spiceworks.com": [
-      "cloudflare.com",
-      "symantec.com",
-      "sophos.com",
-      "hp.com"
-    ],
-    "spineuniverse.com": [
-      "psychcentral.com"
-    ],
-    "spingo.com": [
-      "detroitnews.com"
+      "hp.com",
+      "slack.com",
+      "sophos.com"
     ],
     "sportz.io": [
       "gulfnews.com"
@@ -7451,18 +9034,13 @@
       "engadget.com",
       "denverpost.com"
     ],
-    "spotify.com": [
-      "oregonstate.edu"
-    ],
     "spots.im": [
       "denverpost.com"
     ],
     "spotxchange.com": [
-      "amazon.com",
-      "dropbox.com",
+      "imdb.com",
       "dailymotion.com",
-      "express.co.uk",
-      "bostonherald.com"
+      "npr.org"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -7470,246 +9048,144 @@
     ],
     "springernature.com": [
       "nature.com",
-      "biomedcentral.com",
-      "springer.com"
+      "springer.com",
+      "biomedcentral.com"
     ],
     "springserve.com": [
-      "tinypic.com",
-      "liveuamap.com",
-      "magento.com"
+      "tinypic.com"
     ],
-    "sprinklr.com": [
-      "autodesk.com"
+    "springserve.net": [
+      "tinypic.com"
     ],
     "srx.com.sg": [
       "straitstimes.com"
     ],
     "stackadapt.com": [
-      "thehill.com",
-      "farfetch.com",
-      "threadless.com"
-    ],
-    "staples-sparx.com": [
-      "staples.com"
-    ],
-    "staples-static.com": [
-      "staples.com"
-    ],
-    "starfieldtech.com": [
-      "scamnumbers.info"
+      "shopify.com",
+      "farfetch.com"
     ],
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org",
-      "cbslocal.com",
-      "zerohedge.com"
-    ],
-    "staticimgfarm.com": [
-      "excite.com"
-    ],
-    "staybridge.com": [
-      "ihg.com"
+      "freepik.com"
     ],
     "steelhousemedia.com": [
-      "prezi.com",
       "wpengine.com",
-      "istockphoto.com",
-      "newegg.com",
-      "careerbuilder.com"
-    ],
-    "steepto.com": [
-      "liveleak.com"
+      "prezi.com",
+      "gettyimages.com"
     ],
     "stg-sp.global.ssl.fastly.net": [
       "theglobeandmail.com"
     ],
-    "stg8.com": [
-      "sina.com.cn"
-    ],
     "stickyadstv.com": [
-      "bloomberg.com",
       "dailymotion.com",
-      "feedburner.com"
+      "discovery.com",
+      "thinkgeek.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
     ],
     "storygize.net": [
-      "autodesk.com",
-      "squareup.com",
-      "dn.ua"
-    ],
-    "streem.com.au": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "streetscout.com": [
-      "azcentral.com"
+      "squareup.com"
     ],
     "stripe.com": [
-      "iconfinder.com",
+      "smashballoon.com",
       "presscustomizr.com",
       "themezee.com",
-      "feedly.com",
       "documentcloud.org"
     ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com",
-      "sitepoint.com",
-      "makezine.com"
+      "studiopress.com"
     ],
     "sundaysky.com": [
-      "overstock.com",
-      "alternet.org",
-      "infoplease.com",
+      "fiverr.com",
+      "jpost.com",
       "dailydot.com"
     ],
     "suning.com": [
       "qq.com",
-      "ifeng.com",
-      "sohu.com"
-    ],
-    "sunrtb.com": [
-      "yesky.com"
+      "ifeng.com"
     ],
     "supplyframe.com": [
-      "ti.com",
-      "arduino.cc"
+      "arduino.cc",
+      "ti.com"
     ],
     "survata.com": [
       "tripadvisor.com"
     ],
     "surveymonkey.com": [
       "cambridge.org",
-      "investopedia.com",
-      "foreignpolicy.com",
-      "iop.org"
+      "iop.org",
+      "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
-      "metacafe.com",
-      "indianexpress.com",
-      "springer.com",
       "thehindu.com"
     ],
     "symantec.com": [
-      "norton.com",
-      "opinionlab.com"
-    ],
-    "synacor.com": [
-      "att.net"
+      "norton.com"
     ],
     "taboola.com": [
       "weebly.com",
-      "dropbox.com",
-      "t-online.de",
       "msn.com",
-      "ajc.com",
-      "infoplease.com"
+      "wsj.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
     ],
-    "tag4arm.com": [
-      "norton.com"
-    ],
-    "tagdelivery.com": [
-      "overstock.com"
-    ],
     "tailtarget.com": [
-      "uol.com.br"
+      "uol.com.br",
+      "variety.com"
     ],
     "tamgrt.com": [
       "tripadvisor.com",
       "hotels.com"
     ],
     "tanx.com": [
-      "sina.com.cn",
-      "alibaba.com",
+      "sohu.com",
       "ifeng.com",
-      "tmall.com",
-      "2345.com"
+      "tmall.com"
     ],
     "taobao.com": [
       "sina.com.cn",
-      "1688.com",
-      "tmall.com",
       "alibaba.com",
-      "2345.com"
+      "tmall.com"
     ],
     "tapad.com": [
-      "adobe.com",
-      "yahoo.com",
-      "soundcloud.com",
-      "dropbox.com",
-      "globalnews.ca",
-      "networksolutions.com"
-    ],
-    "targetimg1.com": [
-      "target.com"
+      "tinyurl.com",
+      "wsj.com",
+      "paypal.com"
     ],
     "tawk.to": [
       "cba.pl"
     ],
-    "tcell.io": [
-      "sophos.com"
-    ],
-    "teads.tv": [
-      "alternet.org",
-      "networksolutions.com"
+    "taylorandfrancis.com": [
+      "tandfonline.com"
     ],
     "tealiumiq.com": [
       "ibm.com",
-      "cbsnews.com",
-      "evernote.com",
       "cnet.com",
-      "ancestry.com",
-      "usmagazine.com"
-    ],
-    "technolutions.net": [
-      "illinois.edu",
-      "upenn.edu",
-      "uci.edu"
+      "samsung.com"
     ],
     "techweb.com": [
       "informationweek.com"
     ],
     "teenvogue.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
-    ],
-    "telegraph.co.uk": [
-      "wordpress.com"
-    ],
-    "telekom.de": [
-      "t-online.de"
-    ],
-    "tenmax.io": [
-      "biglobe.ne.jp"
     ],
     "theadex.com": [
       "t-online.de",
-      "gnu.org",
       "spiegel.de",
-      "focus.de"
-    ],
-    "theatlas.com": [
-      "qz.com"
+      "sueddeutsche.de"
     ],
     "thebrighttag.com": [
       "netflix.com",
-      "wufoo.com",
       "playstation.com",
-      "zappos.com"
-    ],
-    "thecut.com": [
-      "nymag.com"
+      "washingtontimes.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -7717,50 +9193,35 @@
     "theguardian.com": [
       "videojs.com"
     ],
-    "thesaurus.com": [
-      "dictionary.com"
+    "thrtle.com": [
+      "sourceforge.net"
     ],
-    "thomsonreuters.com": [
-      "reuters.com"
+    "tianqi.com": [
+      "qianlong.com"
     ],
     "tidaltv.com": [
-      "dailymotion.com",
-      "nationalgeographic.com",
-      "xfinity.com"
+      "dailymotion.com"
     ],
     "tidelinedata.io": [
       "deviantart.com"
     ],
     "timecommerce.net": [
-      "fortune.com",
-      "people.com",
-      "ew.com",
       "time.com",
-      "allrecipes.com"
+      "fortune.com",
+      "people.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
     ],
     "tinypass.com": [
-      "businessinsider.com",
-      "techcrunch.com",
-      "kickstarter.com",
       "bloomberg.com",
-      "thenation.com",
-      "gizmodo.com"
+      "businessinsider.com",
+      "techcrunch.com"
     ],
     "tiqcdn.com": [
-      "cisco.com",
-      "nbcnews.com",
-      "ibm.com",
       "wsj.com",
-      "hpe.com",
-      "orange.fr",
-      "francetvinfo.fr"
-    ],
-    "tl813.com": [
-      "panasonic.com",
-      "squareup.com"
+      "cisco.com",
+      "marketwatch.com"
     ],
     "tm-awx.com": [
       "mirror.co.uk"
@@ -7769,45 +9230,21 @@
       "taobao.com"
     ],
     "tns-counter.ru": [
-      "livejournal.com",
       "vk.com",
-      "yandex.ru",
-      "mail.ru",
-      "ria.ru",
-      "radikal.ru"
+      "livejournal.com",
+      "yandex.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
     ],
-    "tracc.it": [
-      "france24.com",
-      "rfi.fr"
-    ],
-    "trackad.cz": [
-      "idnes.cz"
-    ],
-    "trackalyzer.com": [
-      "squareup.com"
-    ],
-    "tradedoubler.com": [
-      "lemonde.fr",
-      "interia.pl"
-    ],
     "tradelab.fr": [
-      "eklablog.com",
-      "leparisien.fr"
-    ],
-    "traffic-media.co": [
-      "radikal.ru"
-    ],
-    "trafficgate.net": [
-      "rakuten.co.jp"
-    ],
-    "trafficjam.cn": [
-      "youku.com"
+      "eklablog.com"
     ],
     "trafficjunky.net": [
       "pornhub.com"
+    ],
+    "travelsmarter.net": [
+      "tripadvisor.com"
     ],
     "travelzoo.com": [
       "philly.com"
@@ -7815,30 +9252,24 @@
     "trb.com": [
       "latimes.com",
       "chicagotribune.com",
-      "nydailynews.com"
+      "baltimoresun.com"
     ],
     "treasuredata.com": [
-      "biglobe.ne.jp",
-      "nintendo.com",
-      "exblog.jp"
-    ],
-    "tremorhub.com": [
-      "usatoday.com",
-      "azcentral.com",
-      "freep.com",
-      "detroitnews.com"
+      "exblog.jp",
+      "hatena.ne.jp",
+      "nintendo.com"
     ],
     "tribalfusion.com": [
       "dailymotion.com",
-      "pastebin.com",
-      "liveleak.com",
-      "usatoday.com",
-      "thehindu.com"
+      "marriott.com",
+      "pastebin.com"
     ],
     "tribl.io": [
-      "prezi.com",
-      "zimbra.com",
-      "prnewswire.com"
+      "prnewswire.com",
+      "zimbra.com"
+    ],
+    "triblive.com": [
+      "bleacherreport.com"
     ],
     "tripadvisor.com": [
       "accorhotels.com"
@@ -7846,106 +9277,66 @@
     "tronc.com": [
       "latimes.com",
       "chicagotribune.com",
-      "nydailynews.com"
+      "baltimoresun.com"
     ],
     "trumba.com": [
       "ucdavis.edu",
-      "utah.edu",
       "emory.edu"
     ],
     "truoptik.com": [
-      "slashdot.org",
-      "infoplease.com"
+      "slashdot.org"
     ],
     "trustarc.com": [
       "skynet.be"
     ],
-    "trustev.com": [
-      "lenovo.com"
-    ],
     "trustpilot.com": [
-      "jalbum.net",
-      "avira.com",
-      "moonfruit.com"
-    ],
-    "trvl-px.com": [
-      "hotels.com",
-      "expedia.com"
-    ],
-    "tumblr.com": [
-      "dailydot.com"
+      "jalbum.net"
     ],
     "turn.com": [
-      "bloomberg.com",
-      "wired.com",
-      "webmd.com",
+      "forbes.com",
       "hp.com",
-      "gq.com",
-      "pitchfork.com"
+      "wired.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
     ],
     "tvsquared.com": [
-      "telegraph.co.uk",
+      "wsj.com",
       "jimdo.com",
-      "squarespace.com",
-      "economist.com"
+      "squarespace.com"
     ],
     "twimg.com": [
       "coe.int",
-      "ey.com",
       "dol.gov"
     ],
     "twitter.com": [
       "wordpress.org",
-      "yahoo.com",
-      "chicagotribune.com",
       "nytimes.com",
-      "cnn.com",
-      "msn.com",
-      "haaretz.com",
-      "medicinenet.com",
-      "lexisnexis.com",
-      "edmunds.com"
+      "dropbox.com"
     ],
     "tynt.com": [
-      "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com",
-      "dailycaller.com"
+      "accuweather.com",
+      "washingtontimes.com"
     ],
-    "ubi.com": [
-      "ubisoft.com"
+    "uc.se": [
+      "jalbum.net"
     ],
     "uciservice.com": [
-      "hotels.com",
-      "expedia.com"
+      "hotels.com"
     ],
     "ucoz.net": [
       "narod.ru"
     ],
     "udmserve.net": [
-      "colourlovers.com",
-      "dailydot.com",
       "washingtonexaminer.com"
-    ],
-    "udnfunlife.com": [
-      "udn.com"
-    ],
-    "uefa.com": [
-      "bleacherreport.com"
-    ],
-    "ufpcdn.com": [
-      "brothersoft.com"
     ],
     "ugdturner.com": [
       "cnn.com",
       "nba.com"
     ],
     "undertone.com": [
-      "dallasnews.com",
-      "alternet.org"
+      "dallasnews.com"
     ],
     "unicc.org": [
       "ohchr.org"
@@ -7955,42 +9346,24 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "earthlink.net",
-      "boingboing.net"
-    ],
-    "upravel.com": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
+      "boingboing.net",
+      "bell-labs.com"
     ],
     "upsellit.com": [
       "samsung.com",
-      "garmin.com",
       "motorola.com"
-    ],
-    "uptolike.com": [
-      "live4fun.ru"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
     ],
     "usa.gov": [
-      "transportation.gov",
-      "dhs.gov",
-      "usembassy.gov"
-    ],
-    "useproof.com": [
-      "iconosquare.com"
+      "transportation.gov"
     ],
     "usergram.info": [
       "ocn.ne.jp"
     ],
-    "userreport.com": [
-      "scotsman.com"
-    ],
     "uservoice.com": [
-      "scoop.it",
-      "theknot.com"
+      "scoop.it"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -7999,93 +9372,65 @@
       "radikal.ru"
     ],
     "utarget.ru": [
-      "radikal.ru",
-      "diary.ru"
+      "radikal.ru"
     ],
     "uuidksinc.net": [
-      "radikal.ru",
-      "diary.ru"
+      "radikal.ru"
     ],
-    "v12group.com": [
-      "tinyurl.com",
-      "shopko.com"
+    "v-biz.com.ua": [
+      "novostimira.com"
     ],
     "vanityfair.com": [
       "wired.com",
-      "newyorker.com",
       "vogue.com",
-      "gq.com",
       "pitchfork.com"
     ],
     "veinteractive.com": [
-      "prweb.com",
-      "logitech.com",
-      "wnd.com"
+      "prweb.com"
     ],
     "velaro.com": [
-      "lg.com",
-      "eff.org"
-    ],
-    "velemh.com": [
-      "liveuamap.com"
-    ],
-    "verticalhealth.net": [
-      "psychcentral.com"
-    ],
-    "veruta.com": [
-      "shopko.com"
+      "lg.com"
     ],
     "viafoura.co": [
       "cbc.ca",
-      "columbia.edu",
       "nj.com",
-      "nola.com"
+      "irishtimes.com"
+    ],
+    "viafoura.com": [
+      "irishtimes.com"
     ],
     "viafoura.net": [
       "cbc.ca"
     ],
-    "videoamp.com": [
-      "hpe.com"
-    ],
     "videohub.tv": [
-      "liveuamap.com",
       "wsj.com",
-      "uci.edu"
+      "bloomberg.com"
     ],
     "vidible.tv": [
+      "huffingtonpost.com",
       "aol.com",
-      "nydailynews.com",
-      "autoblog.com",
-      "techcrunch.com"
+      "autoblog.com"
     ],
     "viglink.com": [
-      "zdnet.com",
-      "softonic.com",
-      "techrepublic.com",
       "cnet.com",
-      "dailycaller.com"
+      "zdnet.com",
+      "thedailybeast.com"
     ],
     "vilynx.com": [
+      "cbsnews.com",
       "nbcnews.com",
-      "olympic.org",
-      "tmz.com"
+      "olympic.org"
     ],
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "livestream.com",
       "wufoo.com",
-      "heroku.com",
-      "emarketer.com",
-      "designboom.com"
+      "oclc.org"
     ],
     "vindicosuite.com": [
       "myspace.com",
-      "fortune.com",
-      "people.com",
       "time.com",
-      "allrecipes.com",
-      "zappos.com"
+      "fortune.com"
     ],
     "virgilio.it": [
       "libero.it"
@@ -8093,67 +9438,38 @@
     "visualstudio.com": [
       "microsoft.com"
     ],
-    "vizury.com": [
-      "dreamstime.com"
-    ],
     "vk.com": [
-      "rt.com",
-      "templatemonster.com",
-      "ria.ru",
       "yandex.ru",
-      "sonymobile.com"
-    ],
-    "vmmpxl.com": [
-      "networksolutions.com"
+      "rt.com",
+      "ria.ru"
     ],
     "vogue.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
       "pitchfork.com"
-    ],
-    "volvelle.tech": [
-      "prweb.com",
-      "logitech.com"
     ],
     "voxmedia.com": [
       "theverge.com",
       "vox.com",
       "recode.net",
-      "sbnation.com",
       "polygon.com"
     ],
-    "vtracy.de": [
-      "bloomberg.com"
-    ],
-    "vulture.com": [
-      "nymag.com"
-    ],
     "w55c.net": [
-      "hpe.com",
-      "ebay.com",
-      "sourceforge.net",
-      "hp.com"
+      "forbes.com",
+      "hp.com",
+      "businessinsider.com"
+    ],
+    "wal.co": [
+      "walmart.com"
     ],
     "wallst.com": [
       "reuters.com"
     ],
-    "walmartimages.com": [
-      "walmart.com"
-    ],
-    "waptime.cn": [
-      "tianqi.com"
-    ],
-    "warnerbros.com": [
-      "tmz.com"
-    ],
     "wbtrk.net": [
-      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
     "wcfbc.net": [
+      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
@@ -8167,7 +9483,6 @@
     "weborama.fr": [
       "lemonde.fr",
       "rbc.ru",
-      "lexpress.fr",
       "leparisien.fr"
     ],
     "webpush.jp": [
@@ -8181,23 +9496,17 @@
       "freewebs.com"
     ],
     "webspectator.com": [
-      "goal.com",
-      "guinnessworldrecords.com"
+      "goal.com"
     ],
     "webtrekk.net": [
       "springer.com",
-      "localiser-ip.com",
-      "welt.de",
+      "repubblica.it",
       "goethe.de"
     ],
     "webtrendslive.com": [
-      "nature.com",
       "abc.net.au",
       "oup.com",
-      "dhl.com"
-    ],
-    "webvisor.org": [
-      "kharkov.ua"
+      "ethz.ch"
     ],
     "weibo.com": [
       "sina.com.cn"
@@ -8214,36 +9523,24 @@
     "wikimedia.org": [
       "wikipedia.org",
       "wiktionary.org",
-      "mediawiki.org",
-      "wikisource.org",
-      "wikibooks.org"
+      "wikisource.org"
     ],
     "wired.com": [
-      "newyorker.com",
-      "vanityfair.com",
       "vogue.com",
-      "gq.com",
       "pitchfork.com"
-    ],
-    "wise.space": [
-      "purevolume.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
-      "canada.com",
       "globalnews.ca",
-      "bostonherald.com"
+      "vancouversun.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
     ],
-    "wishpond.net": [
-      "discovermagazine.com"
-    ],
     "wistia.com": [
-      "zendesk.com",
       "typeform.com",
+      "buffer.com",
       "photoshelter.com"
     ],
     "wistia.net": [
@@ -8253,20 +9550,16 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "upwork.com",
-      "zappos.com",
-      "redbubble.com"
+      "redbubble.com",
+      "upwork.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "wnyc.org": [
-      "newyorker.com",
-      "qq.com"
+      "newyorker.com"
     ],
     "wolfram.com": [
       "wolframalpha.com"
@@ -8275,256 +9568,146 @@
       "tinypic.com"
     ],
     "woopic.com": [
-      "orange.fr",
-      "2345.com"
+      "orange.fr"
     ],
     "wordpress.com": [
       "time.com",
-      "prnewswire.com",
-      "cbslocal.com",
       "fortune.com",
-      "akismet.com",
-      "nypost.com",
-      "news.com.au",
-      "variety.com"
+      "akismet.com"
     ],
     "wrating.com": [
-      "163.com",
       "jrj.com.cn",
       "weather.com.cn"
     ],
-    "wsj.com": [
+    "wsj.net": [
+      "wsj.com",
       "marketwatch.com"
     ],
-    "wsj.net": [
-      "marketwatch.com",
-      "sfgate.com",
-      "wsj.com"
-    ],
     "wsod.com": [
-      "seekingalpha.com",
       "zerohedge.com"
     ],
     "wt-eu02.net": [
-      "virgilio.it",
-      "libero.it"
-    ],
-    "wurfl.io": [
-      "dw.com",
-      "bartleby.com"
-    ],
-    "wywyuserservice.com": [
-      "vmware.com"
+      "libero.it",
+      "virgilio.it"
     ],
     "xad.com": [
       "vt.edu"
     ],
-    "xg4ken.com": [
-      "bluehost.com",
-      "redbubble.com"
-    ],
-    "xinhuanet.com": [
-      "news.cn"
-    ],
     "xiti.com": [
       "lemonde.fr",
-      "unblog.fr",
-      "uefa.com",
       "skyrock.com",
-      "ovh.com",
-      "leparisien.fr"
+      "faz.net"
     ],
     "xlisting.jp": [
-      "rakuten.co.jp",
-      "biglobe.ne.jp",
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
     "xplosion.de": [
-      "t-online.de",
       "spiegel.de",
-      "faz.net",
-      "focus.de"
+      "sueddeutsche.de",
+      "zeit.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
     ],
-    "xxxlutz.de": [
-      "t-online.de"
-    ],
     "yadro.ru": [
       "vk.com",
-      "novostimira.com",
       "mail.ru",
-      "narod.ru",
-      "ria.ru",
-      "radikal.ru"
+      "rt.com"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
-      "exblog.jp",
-      "rakuten.co.jp",
       "economist.com",
-      "ocn.ne.jp"
+      "exblog.jp"
     ],
     "yahoo.com": [
-      "amazon.com",
       "vimeo.com",
-      "flickr.com",
-      "sourceforge.net",
-      "ancestry.com",
-      "eset.com"
+      "tumblr.com",
+      "flickr.com"
     ],
     "yandex.ru": [
-      "livejournal.com",
       "opera.com",
-      "stanford.edu",
-      "ning.com",
-      "ria.ru",
-      "qip.ru",
-      "radikal.ru",
-      "kharkov.ua"
-    ],
-    "yandex.ua": [
-      "kharkov.ua",
-      "kh.ua"
+      "livejournal.com",
+      "ning.com"
     ],
     "yastatic.net": [
-      "qip.ru",
-      "tass.ru",
-      "radikal.ru"
-    ],
-    "yieldify.com": [
-      "logitech.com"
+      "liveinternet.ru",
+      "sputniknews.com",
+      "ria.ru"
     ],
     "yieldlab.net": [
-      "spiegel.de",
-      "heise.de",
-      "faz.net",
+      "t-online.de",
       "springer.com",
-      "home.pl",
-      "focus.de"
+      "spiegel.de"
     ],
     "yieldoptimizer.com": [
-      "ihg.com",
-      "hyatt.com",
-      "philly.com"
+      "philly.com",
+      "groupon.com"
     ],
     "yimg.com": [
-      "yahoo.com",
       "flickr.com",
       "nytimes.com",
-      "dropbox.com",
-      "iop.org",
-      "cnet.com",
-      "sbs.com.au",
-      "eset.com"
+      "dropbox.com"
     ],
     "yldbt.com": [
-      "wired.com",
-      "arstechnica.com",
-      "newyorker.com",
-      "pcworld.com",
-      "infoworld.com"
-    ],
-    "ymetrica1.com": [
-      "kharkov.ua",
-      "kh.ua",
-      "ucoz.ru"
-    ],
-    "yoox.it": [
-      "net-a-porter.com"
-    ],
-    "yotpo.com": [
-      "gopro.com"
+      "biography.com",
+      "freep.com",
+      "jsonline.com"
     ],
     "youtube-nocookie.com": [
-      "epa.gov",
       "moodle.org",
       "popsci.com",
       "uscourts.gov"
     ],
     "youtube.com": [
-      "vimeo.com",
       "google.com",
-      "godaddy.com",
+      "mozilla.org",
       "nih.gov",
-      "telegraph.co.uk",
-      "caltech.edu",
-      "ucr.edu",
-      "onet.pl",
       "honeywell.com"
     ],
     "youvisit.com": [
       "osu.edu",
-      "oregonstate.edu",
       "fsu.edu"
     ],
     "ypcdn.com": [
       "yellowpages.com"
     ],
-    "yudu.co.nz": [
-      "nzherald.co.nz"
-    ],
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com",
-      "everydayhealth.com"
+      "ign.com"
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com",
-      "infoplease.com"
+      "thehindu.com"
     ],
     "zemanta.com": [
-      "independent.co.uk",
-      "thehill.com",
-      "farfetch.com",
-      "paypal.com",
-      "orange.fr",
-      "infoplease.com"
-    ],
-    "zendesk.com": [
-      "jugem.jp",
-      "in.gov",
-      "hobbyking.com"
+      "variety.com",
+      "lemonde.fr",
+      "standard.co.uk"
     ],
     "zergnet.com": [
       "imdb.com",
-      "pcmag.com",
-      "rollingstone.com",
-      "marketwatch.com"
-    ],
-    "zhaopin.cn": [
-      "zhaopin.com"
-    ],
-    "zhiziyun.com": [
-      "ctrip.com"
+      "marketwatch.com",
+      "weather.com"
     ],
     "zidtech.com": [
       "coindesk.com"
     ],
     "ziffdavis.com": [
-      "ign.com",
       "extremetech.com"
     ],
-    "zoho.com": [
-      "zoho.in"
-    ],
-    "zohopublic.com": [
-      "zoho.com"
-    ],
     "zoomph.com": [
-      "udel.edu",
-      "biglobe.ne.jp",
       "uga.edu"
     ],
     "zprk.io": [
       "news.com.au",
       "theaustralian.com.au",
       "heraldsun.com.au"
+    ],
+    "zynbit.com": [
+      "parallels.com"
     ]
   },
-  "version": "2018.8.27"
+  "version": "2018.9.26"
 }

--- a/results-prev.json
+++ b/results-prev.json
@@ -3,7 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598197544,
+      "nextUpdateTime": 1535788795191,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,31 +27,31 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535671078852,
+      "nextUpdateTime": 1535401551141,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535760970927,
+      "nextUpdateTime": 1535675926040,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477982326,
+      "nextUpdateTime": 1535526413536,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535520902504,
+      "nextUpdateTime": 1535446296434,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535508988871,
+      "nextUpdateTime": 1535464900319,
       "userAction": ""
     },
     "2o7.net": {
@@ -69,157 +69,163 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535388856176,
+      "nextUpdateTime": 1535761492828,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535492182388,
+      "nextUpdateTime": 1535388823758,
       "userAction": ""
     },
     "4303900.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535709815906,
+      "nextUpdateTime": 1535478816612,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535690936934,
+      "nextUpdateTime": 1535759188077,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535282712221,
+      "nextUpdateTime": 1535688182526,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535642991767,
+      "nextUpdateTime": 1535386344298,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526803320,
+      "nextUpdateTime": 1535654852731,
       "userAction": ""
     },
     "516-dgm-318.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535662787551,
+      "nextUpdateTime": 1535777195298,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535488582093,
+      "nextUpdateTime": 1535469873107,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535328095043,
+      "nextUpdateTime": 1535673581756,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535323766046,
+      "nextUpdateTime": 1535389517664,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535614886406,
+      "nextUpdateTime": 1535862929541,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535360379630,
+      "nextUpdateTime": 1535450680018,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535440566618,
+      "nextUpdateTime": 1535699002706,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535299551431,
+      "nextUpdateTime": 1535735755008,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315581112,
+      "nextUpdateTime": 1535856801759,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535376693594,
+      "nextUpdateTime": 1535737606634,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535719315712,
+      "nextUpdateTime": 1535694525374,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535589740320,
+      "nextUpdateTime": 1535541776370,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535470877593,
+      "nextUpdateTime": 1535586462406,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535702667567,
+      "nextUpdateTime": 1535692286771,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535724954686,
+      "nextUpdateTime": 1535584735036,
+      "userAction": ""
+    },
+    "a6264210458.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535775205652,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535483154043,
+      "nextUpdateTime": 1535709114205,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535780115828,
+      "nextUpdateTime": 1535877883165,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535779559578,
+      "nextUpdateTime": 1535710239051,
       "userAction": ""
     },
     "aax.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535412607145,
+      "nextUpdateTime": 1535526366481,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -231,13 +237,13 @@
     "accounts.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434218229,
+      "nextUpdateTime": 1535397748018,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535660982750,
+      "nextUpdateTime": 1535499002047,
       "userAction": ""
     },
     "acpm.fr": {
@@ -249,37 +255,37 @@
     "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535490888501,
+      "nextUpdateTime": 1535492709945,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535404713512,
+      "nextUpdateTime": 1535703175969,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535641831031,
-      "userAction": ""
-    },
-    "ad-score.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535624113348,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535379331728,
+      "nextUpdateTime": 1535795181462,
+      "userAction": ""
+    },
+    "ad.turn.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535645779490,
       "userAction": ""
     },
     "ad.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535307543537,
+      "nextUpdateTime": 1535465359379,
       "userAction": ""
     },
     "addthis.com": {
@@ -315,7 +321,7 @@
     "ado.pro-market.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535527859438,
+      "nextUpdateTime": 1535496181306,
       "userAction": ""
     },
     "adroll.com": {
@@ -324,46 +330,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ads.creative-serving.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535547437788,
+      "userAction": ""
+    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445477120,
+      "nextUpdateTime": 1535622785616,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585934820,
-      "userAction": ""
-    },
-    "ads.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535744320295,
+      "nextUpdateTime": 1535644312504,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535694008167,
+      "nextUpdateTime": 1535374198969,
+      "userAction": ""
+    },
+    "ads.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535698534424,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535577473176,
+      "nextUpdateTime": 1535762468415,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711402958,
+      "nextUpdateTime": 1535801173589,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535726386777,
+      "nextUpdateTime": 1535805192169,
       "userAction": ""
     },
     "adsnative.com": {
@@ -398,8 +410,8 @@
     },
     "aimfar.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535609624527,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535411075710,
       "userAction": ""
     },
     "allure.com": {
@@ -423,31 +435,31 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535691963120,
+      "nextUpdateTime": 1535875271545,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535516989467,
+      "nextUpdateTime": 1535627226385,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535284316576,
+      "nextUpdateTime": 1535453996514,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535285639223,
+      "nextUpdateTime": 1535666267445,
       "userAction": ""
     },
     "analytics.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535540660259,
+      "nextUpdateTime": 1535406703135,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -459,67 +471,61 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535751809759,
+      "nextUpdateTime": 1535677918307,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535472792249,
+      "nextUpdateTime": 1535404214200,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535501927149,
-      "userAction": ""
-    },
-    "api-public.addthis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535762945972,
+      "nextUpdateTime": 1535728889831,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535704572492,
+      "nextUpdateTime": 1535824772269,
       "userAction": ""
     },
     "api.adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535558537040,
+      "nextUpdateTime": 1535869432705,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535711849116,
+      "nextUpdateTime": 1535382298584,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535630848647,
+      "nextUpdateTime": 1535785037169,
       "userAction": ""
     },
     "api.nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535780608617,
+      "nextUpdateTime": 1535718185775,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535442958777,
+      "nextUpdateTime": 1535527024950,
       "userAction": ""
     },
     "api.viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535461454234,
+      "nextUpdateTime": 1535637161762,
       "userAction": ""
     },
     "apis.google.com": {
@@ -531,7 +537,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535346277488,
+      "nextUpdateTime": 1535495358983,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -543,7 +549,7 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535661299224,
+      "nextUpdateTime": 1535541366255,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -555,49 +561,49 @@
     "au.audience.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535726850586,
+      "nextUpdateTime": 1535814559640,
       "userAction": ""
     },
     "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535553365774,
+      "nextUpdateTime": 1535677376528,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469524850,
+      "nextUpdateTime": 1535872214563,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535654763789,
+      "nextUpdateTime": 1535424935792,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535637344742,
+      "nextUpdateTime": 1535376045654,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535524792139,
+      "nextUpdateTime": 1535517044616,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535726960200,
+      "nextUpdateTime": 1535856575288,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535432389781,
+      "nextUpdateTime": 1535852563130,
       "userAction": ""
     },
     "bfmio.com": {
@@ -609,19 +615,19 @@
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535784224054,
+      "nextUpdateTime": 1535415374852,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535573293865,
+      "nextUpdateTime": 1535474628495,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535551251160,
+      "nextUpdateTime": 1535431025536,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -669,7 +675,7 @@
     "boxinc.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535478347303,
+      "nextUpdateTime": 1535712697947,
       "userAction": ""
     },
     "brides.com": {
@@ -681,61 +687,61 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535315840766,
+      "nextUpdateTime": 1535842806454,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535306900694,
+      "nextUpdateTime": 1535399016694,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535302383139,
+      "nextUpdateTime": 1535736023435,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535392133905,
+      "nextUpdateTime": 1535782500293,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503302723,
+      "nextUpdateTime": 1535392363633,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535412362928,
+      "nextUpdateTime": 1535786966647,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584173633,
+      "nextUpdateTime": 1535852907247,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535597776860,
+      "nextUpdateTime": 1535445294990,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535690141366,
+      "nextUpdateTime": 1535750341028,
       "userAction": ""
     },
     "cache.vindicosuite.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535279594967,
+      "nextUpdateTime": 1535798036507,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -747,13 +753,13 @@
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535327513388,
+      "nextUpdateTime": 1535524141208,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535568142694,
+      "nextUpdateTime": 1535434052072,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -765,37 +771,31 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517244578,
+      "nextUpdateTime": 1535430074265,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517807139,
+      "nextUpdateTime": 1535636853472,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535755634406,
-      "userAction": ""
-    },
-    "cdn.inquisitr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535779331445,
+      "nextUpdateTime": 1535554773399,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535713763814,
+      "nextUpdateTime": 1535689602008,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535528231483,
+      "nextUpdateTime": 1535464365388,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -807,31 +807,31 @@
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560444094,
+      "nextUpdateTime": 1535592534219,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535368051541,
+      "nextUpdateTime": 1535840819214,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535608113749,
+      "nextUpdateTime": 1535447686266,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535644505799,
+      "nextUpdateTime": 1535589550351,
       "userAction": ""
     },
     "cdns.gigya.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535455708662,
+      "nextUpdateTime": 1535647245640,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -843,7 +843,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535567467824,
+      "nextUpdateTime": 1535574432947,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -861,13 +861,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535483839903,
+      "nextUpdateTime": 1535663337899,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535365976800,
+      "nextUpdateTime": 1535553091314,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -879,7 +879,7 @@
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535444044156,
+      "nextUpdateTime": 1535827604724,
       "userAction": ""
     },
     "company-target.com": {
@@ -891,7 +891,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535682892731,
+      "nextUpdateTime": 1535374260391,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -903,7 +903,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535296279568,
+      "nextUpdateTime": 1535847059054,
       "userAction": ""
     },
     "consensu.org": {
@@ -921,13 +921,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535506369860,
+      "nextUpdateTime": 1535761812068,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535701071745,
+      "nextUpdateTime": 1535878685866,
       "userAction": ""
     },
     "contextweb.com": {
@@ -939,12 +939,18 @@
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535424975290,
+      "nextUpdateTime": 1535679702748,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creative-serving.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -960,10 +966,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "csm2waycm-atl.netmng.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535410980550,
+      "userAction": ""
+    },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535762279418,
+      "nextUpdateTime": 1535439755325,
       "userAction": ""
     },
     "cxense.com": {
@@ -975,73 +987,67 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535342840522,
+      "nextUpdateTime": 1535430010745,
       "userAction": ""
     },
     "d.agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535565611927,
+      "nextUpdateTime": 1535878099411,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535713060726,
+      "nextUpdateTime": 1535631040531,
       "userAction": ""
     },
     "d.df-srv.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535364087304,
+      "nextUpdateTime": 1535827462928,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535674921575,
+      "nextUpdateTime": 1535848586849,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535487468755,
+      "nextUpdateTime": 1535668347467,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606881689,
-      "userAction": ""
-    },
-    "data.ad-score.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535303631043,
+      "nextUpdateTime": 1535504240917,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535379877739,
+      "nextUpdateTime": 1535749458146,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535357000518,
+      "nextUpdateTime": 1535454047672,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535668414319,
+      "nextUpdateTime": 1535863673793,
       "userAction": ""
     },
     "de.ioam.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535731438109,
+      "nextUpdateTime": 1535379626780,
       "userAction": ""
     },
     "deepintent.com": {
@@ -1083,19 +1089,19 @@
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535432116374,
+      "nextUpdateTime": 1535628369138,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535319875858,
+      "nextUpdateTime": 1535449581444,
       "userAction": ""
     },
     "districtm-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535721504755,
+      "nextUpdateTime": 1535854298539,
       "userAction": ""
     },
     "districtm.io": {
@@ -1107,7 +1113,7 @@
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535293970894,
+      "nextUpdateTime": 1535378721840,
       "userAction": ""
     },
     "docs.google.com": {
@@ -1131,7 +1137,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535778123280,
+      "nextUpdateTime": 1535831172248,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1143,19 +1149,13 @@
     "dsum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535544929225,
+      "nextUpdateTime": 1535678767436,
       "userAction": ""
     },
     "dsum.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535728636063,
-      "userAction": ""
-    },
-    "dxpmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535609816884,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1167,7 +1167,7 @@
     "eb2.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535569655087,
+      "nextUpdateTime": 1535722569370,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1179,7 +1179,7 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535525806664,
+      "nextUpdateTime": 1535753398903,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1203,19 +1203,19 @@
     "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535726564765,
+      "nextUpdateTime": 1535856865212,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399555453,
+      "nextUpdateTime": 1535641546461,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535428968914,
+      "nextUpdateTime": 1535653806247,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1227,7 +1227,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535403017484,
+      "nextUpdateTime": 1535738201505,
       "userAction": ""
     },
     "exelator.com": {
@@ -1239,7 +1239,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535646811319,
+      "nextUpdateTime": 1535558917724,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1250,7 +1250,7 @@
     },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1263,13 +1263,13 @@
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535725073044,
+      "nextUpdateTime": 1535510602994,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535696802415,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535503704591,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1293,13 +1293,13 @@
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535786271610,
+      "nextUpdateTime": 1535786137485,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535281885570,
+      "nextUpdateTime": 1535672050463,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1314,58 +1314,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "g.cn.miaozhen.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535453186928,
+      "userAction": ""
+    },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535692750885,
+      "nextUpdateTime": 1535882689211,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535691303682,
+      "nextUpdateTime": 1535656273590,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535691097103,
+      "nextUpdateTime": 1535727758035,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535545531677,
+      "nextUpdateTime": 1535797268646,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535587812182,
+      "nextUpdateTime": 1535705787427,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535649331173,
+      "nextUpdateTime": 1535540739730,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535491753062,
+      "nextUpdateTime": 1535730629382,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535307250586,
-      "userAction": ""
-    },
-    "geosync.solution.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535284522122,
+      "nextUpdateTime": 1535626747902,
       "userAction": ""
     },
     "gigya.com": {
@@ -1401,7 +1401,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535317462506,
+      "nextUpdateTime": 1535826656370,
       "userAction": ""
     },
     "gq.com": {
@@ -1413,7 +1413,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535648552872,
+      "nextUpdateTime": 1535759414387,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1425,19 +1425,19 @@
     "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535453629901,
+      "nextUpdateTime": 1535507099814,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535367472545,
+      "nextUpdateTime": 1535649797924,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535629285942,
+      "nextUpdateTime": 1535648232623,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1455,49 +1455,49 @@
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465563548,
+      "nextUpdateTime": 1535553980236,
       "userAction": ""
     },
     "hpr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535418833610,
+      "nextUpdateTime": 1535743743028,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535364247788,
+      "nextUpdateTime": 1535512774273,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535423720799,
+      "nextUpdateTime": 1535584943973,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418433351,
+      "nextUpdateTime": 1535787032117,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535791087893,
+      "nextUpdateTime": 1535513900580,
       "userAction": ""
     },
     "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535533568374,
+      "nextUpdateTime": 1535842083486,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535505218565,
+      "nextUpdateTime": 1535758065418,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1509,19 +1509,13 @@
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535334042860,
-      "userAction": ""
-    },
-    "inquisitr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535808038725,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535515823670,
+      "nextUpdateTime": 1535671726914,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -1533,7 +1527,7 @@
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535619321717,
+      "nextUpdateTime": 1535612904028,
       "userAction": ""
     },
     "intercom.io": {
@@ -1545,7 +1539,13 @@
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535538084696,
+      "nextUpdateTime": 1535735061426,
+      "userAction": ""
+    },
+    "io.narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535606837889,
       "userAction": ""
     },
     "ioam.de": {
@@ -1563,13 +1563,13 @@
     "ips-invite.iperceptions.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535461878087,
+      "nextUpdateTime": 1535375027028,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535692870860,
+      "nextUpdateTime": 1535770127897,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1668,12 +1668,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "live.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1689,61 +1683,49 @@
     "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535681411551,
+      "nextUpdateTime": 1535428983326,
       "userAction": ""
     },
     "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535321905319,
+      "nextUpdateTime": 1535568292353,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535566793461,
+      "nextUpdateTime": 1535748410763,
       "userAction": ""
     },
     "log.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418449649,
+      "nextUpdateTime": 1535370949838,
       "userAction": ""
     },
     "login-ds.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535561002865,
+      "nextUpdateTime": 1535825469673,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535755600759,
-      "userAction": ""
-    },
-    "login.live.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535388260240,
+      "nextUpdateTime": 1535874272649,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584230515,
+      "nextUpdateTime": 1535689077144,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535708708425,
-      "userAction": ""
-    },
-    "map.dxpmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535628695462,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535461732087,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1767,19 +1749,19 @@
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535652945157,
+      "nextUpdateTime": 1535538905152,
       "userAction": ""
     },
     "match.deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535460992471,
+      "nextUpdateTime": 1535666184280,
       "userAction": ""
     },
     "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535663791310,
+      "nextUpdateTime": 1535472065106,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1791,13 +1773,13 @@
     "mc.webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535286232291,
+      "nextUpdateTime": 1535487104791,
       "userAction": ""
     },
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535536846686,
+      "nextUpdateTime": 1535384523811,
       "userAction": ""
     },
     "media.net": {
@@ -1815,7 +1797,7 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535302299674,
+      "nextUpdateTime": 1535521562609,
       "userAction": ""
     },
     "mediarithmics.com": {
@@ -1824,16 +1806,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "messenger.live.com": {
+    "miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606263682,
+      "nextUpdateTime": 1535678969255,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1845,7 +1827,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535387249359,
+      "nextUpdateTime": 1535583104262,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1896,10 +1878,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535381874834,
+      "nextUpdateTime": 1535370153417,
+      "userAction": ""
+    },
+    "netmng.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newscgp.com": {
@@ -1911,7 +1905,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535311629687,
+      "nextUpdateTime": 1535570964190,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1923,13 +1917,13 @@
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535376489955,
+      "nextUpdateTime": 1535589900794,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418451285,
+      "nextUpdateTime": 1535639927435,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1941,7 +1935,7 @@
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535785645386,
+      "nextUpdateTime": 1535764787069,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -1971,7 +1965,7 @@
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535785571775,
+      "nextUpdateTime": 1535776170008,
       "userAction": ""
     },
     "optimizely.com": {
@@ -1995,43 +1989,43 @@
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535329796782,
+      "nextUpdateTime": 1535464989725,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535520890292,
+      "nextUpdateTime": 1535587202023,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389036499,
+      "nextUpdateTime": 1535753838397,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535511748310,
+      "nextUpdateTime": 1535599122136,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711083150,
+      "nextUpdateTime": 1535416241814,
       "userAction": ""
     },
     "p.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535505388228,
+      "nextUpdateTime": 1535444945040,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535641328780,
+      "nextUpdateTime": 1535521835134,
       "userAction": ""
     },
     "pardot.com": {
@@ -2049,19 +2043,19 @@
     "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535336231323,
+      "nextUpdateTime": 1535764673436,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535496198612,
+      "nextUpdateTime": 1535470402299,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535546381760,
+      "nextUpdateTime": 1535690679472,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -2079,73 +2073,73 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535775677065,
+      "nextUpdateTime": 1535419137841,
       "userAction": ""
     },
     "pixel-geo.prfct.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535759777976,
+      "nextUpdateTime": 1535473701074,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535462179315,
+      "nextUpdateTime": 1535791753209,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535427198698,
+      "nextUpdateTime": 1535454724028,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535373297517,
+      "nextUpdateTime": 1535584375101,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535355242307,
+      "nextUpdateTime": 1535431775060,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535647714316,
+      "nextUpdateTime": 1535470366014,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535525085673,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535494298982,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535665286918,
+      "nextUpdateTime": 1535827732761,
       "userAction": ""
     },
     "pixel.tapad.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535312220420,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535550390073,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535543028633,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535443656582,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535298519588,
+      "nextUpdateTime": 1535862853985,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2163,13 +2157,13 @@
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535737640371,
+      "nextUpdateTime": 1535634741658,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535668829519,
+      "nextUpdateTime": 1535602138418,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2181,13 +2175,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606931325,
+      "nextUpdateTime": 1535694456088,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421638602,
+      "nextUpdateTime": 1535608927078,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2199,7 +2193,7 @@
     "pr-bh.ybp.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535293929134,
+      "nextUpdateTime": 1535721998785,
       "userAction": ""
     },
     "prfct.co": {
@@ -2217,25 +2211,25 @@
     "profile.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535623328400,
+      "nextUpdateTime": 1535868066793,
       "userAction": ""
     },
     "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535551954716,
+      "nextUpdateTime": 1535775857188,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535593545310,
+      "nextUpdateTime": 1535440273805,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535583692664,
+      "nextUpdateTime": 1535537986452,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2247,49 +2241,55 @@
     "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370162061,
+      "nextUpdateTime": 1535447877021,
+      "userAction": ""
+    },
+    "purch-sync.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535442782846,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535542087750,
+      "nextUpdateTime": 1535475285092,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535646457589,
+      "nextUpdateTime": 1535501609306,
       "userAction": ""
     },
     "px.owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535403538242,
+      "nextUpdateTime": 1535800014348,
       "userAction": ""
     },
     "px.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535353388308,
+      "nextUpdateTime": 1535366852912,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535419488708,
+      "nextUpdateTime": 1535668867614,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535369878735,
+      "nextUpdateTime": 1535644633942,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535360796345,
+      "nextUpdateTime": 1535552433183,
       "userAction": ""
     },
     "quantserve.com": {
@@ -2307,7 +2307,7 @@
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535352011476,
+      "nextUpdateTime": 1535814046934,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2319,31 +2319,31 @@
     "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535286295528,
+      "nextUpdateTime": 1535373600303,
       "userAction": ""
     },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535306518026,
+      "nextUpdateTime": 1535496894433,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694908698,
+      "nextUpdateTime": 1535666183003,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535378845796,
+      "nextUpdateTime": 1535584949059,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535430722611,
+      "nextUpdateTime": 1535711947766,
       "userAction": ""
     },
     "rfihub.com": {
@@ -2366,20 +2366,20 @@
     },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535722022072,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535845692253,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535789545771,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535583943990,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535426725737,
+      "nextUpdateTime": 1535699311885,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -2397,79 +2397,73 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535544352908,
+      "nextUpdateTime": 1535807522405,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535604512693,
+      "nextUpdateTime": 1535399131116,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535629576922,
+      "nextUpdateTime": 1535856992384,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598595757,
+      "nextUpdateTime": 1535407116454,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535337571271,
+      "nextUpdateTime": 1535517735871,
       "userAction": ""
     },
     "s.po.st": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535309914794,
+      "nextUpdateTime": 1535601704447,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535468509231,
+      "nextUpdateTime": 1535470740234,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535566474727,
-      "userAction": ""
-    },
-    "s.yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535661147872,
+      "nextUpdateTime": 1535548076811,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535527772076,
+      "nextUpdateTime": 1535650294754,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535375732663,
+      "nextUpdateTime": 1535442162234,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535418939591,
+      "nextUpdateTime": 1535683133775,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535312742531,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436416136,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2481,25 +2475,25 @@
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535671086115,
+      "nextUpdateTime": 1535554044154,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535415217899,
+      "nextUpdateTime": 1535640650960,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535520014307,
+      "nextUpdateTime": 1535622073754,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535492741324,
+      "nextUpdateTime": 1535641445518,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2511,7 +2505,7 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535722846588,
+      "nextUpdateTime": 1535699162400,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -2523,7 +2517,7 @@
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535778464447,
+      "nextUpdateTime": 1535406047367,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2535,85 +2529,85 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535511738519,
+      "nextUpdateTime": 1535475183501,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535642980054,
+      "nextUpdateTime": 1535590066515,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535738150884,
+      "nextUpdateTime": 1535681640966,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510232378,
+      "nextUpdateTime": 1535516546452,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389044916,
+      "nextUpdateTime": 1535508368840,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535444722549,
+      "nextUpdateTime": 1535791057311,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535337220991,
+      "nextUpdateTime": 1535711269325,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535346501751,
+      "nextUpdateTime": 1535537879488,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535490196521,
+      "nextUpdateTime": 1535460219033,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535340041154,
+      "nextUpdateTime": 1535643556045,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535662738397,
+      "nextUpdateTime": 1535879474697,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535494946898,
+      "nextUpdateTime": 1535619679394,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535708162903,
+      "nextUpdateTime": 1535654613358,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436904126,
+      "nextUpdateTime": 1535573504719,
       "userAction": ""
     },
     "self.com": {
@@ -2649,7 +2643,7 @@
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535443540105,
+      "nextUpdateTime": 1535633318133,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -2679,7 +2673,7 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535591895325,
+      "nextUpdateTime": 1535372330669,
       "userAction": ""
     },
     "snapchat.com": {
@@ -2703,7 +2697,7 @@
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535500469983,
+      "nextUpdateTime": 1535631243909,
       "userAction": ""
     },
     "spotxchange.com": {
@@ -2718,52 +2712,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-25-09.config.parsely.com": {
+    "srv-2018-08-26-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535320516701,
+      "nextUpdateTime": 1535415293805,
       "userAction": ""
     },
-    "srv-2018-08-25-09.pixel.parsely.com": {
+    "srv-2018-08-26-09.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535492273466,
+      "nextUpdateTime": 1535541971804,
       "userAction": ""
     },
-    "srv-2018-08-25-10.config.parsely.com": {
+    "srv-2018-08-26-10.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535675261339,
+      "nextUpdateTime": 1535427058911,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535327444761,
+      "nextUpdateTime": 1535673135301,
       "userAction": ""
     },
     "ssl.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535590743011,
+      "nextUpdateTime": 1535545018325,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535583569862,
+      "nextUpdateTime": 1535743749252,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535766135977,
+      "nextUpdateTime": 1535749834287,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535591035984,
+      "nextUpdateTime": 1535393160160,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2781,19 +2775,19 @@
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535419436462,
+      "nextUpdateTime": 1535471382942,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526724439,
+      "nextUpdateTime": 1535539060159,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535354675061,
+      "nextUpdateTime": 1535587267608,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2805,13 +2799,13 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535449503047,
+      "nextUpdateTime": 1535416632424,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535353496047,
+      "nextUpdateTime": 1535669657331,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -2829,7 +2823,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535385706713,
+      "nextUpdateTime": 1535410096945,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2841,67 +2835,61 @@
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535466735514,
+      "nextUpdateTime": 1535775576457,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535402210709,
+      "nextUpdateTime": 1535509470133,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535601519697,
+      "nextUpdateTime": 1535599232106,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535354555122,
+      "nextUpdateTime": 1535727505148,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535721836756,
+      "nextUpdateTime": 1535386374072,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535707308539,
-      "userAction": ""
-    },
-    "sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535279621142,
+      "nextUpdateTime": 1535823492565,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535481640591,
+      "nextUpdateTime": 1535499554312,
       "userAction": ""
     },
     "sync.multiview.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535782023227,
+      "nextUpdateTime": 1535446837680,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535286963228,
+      "nextUpdateTime": 1535533239526,
       "userAction": ""
     },
     "sync.teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535597792238,
+      "nextUpdateTime": 1535693045071,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2919,7 +2907,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535325417249,
+      "nextUpdateTime": 1535695664896,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -2931,13 +2919,19 @@
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535448475939,
+      "nextUpdateTime": 1535750776402,
       "userAction": ""
     },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tapestry.tapad.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535791510610,
       "userAction": ""
     },
     "teads.tv": {
@@ -2973,13 +2967,13 @@
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535452783142,
+      "nextUpdateTime": 1535800953607,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535746635108,
+      "nextUpdateTime": 1535498571655,
       "userAction": ""
     },
     "tinypass.com": {
@@ -2991,7 +2985,7 @@
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535550935721,
+      "nextUpdateTime": 1535433221586,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3003,19 +2997,25 @@
     "top100.rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535684529979,
+      "nextUpdateTime": 1535878948535,
+      "userAction": ""
+    },
+    "tr.outbrain.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529445629,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535544639408,
+      "nextUpdateTime": 1535691727010,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535567234151,
+      "nextUpdateTime": 1535502278546,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3027,7 +3027,7 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535732628184,
+      "nextUpdateTime": 1535381700109,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -3045,7 +3045,7 @@
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535545230967,
+      "nextUpdateTime": 1535459821318,
       "userAction": ""
     },
     "turn.com": {
@@ -3069,37 +3069,37 @@
     "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535784547100,
+      "nextUpdateTime": 1535420971761,
       "userAction": ""
     },
     "ups.xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535314703086,
+      "nextUpdateTime": 1535483153937,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535688937954,
+      "nextUpdateTime": 1535571457788,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535597114866,
+      "nextUpdateTime": 1535862306211,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535432676742,
+      "nextUpdateTime": 1535560041560,
       "userAction": ""
     },
     "va.v.liveperson.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535729794135,
+      "nextUpdateTime": 1535510754633,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -3135,7 +3135,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434926452,
+      "nextUpdateTime": 1535374260274,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -3147,7 +3147,7 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535472656099,
+      "nextUpdateTime": 1535879370927,
       "userAction": ""
     },
     "vogue.com": {
@@ -3159,7 +3159,7 @@
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535338852200,
+      "nextUpdateTime": 1535532865527,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3171,25 +3171,19 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535690600138,
-      "userAction": ""
-    },
-    "wam-yahoo.solution.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535775196955,
+      "nextUpdateTime": 1535786495983,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535325407427,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535427771016,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535709876484,
+      "nextUpdateTime": 1535518923351,
       "userAction": ""
     },
     "weborama.fr": {
@@ -3213,7 +3207,7 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535679663540,
+      "nextUpdateTime": 1535766647842,
       "userAction": ""
     },
     "wired.com": {
@@ -3237,25 +3231,25 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535335492897,
+      "nextUpdateTime": 1535445893357,
       "userAction": ""
     },
     "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535556921277,
+      "nextUpdateTime": 1535369602618,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535475009981,
+      "nextUpdateTime": 1535680288285,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535491915288,
+      "nextUpdateTime": 1535572118422,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3267,25 +3261,25 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535370836192,
+      "nextUpdateTime": 1535662491591,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535367117721,
+      "nextUpdateTime": 1535456082317,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535557439829,
+      "nextUpdateTime": 1535602597669,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535356981005,
+      "nextUpdateTime": 1535383347016,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -3297,13 +3291,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535304134792,
+      "nextUpdateTime": 1535684316433,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535654060736,
+      "nextUpdateTime": 1535777753978,
       "userAction": ""
     },
     "www.google.com": {
@@ -3315,97 +3309,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535557201033,
+      "nextUpdateTime": 1535533301706,
       "userAction": ""
     },
     "www.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535439526561,
+      "nextUpdateTime": 1535835623263,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535774798008,
+      "nextUpdateTime": 1535634668073,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535438867974,
+      "nextUpdateTime": 1535647703467,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535786649584,
+      "nextUpdateTime": 1535713896951,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535513903637,
+      "nextUpdateTime": 1535717161877,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483680212,
+      "nextUpdateTime": 1535472362868,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535581539395,
+      "nextUpdateTime": 1535775225012,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535452630744,
+      "nextUpdateTime": 1535779192331,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535391747796,
+      "nextUpdateTime": 1535854231963,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535721812757,
+      "nextUpdateTime": 1535683085556,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535369389550,
+      "nextUpdateTime": 1535492902964,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535752078138,
+      "nextUpdateTime": 1535633330954,
       "userAction": ""
     },
     "www.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535659930279,
+      "nextUpdateTime": 1535622719621,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535279092662,
+      "nextUpdateTime": 1535870220028,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535589911304,
+      "nextUpdateTime": 1535717582854,
       "userAction": ""
     },
     "xiti.com": {
@@ -3417,7 +3411,7 @@
     "xpl.theadex.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535345322663,
+      "nextUpdateTime": 1535552741878,
       "userAction": ""
     },
     "xplosion.de": {
@@ -3456,12 +3450,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3471,19 +3459,19 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535353268865,
+      "nextUpdateTime": 1535731599614,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535603698010,
+      "nextUpdateTime": 1535474370166,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535719784949,
+      "nextUpdateTime": 1535712458694,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3535,6 +3523,7 @@
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
+      "philips.com",
       "oclc.org"
     ],
     "33across.com": [
@@ -3554,13 +3543,13 @@
     "3gl.net": [
       "istockphoto.com",
       "gettyimages.com",
-      "thedailybeast.com"
+      "economist.com"
     ],
     "3lift.com": [
       "nature.com",
       "springer.com",
       "theverge.com",
-      "wunderground.com",
+      "deviantart.com",
       "focus.de"
     ],
     "4dsply.com": [
@@ -3639,9 +3628,6 @@
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-score.com": [
-      "wnd.com"
-    ],
     "ad-stir.com": [
       "sakura.ne.jp",
       "biglobe.ne.jp",
@@ -3666,7 +3652,8 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com"
+      "washingtonexaminer.com",
+      "tinypic.com"
     ],
     "addthis.com": [
       "nasa.gov",
@@ -3686,7 +3673,7 @@
       "t-online.de",
       "bloomberg.com",
       "springer.com",
-      "shutterstock.com",
+      "sciencemag.org",
       "helsinki.fi"
     ],
     "adfox.ru": [
@@ -3712,7 +3699,8 @@
       "bloomberg.com",
       "dailymotion.com",
       "spiegel.de",
-      "t-online.de"
+      "t-online.de",
+      "lemonde.fr"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -3722,6 +3710,7 @@
       "venturebeat.com",
       "livescience.com",
       "space.com",
+      "t-online.de",
       "dailydot.com"
     ],
     "adlmerge.com": [
@@ -3729,7 +3718,8 @@
     ],
     "admaster.com.cn": [
       "autohome.com.cn",
-      "bshare.cn"
+      "bshare.cn",
+      "youku.com"
     ],
     "admission.net": [
       "edmunds.com"
@@ -3742,6 +3732,7 @@
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
+      "telegraph.co.uk",
       "rfi.fr"
     ],
     "adobe.com": [
@@ -3757,7 +3748,8 @@
     ],
     "adotmob.com": [
       "standard.co.uk",
-      "upwork.com"
+      "upwork.com",
+      "nypost.com"
     ],
     "adriver.ru": [
       "ria.ru",
@@ -3790,7 +3782,8 @@
       "yahoo.com",
       "googletagmanager.com",
       "sourceforge.net",
-      "hgtv.com"
+      "cnet.com",
+      "gizmodo.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -3801,7 +3794,7 @@
       "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "foursquare.com",
+      "economist.com",
       "realtor.com"
     ],
     "adtags.pro": [
@@ -3815,6 +3808,7 @@
       "sourceforge.net",
       "dropbox.com",
       "wsj.com",
+      "dailymotion.com",
       "walgreens.com"
     ],
     "advertur.ru": [
@@ -3866,8 +3860,7 @@
       "voanews.com",
       "repubblica.it",
       "iyfubh.com",
-      "forbes.com",
-      "francetvinfo.fr"
+      "forbes.com"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -3887,7 +3880,7 @@
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
-      "tmall.com",
+      "aliexpress.com",
       "1688.com"
     ],
     "alipay.com": [
@@ -3914,6 +3907,7 @@
       "nytimes.com",
       "reddit.com",
       "cnn.com",
+      "telegraph.co.uk",
       "bostonherald.com"
     ],
     "amazon.co.uk": [
@@ -3939,7 +3933,6 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "nasa.gov",
       "walgreens.com"
     ],
     "antdsp.com": [
@@ -3951,7 +3944,8 @@
     "aol.com": [
       "engadget.com",
       "indiatimes.com",
-      "autoblog.com"
+      "autoblog.com",
+      "techcrunch.com"
     ],
     "ap.org": [
       "post-gazette.com"
@@ -3968,6 +3962,7 @@
       "foursquare.com",
       "history.com",
       "nbc.com",
+      "airbnb.com",
       "strava.com"
     ],
     "appdynamics.com": [
@@ -4011,7 +4006,8 @@
     "atdmt.com": [
       "facebook.com",
       "yahoo.com",
-      "msn.com"
+      "msn.com",
+      "t-online.de"
     ],
     "atemda.com": [
       "springer.com",
@@ -4047,7 +4043,7 @@
       "sina.com.cn",
       "163.com",
       "ifeng.com",
-      "51.la"
+      "sohu.com"
     ],
     "bam-x.com": [
       "gq.com"
@@ -4117,7 +4113,8 @@
       "google.com",
       "amazon.com",
       "forbes.com",
-      "bostonherald.com"
+      "npr.org",
+      "newatlas.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -4131,6 +4128,8 @@
       "cnn.com",
       "weebly.com",
       "msn.com",
+      "telegraph.co.uk",
+      "office.com",
       "pingdom.com"
     ],
     "bitbucket.org": [
@@ -4140,12 +4139,11 @@
       "eventbrite.com",
       "cloudflare.com",
       "zendesk.com",
-      "shutterstock.com",
+      "ibm.com",
       "gitlab.com"
     ],
     "bizibly.com": [
-      "eventbrite.com",
-      "cloudflare.com"
+      "eventbrite.com"
     ],
     "bizographics.com": [
       "zend.com",
@@ -4156,8 +4154,7 @@
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com"
+      "ew.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -4167,7 +4164,8 @@
     ],
     "bluecava.com": [
       "history.com",
-      "biography.com"
+      "biography.com",
+      "jimdo.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
@@ -4198,8 +4196,7 @@
       "pitchfork.com"
     ],
     "boston.com": [
-      "bostonglobe.com",
-      "bleacherreport.com"
+      "bostonglobe.com"
     ],
     "bostonglobemedia.com": [
       "boston.com"
@@ -4236,14 +4233,13 @@
     "brightcove.net": [
       "lefigaro.fr",
       "politico.com",
-      "bostonglobe.com",
-      "techtarget.com"
+      "bostonglobe.com"
     ],
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
       "zendesk.com",
-      "uci.edu",
+      "nypost.com",
       "dailydot.com"
     ],
     "btttag.com": [
@@ -4286,6 +4282,7 @@
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
+      "dailymail.co.uk",
       "pitchfork.com"
     ],
     "cbsi.com": [
@@ -4362,7 +4359,8 @@
     ],
     "clicktale.net": [
       "xbox.com",
-      "office.com"
+      "office.com",
+      "microsoft.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
@@ -4377,9 +4375,6 @@
       "sciencemag.org",
       "nginx.com",
       "allaboutcookies.org"
-    ],
-    "cmgdigital.com": [
-      "ajc.com"
     ],
     "cnet.com": [
       "zdnet.com"
@@ -4461,6 +4456,9 @@
     "consumable.com": [
       "xfinity.com"
     ],
+    "content.ad": [
+      "tinypic.com"
+    ],
     "contentabc.com": [
       "pornhub.com"
     ],
@@ -4469,7 +4467,8 @@
       "myspace.com",
       "bloomberg.com",
       "forbes.com",
-      "walgreens.com"
+      "samsung.com",
+      "coindesk.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -4507,6 +4506,9 @@
     "cr-nielsen.com": [
       "youku.com"
     ],
+    "creative-serving.com": [
+      "newatlas.com"
+    ],
     "creativecdn.com": [
       "ria.ru",
       "udn.com"
@@ -4519,6 +4521,7 @@
       "washingtonpost.com",
       "dailymail.co.uk",
       "dropbox.com",
+      "cnet.com",
       "sedo.com"
     ],
     "croissed.info": [
@@ -4550,6 +4553,7 @@
       "talktalk.co.uk",
       "gizmodo.com",
       "wsj.com",
+      "cbc.ca",
       "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
@@ -4613,6 +4617,7 @@
       "yahoo.com",
       "amazon.com",
       "soundcloud.com",
+      "telegraph.co.uk",
       "skynet.be"
     ],
     "departapp.com": [
@@ -4663,6 +4668,7 @@
       "britannica.com",
       "lifehacker.com",
       "express.co.uk",
+      "gizmodo.com",
       "bostonherald.com"
     ],
     "disney.com": [
@@ -4701,13 +4707,15 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com"
+      "tinypic.com",
+      "slashdot.org"
     ],
     "dotomi.com": [
       "tinyurl.com",
       "samsung.com",
       "webmd.com",
       "forbes.com",
+      "economist.com",
       "walgreens.com"
     ],
     "dotsub.com": [
@@ -4718,6 +4726,7 @@
       "twitter.com",
       "linkedin.com",
       "sourceforge.net",
+      "telegraph.co.uk",
       "focus.de"
     ],
     "doublemax.net": [
@@ -4730,17 +4739,11 @@
       "military.com",
       "allafrica.com"
     ],
-    "dowjones.io": [
-      "marketwatch.com"
-    ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
       "techtarget.com",
       "adweek.com"
-    ],
-    "dxpmedia.com": [
-      "autohome.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4836,9 +4839,6 @@
       "vanityfair.com",
       "pitchfork.com"
     ],
-    "epital.gdn": [
-      "4shared.com"
-    ],
     "equalstyle.com": [
       "hubpages.com"
     ],
@@ -4853,9 +4853,6 @@
       "canalblog.com",
       "lefigaro.fr",
       "sfgate.com"
-    ],
-    "etahub.com": [
-      "pornhub.com"
     ],
     "etracker.de": [
       "sedo.com"
@@ -4874,6 +4871,7 @@
       "yahoo.com",
       "sourceforge.net",
       "tinyurl.com",
+      "telegraph.co.uk",
       "newatlas.com"
     ],
     "everyaction.com": [
@@ -4906,7 +4904,7 @@
       "soundcloud.com",
       "forbes.com",
       "bloomberg.com",
-      "businessinsider.com",
+      "surveymonkey.com",
       "gizmodo.com"
     ],
     "exosrv.com": [
@@ -4919,7 +4917,7 @@
       "sourceforge.net",
       "forbes.com",
       "bloomberg.com",
-      "gizmodo.com",
+      "news.com.au",
       "heraldsun.com.au"
     ],
     "eyereturn.com": [
@@ -4928,6 +4926,7 @@
     ],
     "eyeviewads.com": [
       "staples.com",
+      "nypost.com",
       "walgreens.com"
     ],
     "ezoic.net": [
@@ -4939,6 +4938,7 @@
       "wordpress.org",
       "adobe.com",
       "nytimes.com",
+      "telegraph.co.uk",
       "focus.de"
     ],
     "facetz.net": [
@@ -4979,7 +4979,8 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu"
+      "msu.edu",
+      "bmj.com"
     ],
     "flickr.com": [
       "state.gov",
@@ -5006,6 +5007,9 @@
       "moonfruit.com",
       "webex.com",
       "sitepoint.com"
+    ],
+    "foreignpolicy.com": [
+      "onecount.net"
     ],
     "foresee.com": [
       "epa.gov",
@@ -5047,9 +5051,6 @@
     ],
     "friendbuy.com": [
       "lulu.com"
-    ],
-    "fuel451.com": [
-      "prezi.com"
     ],
     "funcaptcha.com": [
       "axs.com"
@@ -5156,7 +5157,7 @@
       "linkedin.com",
       "google.de",
       "sourceforge.net",
-      "google.ca",
+      "telegraph.co.uk",
       "scmp.com",
       "chromium.org",
       "focus.de"
@@ -5199,6 +5200,7 @@
       "adobe.com",
       "ox.ac.uk",
       "ihg.com",
+      "economist.com",
       "business2community.com"
     ],
     "gwmtracking.com": [
@@ -5338,7 +5340,8 @@
     "im-apps.net": [
       "exblog.jp",
       "rakuten.co.jp",
-      "biglobe.ne.jp"
+      "biglobe.ne.jp",
+      "economist.com"
     ],
     "imagetopng.club": [
       "4shared.com"
@@ -5357,13 +5360,15 @@
     "impact-ad.jp": [
       "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "economist.com"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
       "bbc.com",
       "wsj.com",
+      "cnet.com",
       "gizmodo.com"
     ],
     "infinity-tracking.net": [
@@ -5382,8 +5387,7 @@
       "ups.com"
     ],
     "inquisitr.com": [
-      "www.poznan.pl",
-      "flipboard.com"
+      "www.poznan.pl"
     ],
     "inside-graph.com": [
       "staples.com"
@@ -5392,13 +5396,15 @@
       "unsplash.com",
       "standard.co.uk",
       "motorola.com",
+      "giphy.com",
       "gopro.com"
     ],
     "instagram.com": [
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu"
+      "arizona.edu",
+      "tmz.com"
     ],
     "instinctiveads.com": [
       "variety.com",
@@ -5408,7 +5414,8 @@
     ],
     "intentiq.com": [
       "sourceforge.net",
-      "symantec.com"
+      "symantec.com",
+      "slashdot.org"
     ],
     "intentmedia.net": [
       "hotels.com",
@@ -5467,7 +5474,8 @@
       "indianexpress.com"
     ],
     "janrainsso.com": [
-      "vancouversun.com"
+      "vancouversun.com",
+      "nationalpost.com"
     ],
     "jd.com": [
       "163.com",
@@ -5519,6 +5527,7 @@
       "nationalgeographic.com",
       "chicagotribune.com",
       "nytimes.com",
+      "rollingstone.com",
       "zappos.com"
     ],
     "kinja.com": [
@@ -5534,6 +5543,7 @@
       "bgr.com",
       "jalopnik.com",
       "cnn.com",
+      "usatoday.com",
       "gizmodo.com"
     ],
     "ladsp.com": [
@@ -5559,6 +5569,7 @@
       "nj.com",
       "patch.com",
       "bloomberg.com",
+      "economist.com",
       "washingtonexaminer.com"
     ],
     "libero.it": [
@@ -5579,7 +5590,7 @@
       "zdnet.com",
       "fastcompany.com",
       "adweek.com",
-      "gizmodo.com",
+      "mashable.com",
       "dailycaller.com"
     ],
     "lijit.com": [
@@ -5600,7 +5611,8 @@
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "msn.com",
+      "forbes.com",
+      "hp.com",
       "lexisnexis.com"
     ],
     "linksynergy.com": [
@@ -5618,9 +5630,9 @@
       "paypal.com",
       "skype.com",
       "msn.com",
+      "microsoft.com",
       "bing.com",
-      "office.com",
-      "microsoft.com"
+      "office.com"
     ],
     "livechatinc.com": [
       "ning.com",
@@ -5691,7 +5703,8 @@
     "mailchimp.com": [
       "colorlib.com",
       "fas.org",
-      "tias.com"
+      "tias.com",
+      "nap.edu"
     ],
     "mantisadnetwork.com": [
       "tvtropes.org"
@@ -5712,8 +5725,6 @@
       "nokia.com",
       "panasonic.com",
       "dyn.com",
-      "searchengineland.com",
-      "hootsuite.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
@@ -5726,6 +5737,7 @@
       "vimeo.com",
       "sourceforge.net",
       "forbes.com",
+      "usatoday.com",
       "pitchfork.com"
     ],
     "media.net": [
@@ -5733,6 +5745,7 @@
       "dropbox.com",
       "forbes.com",
       "reuters.com",
+      "npr.org",
       "cracked.com"
     ],
     "media6degrees.com": [
@@ -5752,7 +5765,8 @@
     "mediaplex.com": [
       "dell.com",
       "shutterfly.com",
-      "military.com"
+      "military.com",
+      "economist.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
@@ -5783,7 +5797,11 @@
     ],
     "metadsp.co.uk": [
       "nypost.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "variety.com"
+    ],
+    "mfadsrvr.com": [
+      "forbes.com"
     ],
     "mg2connext.com": [
       "mercurynews.com",
@@ -5801,7 +5819,8 @@
     "miaozhen.com": [
       "sina.com.cn",
       "163.com",
-      "dzwww.com"
+      "dzwww.com",
+      "autohome.com.cn"
     ],
     "microad.jp": [
       "rakuten.co.jp",
@@ -5828,7 +5847,7 @@
       "parallels.com",
       "prnewswire.com",
       "zend.com",
-      "nginx.com",
+      "oreilly.com",
       "pingdom.com"
     ],
     "ml314.com": [
@@ -5836,6 +5855,7 @@
       "forbes.com",
       "bloomberg.com",
       "wsj.com",
+      "businessinsider.com",
       "zerohedge.com"
     ],
     "mlb.com": [
@@ -5932,7 +5952,8 @@
       "soundcloud.com",
       "surveymonkey.com",
       "spotify.com",
-      "paypal.com"
+      "paypal.com",
+      "economist.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
@@ -5942,7 +5963,7 @@
     ],
     "narrative.io": [
       "sourceforge.net",
-      "gizmodo.com"
+      "business2community.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -5985,7 +6006,8 @@
     "netmng.com": [
       "lenovo.com",
       "theknot.com",
-      "shopko.com"
+      "shopko.com",
+      "pitchfork.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -6012,6 +6034,7 @@
       "nypost.com",
       "thesun.co.uk",
       "wsj.com",
+      "news.com.au",
       "heraldsun.com.au"
     ],
     "newsinc.com": [
@@ -6057,6 +6080,7 @@
       "wsj.com",
       "oracle.com",
       "huffingtonpost.com",
+      "harvard.edu",
       "helsinki.fi"
     ],
     "nsaudience.pl": [
@@ -6129,7 +6153,7 @@
       "springer.com",
       "standard.co.uk",
       "home.pl",
-      "skyrock.com"
+      "variety.com"
     ],
     "omtrdc.net": [
       "adobe.com",
@@ -6152,6 +6176,7 @@
       "bitbucket.org",
       "namecheap.com",
       "cnn.com",
+      "thesun.co.uk",
       "active.com"
     ],
     "onevision.com.tw": [
@@ -6186,6 +6211,7 @@
       "amazon.com",
       "nytimes.com",
       "forbes.com",
+      "telegraph.co.uk",
       "active.com"
     ],
     "opinionstage.com": [
@@ -6201,24 +6227,20 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
-      "nytimes.com",
-      "bbc.com",
-      "live.com",
       "ibm.com",
-      "hp.com",
+      "microsoft.com",
+      "bbc.com",
       "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
-      "foxnews.com",
-      "constantcontact.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
       "evernote.com",
-      "box.com",
       "prezi.com",
       "prweb.com",
+      "ign.com",
       "dictionary.com",
       "bitbucket.org",
       "gotomeeting.com",
@@ -6247,6 +6269,7 @@
       "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
+      "box.com",
       "fox.com"
     ],
     "optimove.events": [
@@ -6257,7 +6280,8 @@
       "alternet.org"
     ],
     "oracleimg.com": [
-      "dyn.com"
+      "dyn.com",
+      "oracle.com"
     ],
     "orangeads.fr": [
       "orange.fr"
@@ -6279,6 +6303,7 @@
       "scribd.com",
       "foxnews.com",
       "cnn.com",
+      "telegraph.co.uk",
       "focus.de"
     ],
     "ovh.com": [
@@ -6307,6 +6332,7 @@
       "wired.com",
       "wikia.com",
       "wsj.com",
+      "techcrunch.com",
       "dezeen.com"
     ],
     "paypal.com": [
@@ -6401,12 +6427,14 @@
       "independent.co.uk",
       "chicagotribune.com",
       "wsj.com",
+      "marketwatch.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
       "livescience.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "variety.com"
     ],
     "pressboard.ca": [
       "observer.com"
@@ -6498,8 +6526,7 @@
     "qq.com": [
       "sina.com.cn",
       "ctrip.com",
-      "weather.com.cn",
-      "tencent.com"
+      "weather.com.cn"
     ],
     "qsstats.com": [
       "serverwatch.com",
@@ -6519,6 +6546,7 @@
       "vimeo.com",
       "reddit.com",
       "soundcloud.com",
+      "jimdo.com",
       "gizmodo.com"
     ],
     "quantummetric.com": [
@@ -6614,17 +6642,15 @@
     ],
     "rezync.com": [
       "economist.com",
-      "salon.com"
+      "investopedia.com"
     ],
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
       "npr.org",
-      "foursquare.com",
+      "forbes.com",
+      "economist.com",
       "gopro.com"
-    ],
-    "rhombusads.com": [
-      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6653,6 +6679,7 @@
       "yahoo.com",
       "sourceforge.net",
       "reddit.com",
+      "hp.com",
       "box.com"
     ],
     "rnengage.com": [
@@ -6675,28 +6702,27 @@
     ],
     "rtk.io": [
       "post-gazette.com",
-      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
       "bloomberg.com",
-      "uci.edu"
+      "npr.org"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "pitchfork.com"
+      "dailymail.co.uk",
+      "gizmodo.com"
     ],
     "rundsp.com": [
       "hpe.com",
       "alternet.org"
     ],
     "rutarget.ru": [
-      "rambler.ru",
-      "ria.ru"
+      "rambler.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "codepen.io",
@@ -6709,9 +6735,6 @@
     ],
     "sabavision.com": [
       "mihanblog.com"
-    ],
-    "salecycle.com": [
-      "talktalk.co.uk"
     ],
     "salesforceliveagent.com": [
       "constantcontact.com",
@@ -6767,6 +6790,7 @@
       "yahoo.com",
       "tumblr.com",
       "nytimes.com",
+      "telegraph.co.uk",
       "gizmodo.com"
     ],
     "scribblelive.com": [
@@ -6831,7 +6855,7 @@
       "dropbox.com",
       "t-online.de",
       "nbcnews.com",
-      "npr.org",
+      "businessinsider.com",
       "hgtv.com"
     ],
     "sessioncam.com": [
@@ -6853,6 +6877,7 @@
       "yahoo.com",
       "cnn.com",
       "time.com",
+      "forbes.com",
       "cnet.com",
       "walgreens.com"
     ],
@@ -6867,9 +6892,6 @@
     "shopify.com": [
       "codepen.io",
       "raspberrypi.org"
-    ],
-    "sibautomation.com": [
-      "themeisle.com"
     ],
     "simplereach.com": [
       "theatlantic.com"
@@ -6900,6 +6922,7 @@
       "udel.edu",
       "berkeley.edu",
       "jhu.edu",
+      "ethz.ch",
       "helsinki.fi",
       "case.edu",
       "oclc.org"
@@ -6926,7 +6949,7 @@
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
-      "arstechnica.com",
+      "jimdo.com",
       "coindesk.com"
     ],
     "sky.com": [
@@ -6967,6 +6990,7 @@
       "overstock.com",
       "complex.com",
       "wsj.com",
+      "giphy.com",
       "zappos.com"
     ],
     "snapwidget.com": [
@@ -7019,8 +7043,9 @@
       "photobucket.com",
       "deviantart.com",
       "springer.com",
-      "forbes.com",
-      "detroitnews.com"
+      "myspace.com",
+      "cnet.com",
+      "edmunds.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -7029,7 +7054,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "independent.ie",
+      "irishtimes.com",
       "mo.gov"
     ],
     "sourceforge.net": [
@@ -7073,7 +7098,7 @@
       "amazon.com",
       "dropbox.com",
       "dailymotion.com",
-      "thenextweb.com",
+      "npr.org",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -7114,6 +7139,7 @@
       "hugedomains.com",
       "dropcatch.com",
       "man7.org",
+      "cbslocal.com",
       "zerohedge.com"
     ],
     "staticimgfarm.com": [
@@ -7164,6 +7190,9 @@
       "feedly.com",
       "documentcloud.org"
     ],
+    "stripe.network": [
+      "smashballoon.com"
+    ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
@@ -7194,13 +7223,13 @@
     "surveymonkey.com": [
       "cambridge.org",
       "investopedia.com",
-      "foreignpolicy.com",
-      "iop.org"
+      "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
-      "indianexpress.com"
+      "indianexpress.com",
+      "springer.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -7214,6 +7243,7 @@
       "dropbox.com",
       "t-online.de",
       "msn.com",
+      "telegraph.co.uk",
       "edmunds.com"
     ],
     "tacdn.com": [
@@ -7226,8 +7256,7 @@
       "overstock.com"
     ],
     "tailtarget.com": [
-      "uol.com.br",
-      "variety.com"
+      "uol.com.br"
     ],
     "tamgrt.com": [
       "tripadvisor.com",
@@ -7250,7 +7279,8 @@
       "yahoo.com",
       "soundcloud.com",
       "paypal.com",
-      "networksolutions.com"
+      "jimdo.com",
+      "bostonherald.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -7275,8 +7305,7 @@
     "technolutions.net": [
       "illinois.edu",
       "upenn.edu",
-      "uci.edu",
-      "udel.edu"
+      "uci.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -7334,8 +7363,7 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com"
+      "ew.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -7345,6 +7373,7 @@
       "techcrunch.com",
       "kickstarter.com",
       "bloomberg.com",
+      "cnbc.com",
       "gizmodo.com"
     ],
     "tiqcdn.com": [
@@ -7352,6 +7381,7 @@
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
+      "marketwatch.com",
       "hpe.com",
       "francetvinfo.fr"
     ],
@@ -7475,6 +7505,7 @@
       "wired.com",
       "webmd.com",
       "tinyurl.com",
+      "hp.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
@@ -7498,13 +7529,15 @@
       "nytimes.com",
       "cnn.com",
       "msn.com",
-      "lexisnexis.com"
+      "hp.com",
+      "sfgate.com",
+      "lexisnexis.com",
+      "edmunds.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
       "washingtontimes.com",
-      "salon.com",
       "dailycaller.com"
     ],
     "ubi.com": [
@@ -7551,7 +7584,8 @@
     "unrulymedia.com": [
       "nypost.com",
       "earthlink.net",
-      "boingboing.net"
+      "boingboing.net",
+      "networkadvertising.org"
     ],
     "upravel.com": [
       "rambler.ru",
@@ -7583,6 +7617,7 @@
       "scotsman.com"
     ],
     "uservoice.com": [
+      "scoop.it",
       "theknot.com"
     ],
     "ustream.tv": [
@@ -7636,8 +7671,7 @@
       "cbc.ca"
     ],
     "videoamp.com": [
-      "hpe.com",
-      "alternet.org"
+      "hpe.com"
     ],
     "videohub.tv": [
       "liveuamap.com",
@@ -7675,7 +7709,6 @@
       "myspace.com",
       "fortune.com",
       "people.com",
-      "time.com",
       "zappos.com"
     ],
     "virgilio.it": [
@@ -7715,6 +7748,9 @@
     "vtracy.de": [
       "bloomberg.com"
     ],
+    "vulture.com": [
+      "nymag.com"
+    ],
     "w55c.net": [
       "hpe.com",
       "ebay.com",
@@ -7726,6 +7762,9 @@
     ],
     "wallst.com": [
       "reuters.com"
+    ],
+    "walmartimages.com": [
+      "walmart.com"
     ],
     "waptime.cn": [
       "tianqi.com"
@@ -7777,6 +7816,7 @@
       "nature.com",
       "abc.net.au",
       "oup.com",
+      "ethz.ch",
       "dhl.com"
     ],
     "webvisor.org": [
@@ -7950,6 +7990,7 @@
       "vimeo.com",
       "flickr.com",
       "sourceforge.net",
+      "hp.com",
       "eset.com"
     ],
     "yandex.ru": [
@@ -7978,6 +8019,7 @@
       "heise.de",
       "faz.net",
       "t-online.de",
+      "springer.com",
       "focus.de"
     ],
     "yieldoptimizer.com": [
@@ -7988,11 +8030,7 @@
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
-      "nytimes.com",
-      "dropbox.com",
-      "iop.org",
-      "sbs.com.au",
-      "eset.com"
+      "nytimes.com"
     ],
     "yldbt.com": [
       "wired.com",
@@ -8023,8 +8061,9 @@
       "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
+      "harvard.edu",
       "caltech.edu",
-      "dailykos.com",
+      "francetvinfo.fr",
       "honeywell.com"
     ],
     "youvisit.com": [
@@ -8053,7 +8092,7 @@
       "independent.co.uk",
       "thehill.com",
       "farfetch.com",
-      "paypal.com",
+      "lemonde.fr",
       "infoplease.com"
     ],
     "zendesk.com": [
@@ -8065,7 +8104,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "wunderground.com"
+      "marketwatch.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -8097,5 +8136,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.25"
+  "version": "2018.8.26"
 }

--- a/results.json
+++ b/results.json
@@ -30,12 +30,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "247-inc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "247realmedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -87,7 +81,7 @@
     "540-wem-854.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538343204573,
+      "nextUpdateTime": 1538430639682,
       "userAction": ""
     },
     "58.com": {
@@ -102,6 +96,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "5p4rk13.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "6sc.co": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -111,7 +111,7 @@
     "a8270235338.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538228855491,
+      "nextUpdateTime": 1538588686439,
       "userAction": ""
     },
     "aamsitecertifier.com": {
@@ -128,7 +128,7 @@
     },
     "abmr.net": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -162,13 +162,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "actionnetwork.org": {
+    "acuityplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "acuityplatform.com": {
+    "acxiomapac.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -201,7 +201,7 @@
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538275124714,
+      "nextUpdateTime": 1538396026587,
       "userAction": ""
     },
     "adapf.com": {
@@ -210,7 +210,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adc-srv.net": {
+    "adclear.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -234,12 +234,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adfarm.mediaplex.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538220421317,
-      "userAction": ""
-    },
     "adform.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -252,6 +246,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adingo.jp": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -260,7 +260,7 @@
     },
     "adition.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -320,13 +320,13 @@
     },
     "adotmob.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "adriver.ru": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -348,9 +348,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adservice.google.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538552147620,
+      "userAction": ""
+    },
     "adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -372,9 +384,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adtng.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx.com.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -391,6 +415,12 @@
       "userAction": ""
     },
     "afkp.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "afy11.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -558,12 +588,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aol.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "apester.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -648,7 +672,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "audiencemanager.de": {
+    "audtd.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -681,7 +705,7 @@
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538523364120,
+      "nextUpdateTime": 1538545401255,
       "userAction": ""
     },
     "baur.de": {
@@ -888,6 +912,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bumlam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "c-ctrip.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -897,7 +927,7 @@
     "c1.neweggimages.com": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538335697441,
+      "nextUpdateTime": 1538283268925,
       "userAction": ""
     },
     "c212.net": {
@@ -960,16 +990,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cdn.native.ai": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538359925677,
-      "userAction": ""
-    },
-    "cdnwidget.com": {
+    "cdn-apple.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cdn-net.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cdn.native.ai": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538283010864,
       "userAction": ""
     },
     "cern.ch": {
@@ -1062,22 +1098,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cmgdigital.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cmp.smartadserver.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538208881807,
+      "nextUpdateTime": 1538283647956,
       "userAction": ""
     },
     "cmsadmin30.convio.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538440206675,
+      "nextUpdateTime": 1538361066806,
       "userAction": ""
     },
     "cnet.com": {
@@ -1092,10 +1122,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cnzz.com": {
+    "cnzz.mmstat.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538432015990,
       "userAction": ""
     },
     "cobaltgroup.com": {
@@ -1185,13 +1215,13 @@
     "conv-blizzard-emea.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538493335476,
+      "nextUpdateTime": 1538302303292,
       "userAction": ""
     },
     "conv-blizzard-na.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538480483471,
+      "nextUpdateTime": 1538240686171,
       "userAction": ""
     },
     "convertro.com": {
@@ -1256,19 +1286,13 @@
     },
     "cssrvsync.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d1af033869koo7.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1338,6 +1362,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "df-srv.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "di-dtaectolog-us-prod-1.appspot.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1347,6 +1377,12 @@
     "dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaltarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1364,7 +1400,7 @@
     },
     "distiltag.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1452,12 +1488,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dyntrk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ebay-us.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1507,6 +1537,12 @@
       "userAction": ""
     },
     "elsevierhealth.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "embedly.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1644,6 +1680,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "fidelity-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "filepicker.io": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1682,7 +1724,7 @@
     },
     "force.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1700,7 +1742,7 @@
     },
     "fout.jp": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1755,7 +1797,7 @@
     "g.cn.miaozhen.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538491763887,
+      "nextUpdateTime": 1538638207879,
       "userAction": ""
     },
     "geetest.com": {
@@ -1770,12 +1812,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gentags.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "getclicky.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1783,6 +1819,12 @@
       "userAction": ""
     },
     "getsmartcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gfycat.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1815,7 +1857,7 @@
     "gmglobalcorporatefunctions.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538558542584,
+      "nextUpdateTime": 1538354788033,
       "userAction": ""
     },
     "go.com": {
@@ -1845,7 +1887,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538340601964,
+      "nextUpdateTime": 1538521734300,
       "userAction": ""
     },
     "gq.com": {
@@ -1872,9 +1914,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "gssprt.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "gtags.net": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1890,12 +1938,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gxbr.cnzz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538181812392,
-      "userAction": ""
-    },
     "hatena.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1909,12 +1951,6 @@
       "userAction": ""
     },
     "hdslb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "healte.de": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1938,16 +1974,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hive.co": {
+    "hiwoenrep.ru": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hiwoenrep.ru": {
+    "hm.baidu.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538229374628,
       "userAction": ""
     },
     "horyzon-media.com": {
@@ -1957,12 +1993,6 @@
       "userAction": ""
     },
     "huanqiu.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hubpd.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1992,13 +2022,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hwcdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iasds01.com": {
+    "hybrid.ai": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2036,7 +2060,7 @@
     },
     "igodigital.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2090,7 +2114,7 @@
     },
     "insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2180,8 +2204,8 @@
     },
     "irs01.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538642123927,
       "userAction": ""
     },
     "janrainsso.com": {
@@ -2192,7 +2216,7 @@
     },
     "jd.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2204,14 +2228,14 @@
     },
     "jrs5.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1538500509571,
+      "nextUpdateTime": 1538382272732,
       "userAction": ""
     },
     "jsrdn.com": {
@@ -2322,9 +2346,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "lentainform.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "licasd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2486,7 +2522,7 @@
     },
     "marketlinc.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2505,12 +2541,6 @@
     "mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mct01.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2547,6 +2577,12 @@
     "mediav.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediawallahscript.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2744,6 +2780,12 @@
     },
     "nanigans.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "narrative.io": {
+      "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
@@ -2792,7 +2834,7 @@
     },
     "netmng.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2877,7 +2919,7 @@
     "now.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538366209349,
+      "nextUpdateTime": 1538402088426,
       "userAction": ""
     },
     "nr-data.net": {
@@ -2928,6 +2970,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ojrq.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ok.ru": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2947,6 +2995,12 @@
       "userAction": ""
     },
     "omkt.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnidsp.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3051,7 +3105,7 @@
     "optout.betrad.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538300013262,
+      "nextUpdateTime": 1538605610091,
       "userAction": ""
     },
     "ora.tv": {
@@ -3086,7 +3140,7 @@
     },
     "owneriq.net": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3123,12 +3177,6 @@
     "paypalobjects.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "payroll.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3210,12 +3258,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "plista.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "plus.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3266,7 +3308,7 @@
     },
     "prod-mng-proxy-connext.azurewebsites.net": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3324,16 +3366,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pushanert.com": {
+    "purechat.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "px.ads.linkedin.com": {
+    "pushanert.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538262359887,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pxi.pub": {
@@ -3351,6 +3393,12 @@
     "qq.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qualia.id": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3432,7 +3480,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "render.githubusercontent.com": {
+    "republer.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3470,7 +3518,7 @@
     },
     "rezync.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3534,15 +3582,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ru4.com": {
+    "rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rundsp.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rubiconproject.com": {
+    "rutarget.ru": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3666,6 +3720,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "securepubads.g.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538544827245,
+      "userAction": ""
+    },
     "sekindo.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3721,12 +3781,6 @@
       "userAction": ""
     },
     "sf14g.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shareaholic.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3807,7 +3861,7 @@
     "sjs.bizographics.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538321907146,
+      "nextUpdateTime": 1538224333739,
       "userAction": ""
     },
     "skimresources.com": {
@@ -3974,7 +4028,7 @@
     },
     "springernature.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3985,6 +4039,12 @@
       "userAction": ""
     },
     "springserve.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "squarecdn.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4011,7 +4071,7 @@
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538398711735,
+      "nextUpdateTime": 1538715384815,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -4023,7 +4083,7 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538480363136,
+      "nextUpdateTime": 1538650164315,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -4098,6 +4158,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "survata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "surveymonkey.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -4107,6 +4173,12 @@
     "switchadhub.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "symantec.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4218,13 +4290,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tianqi.com": {
+    "thrtle.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tidaltv.com": {
+    "tianqi.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4257,12 +4329,6 @@
     "tiqcdn.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tmall.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4322,7 +4388,7 @@
     },
     "treasuredata.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4348,12 +4414,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trk.mct01.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538388427712,
       "userAction": ""
     },
     "tronc.com": {
@@ -4470,9 +4530,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "upravel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "upsellit.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4539,7 +4605,7 @@
     "v.admaster.com.cn": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538367082123,
+      "nextUpdateTime": 1538452008910,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -4598,7 +4664,7 @@
     },
     "vidible.tv": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4664,7 +4730,7 @@
     },
     "w55c.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4694,7 +4760,7 @@
     },
     "wbtrk.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4911,12 +4977,18 @@
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538427419875,
+      "nextUpdateTime": 1538298428203,
       "userAction": ""
     },
     "wwwimages.adobe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wywyuserservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4928,7 +5000,7 @@
     },
     "xg4ken.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5132,9 +5204,6 @@
     "15gifts.com": [
       "thetimes.co.uk"
     ],
-    "247-inc.net": [
-      "marriott.com"
-    ],
     "247realmedia.com": [
       "bmj.com",
       "americanbar.org"
@@ -5145,7 +5214,7 @@
       "fastcompany.com"
     ],
     "33across.com": [
-      "salon.com"
+      "accuweather.com"
     ],
     "360.cn": [
       "so.com"
@@ -5158,7 +5227,7 @@
     "3gl.net": [
       "go.com",
       "economist.com",
-      "thedailybeast.com"
+      "boston.com"
     ],
     "3lift.com": [
       "msn.com",
@@ -5174,6 +5243,9 @@
     "58cdn.com.cn": [
       "ganji.com"
     ],
+    "5p4rk13.com": [
+      "sfu.ca"
+    ],
     "6sc.co": [
       "brightcove.com"
     ],
@@ -5183,10 +5255,10 @@
       "post-gazette.com"
     ],
     "aaxads.com": [
+      "forbes.com",
       "speedtest.net"
     ],
     "abmr.net": [
-      "paypal.com",
       "nike.com",
       "freetype.org"
     ],
@@ -5206,11 +5278,12 @@
       "osu.edu",
       "amd.com"
     ],
-    "actionnetwork.org": [
-      "dailykos.com"
-    ],
     "acuityplatform.com": [
       "medscape.com"
+    ],
+    "acxiomapac.com": [
+      "businessinsider.com",
+      "npr.org"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
@@ -5229,8 +5302,8 @@
     "adapf.com": [
       "sakura.ne.jp"
     ],
-    "adc-srv.net": [
-      "autodesk.com"
+    "adclear.net": [
+      "t-online.de"
     ],
     "addroplet.com": [
       "wallinside.com",
@@ -5239,7 +5312,7 @@
     "addthis.com": [
       "who.int",
       "columbia.edu",
-      "uci.edu"
+      "giphy.com"
     ],
     "adentifi.com": [
       "metmuseum.org"
@@ -5254,13 +5327,15 @@
       "liveinternet.ru",
       "sputniknews.com"
     ],
+    "adhigh.net": [
+      "rambler.ru"
+    ],
     "adingo.jp": [
       "seesaa.jp"
     ],
     "adition.com": [
       "t-online.de",
-      "dailymotion.com",
-      "spiegel.de"
+      "lemonde.fr"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -5272,9 +5347,9 @@
       "howtogeek.com"
     ],
     "admaster.com.cn": [
-      "sohu.com",
       "yesky.com",
-      "bshare.cn"
+      "bshare.cn",
+      "sohu.com"
     ],
     "admission.net": [
       "edmunds.com"
@@ -5282,7 +5357,7 @@
     "adnxs.com": [
       "sourceforge.net",
       "nytimes.com",
-      "dropbox.com"
+      "forbes.com"
     ],
     "adobe.com": [
       "behance.net",
@@ -5294,23 +5369,20 @@
     ],
     "adobedtm.com": [
       "newyorker.com",
-      "worldbank.org",
-      "nbcnews.com"
+      "symantec.com",
+      "worldbank.org"
     ],
     "adotmob.com": [
-      "dailymotion.com",
-      "nypost.com",
       "variety.com"
     ],
     "adriver.ru": [
       "liveinternet.ru",
-      "sputniknews.com",
-      "ria.ru"
+      "sputniknews.com"
     ],
     "adroll.com": [
-      "nginx.org",
       "photobucket.com",
-      "cloudflare.com"
+      "cloudflare.com",
+      "ning.com"
     ],
     "adrta.com": [
       "seesaa.jp"
@@ -5321,14 +5393,17 @@
       "springer.com"
     ],
     "adsnative.com": [
+      "politico.com",
       "thehill.com",
-      "squareup.com",
       "informationweek.com"
+    ],
+    "adsniper.ru": [
+      "rambler.ru"
     ],
     "adsrvr.org": [
       "adobe.com",
       "sourceforge.net",
-      "forbes.com"
+      "nytimes.com"
     ],
     "adswizz.com": [
       "variety.com",
@@ -5340,10 +5415,16 @@
       "etsy.com",
       "tripadvisor.com"
     ],
+    "adtng.com": [
+      "pornhub.com"
+    ],
     "advertising.com": [
-      "yahoo.com",
-      "wsj.com",
-      "huffingtonpost.com"
+      "nytimes.com",
+      "msn.com",
+      "wsj.com"
+    ],
+    "adx.com.ru": [
+      "rambler.ru"
     ],
     "adzerk.net": [
       "asp.net"
@@ -5354,10 +5435,13 @@
     "afkp.net": [
       "autodesk.com"
     ],
+    "afy11.net": [
+      "sciencedaily.com"
+    ],
     "agkn.com": [
-      "cnet.com",
       "businessinsider.com",
-      "dailymotion.com"
+      "dailymotion.com",
+      "npr.org"
     ],
     "akamaihd.net": [
       "forbes.com",
@@ -5443,20 +5527,17 @@
       "answers.com"
     ],
     "answerscloud.com": [
-      "worldbank.org",
       "acs.org",
-      "fbi.gov"
+      "fbi.gov",
+      "uscourts.gov"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
-    "aol.com": [
-      "techcrunch.com"
-    ],
     "apester.com": [
-      "inquisitr.com",
       "searchenginewatch.com",
-      "nme.com"
+      "nme.com",
+      "indiewire.com"
     ],
     "apn.co.nz": [
       "nzherald.co.nz"
@@ -5483,17 +5564,17 @@
     ],
     "atdmt.com": [
       "facebook.com",
-      "shutterfly.com",
-      "xbox.com"
+      "vimeo.com",
+      "shutterfly.com"
     ],
     "atemda.com": [
       "springer.com",
       "home.pl"
     ],
     "ati-host.net": [
+      "bbc.co.uk",
       "bbc.com",
-      "straitstimes.com",
-      "thestar.com.my"
+      "straitstimes.com"
     ],
     "att.com": [
       "att.net"
@@ -5501,8 +5582,8 @@
     "attvlt2.azurewebsites.net": [
       "att.com"
     ],
-    "audiencemanager.de": [
-      "macrumors.com"
+    "audtd.com": [
+      "rambler.ru"
     ],
     "autopilothq.com": [
       "bitbucket.org",
@@ -5527,7 +5608,6 @@
       "bbc.com"
     ],
     "beemray.com": [
-      "telegraph.co.uk",
       "mirror.co.uk"
     ],
     "beian.gov.cn": [
@@ -5547,8 +5627,7 @@
       "liberation.fr"
     ],
     "biddingx.com": [
-      "sina.com.cn",
-      "sohu.com"
+      "sina.com.cn"
     ],
     "bidr.io": [
       "adobe.com",
@@ -5556,7 +5635,7 @@
       "dailymotion.com"
     ],
     "bidswitch.net": [
-      "dropbox.com",
+      "forbes.com",
       "telegraph.co.uk",
       "time.com"
     ],
@@ -5571,7 +5650,7 @@
     "bizible.com": [
       "cloudflare.com",
       "ibm.com",
-      "shutterstock.com"
+      "dyn.com"
     ],
     "bizographics.com": [
       "jimdo.com",
@@ -5585,7 +5664,7 @@
     ],
     "bluecava.com": [
       "giphy.com",
-      "walmart.com"
+      "active.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
@@ -5643,13 +5722,16 @@
       "qianlong.com"
     ],
     "bttrack.com": [
-      "nypost.com",
+      "walmart.com",
       "livescience.com",
       "variety.com"
     ],
     "btttag.com": [
       "samsung.com",
       "marriott.com"
+    ],
+    "bumlam.com": [
+      "rambler.ru"
     ],
     "c-ctrip.com": [
       "ctrip.com"
@@ -5668,7 +5750,6 @@
       "unm.edu"
     ],
     "carambo.la": [
-      "salon.com",
       "accuweather.com"
     ],
     "casalemedia.com": [
@@ -5685,11 +5766,13 @@
       "cbsnews.com"
     ],
     "ccgateway.net": [
-      "softonic.com",
       "biography.com"
     ],
-    "cdnwidget.com": [
-      "photoshelter.com"
+    "cdn-apple.com": [
+      "icloud.com"
+    ],
+    "cdn-net.com": [
+      "hotels.com"
     ],
     "cern.ch": [
       "home.cern"
@@ -5736,18 +5819,12 @@
       "sciencemag.org",
       "uci.edu"
     ],
-    "cmgdigital.com": [
-      "ajc.com"
-    ],
     "cnet.com": [
       "zdnet.com"
     ],
     "cntraveler.com": [
       "wired.com",
       "vogue.com"
-    ],
-    "cnzz.com": [
-      "zol.com.cn"
     ],
     "cobaltgroup.com": [
       "edmunds.com"
@@ -5765,8 +5842,8 @@
     ],
     "company-target.com": [
       "adobe.com",
-      "ibm.com",
-      "hp.com"
+      "forbes.com",
+      "ibm.com"
     ],
     "complex.com": [
       "knowyourmeme.com",
@@ -5798,8 +5875,8 @@
     ],
     "contextweb.com": [
       "sourceforge.net",
-      "myspace.com",
-      "uci.edu"
+      "forbes.com",
+      "myspace.com"
     ],
     "convertro.com": [
       "slack.com"
@@ -5835,15 +5912,13 @@
     ],
     "cssrvsync.com": [
       "springer.com",
+      "accuweather.com",
       "home.pl"
     ],
     "cxense.com": [
       "opera.com",
-      "talktalk.co.uk",
-      "gizmodo.com"
-    ],
-    "d1af033869koo7.cloudfront.net": [
-      "marriott.com"
+      "gizmodo.com",
+      "cbc.ca"
     ],
     "d1rv23qj5kas56.cloudfront.net": [
       "webnode.com"
@@ -5860,6 +5935,7 @@
       "metro.co.uk"
     ],
     "datamind.ru": [
+      "rambler.ru",
       "novostimira.com"
     ],
     "daum.net": [
@@ -5873,8 +5949,8 @@
     ],
     "demdex.net": [
       "adobe.com",
-      "yahoo.com",
-      "amazon.com"
+      "amazon.com",
+      "soundcloud.com"
     ],
     "deployads.com": [
       "tinyurl.com",
@@ -5884,6 +5960,9 @@
     "dezeenjobs.com": [
       "dezeen.com"
     ],
+    "df-srv.de": [
+      "sueddeutsche.de"
+    ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "go.com",
       "starwars.com"
@@ -5892,6 +5971,9 @@
       "businessinsider.com",
       "marketwatch.com",
       "zerohedge.com"
+    ],
+    "digitaltarget.ru": [
+      "rambler.ru"
     ],
     "digitru.st": [
       "britannica.com",
@@ -5905,16 +5987,16 @@
     ],
     "distiltag.com": [
       "reuters.com",
-      "merriam-webster.com",
-      "washingtontimes.com"
+      "merriam-webster.com"
     ],
     "districtm.io": [
+      "forbes.com",
       "barnesandnoble.com",
-      "scmp.com",
-      "seattletimes.com"
+      "scmp.com"
     ],
     "dmxleo.com": [
-      "dailymotion.com"
+      "dailymotion.com",
+      "pastebin.com"
     ],
     "dnnapi.com": [
       "zenfolio.com"
@@ -5925,9 +6007,9 @@
       "tinypic.com"
     ],
     "dotomi.com": [
+      "forbes.com",
       "samsung.com",
-      "economist.com",
-      "barnesandnoble.com"
+      "economist.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -5953,20 +6035,17 @@
     ],
     "dynamicyield.com": [
       "cnbc.com",
-      "nbcnews.com",
+      "norton.com",
       "washingtonexaminer.com"
-    ],
-    "dyntrk.com": [
-      "dailymotion.com"
     ],
     "ebay-us.com": [
       "ebay.com",
       "ebay.com.au"
     ],
     "ebay.com": [
-      "t-online.de",
       "ebay.co.uk",
-      "ebay.de"
+      "ebay.de",
+      "ebay.com.au"
     ],
     "ebayrtm.com": [
       "ebay.de",
@@ -5996,6 +6075,9 @@
       "thelancet.com",
       "cell.com"
     ],
+    "embedly.com": [
+      "popsci.com"
+    ],
     "emlgrid.com": [
       "home.pl"
     ],
@@ -6014,7 +6096,7 @@
     "everesttech.net": [
       "adobe.com",
       "sourceforge.net",
-      "dropbox.com"
+      "nytimes.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
@@ -6036,14 +6118,14 @@
       "exblog.jp"
     ],
     "exelator.com": [
-      "businessinsider.com",
-      "surveymonkey.com",
-      "talktalk.co.uk"
+      "soundcloud.com",
+      "forbes.com",
+      "businessinsider.com"
     ],
     "eyeota.net": [
       "sourceforge.net",
       "wsj.com",
-      "scientificamerican.com"
+      "investopedia.com"
     ],
     "eyereturn.com": [
       "thestar.com"
@@ -6057,8 +6139,8 @@
     ],
     "facebook.com": [
       "instagram.com",
-      "adobe.com",
-      "apple.com"
+      "apple.com",
+      "vimeo.com"
     ],
     "fastapi.net": [
       "sohu.com"
@@ -6068,6 +6150,9 @@
     ],
     "feathr.co": [
       "informationweek.com"
+    ],
+    "fidelity-media.com": [
+      "springer.com"
     ],
     "filepicker.io": [
       "enlightenment.org",
@@ -6081,7 +6166,7 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "monster.com"
+      "vmware.com"
     ],
     "flickr.com": [
       "oecd.org",
@@ -6100,6 +6185,7 @@
     ],
     "force.com": [
       "constantcontact.com",
+      "teamviewer.us",
       "salesforce.com"
     ],
     "foresee.com": [
@@ -6112,8 +6198,7 @@
     ],
     "fout.jp": [
       "economist.com",
-      "exblog.jp",
-      "seesaa.jp"
+      "exblog.jp"
     ],
     "foxbusiness.com": [
       "fox.com"
@@ -6146,15 +6231,15 @@
       "ria.ru",
       "onet.pl"
     ],
-    "gentags.net": [
-      "sohu.com"
-    ],
     "getclicky.com": [
       "newatlas.com",
       "cyberchimps.com"
     ],
     "getsmartcontent.com": [
       "pcworld.com"
+    ],
+    "gfycat.com": [
+      "reddit.com"
     ],
     "gigya.com": [
       "cnn.com",
@@ -6200,20 +6285,22 @@
     "groupondata.com": [
       "groupon.com"
     ],
+    "gssprt.jp": [
+      "seesaa.jp"
+    ],
     "gtags.net": [
       "ctrip.com",
-      "sina.com.cn",
       "suning.com"
     ],
     "gumgum.com": [
+      "snopes.com",
       "thehindu.com",
-      "home.pl",
-      "zimbio.com"
+      "home.pl"
     ],
     "gwallet.com": [
-      "adobe.com",
       "economist.com",
-      "ox.ac.uk"
+      "ox.ac.uk",
+      "smithsonianmag.com"
     ],
     "hatena.com": [
       "hatena.ne.jp"
@@ -6223,9 +6310,6 @@
     ],
     "hdslb.com": [
       "bilibili.com"
-    ],
-    "healte.de": [
-      "spiegel.de"
     ],
     "hearstnp.com": [
       "sfgate.com",
@@ -6238,9 +6322,6 @@
     "hitslink.com": [
       "webstarts.com"
     ],
-    "hive.co": [
-      "complex.com"
-    ],
     "hiwoenrep.ru": [
       "radikal.ru"
     ],
@@ -6249,9 +6330,6 @@
     ],
     "huanqiu.com": [
       "sina.com.cn"
-    ],
-    "hubpd.com": [
-      "huanqiu.com"
     ],
     "hubspot.com": [
       "scoop.it",
@@ -6267,11 +6345,8 @@
     "huihui.cn": [
       "youdao.com"
     ],
-    "hwcdn.net": [
-      "boingboing.net"
-    ],
-    "iasds01.com": [
-      "discovery.com"
+    "hybrid.ai": [
+      "rambler.ru"
     ],
     "ibclick.stream": [
       "webmd.com",
@@ -6287,14 +6362,15 @@
       "ibtimes.com"
     ],
     "id5-sync.com": [
-      "dailymotion.com",
       "livescience.com",
-      "skyrock.com"
+      "skyrock.com",
+      "space.com"
     ],
     "ign.com": [
       "videojs.com"
     ],
     "igodigital.com": [
+      "hp.com",
       "motorola.com",
       "nintendo.com"
     ],
@@ -6331,8 +6407,9 @@
       "flipboard.com"
     ],
     "insightexpressai.com": [
-      "unsplash.com",
-      "philly.com"
+      "reddit.com",
+      "giphy.com",
+      "unsplash.com"
     ],
     "instagram.com": [
       "illinois.edu",
@@ -6342,18 +6419,20 @@
     "instinctiveads.com": [
       "rollingstone.com",
       "variety.com",
-      "nist.gov"
+      "bgr.com"
     ],
     "intentiq.com": [
-      "thinkgeek.com"
+      "thinkgeek.com",
+      "active.com"
     ],
     "intentmedia.net": [
-      "tripadvisor.com"
+      "tripadvisor.com",
+      "hotels.com"
     ],
     "intercom.io": [
-      "visual.ly",
-      "yumpu.com",
-      "emarketer.com"
+      "elegantthemes.com",
+      "themegrill.com",
+      "yumpu.com"
     ],
     "intergient.com": [
       "infoplease.com"
@@ -6390,14 +6469,16 @@
     ],
     "irs01.com": [
       "youku.com",
-      "sohu.com"
+      "sohu.com",
+      "zol.com.cn"
     ],
     "janrainsso.com": [
       "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
-      "sohu.com"
+      "sohu.com",
+      "ifeng.com"
     ],
     "jquery.com": [
       "opensource.org",
@@ -6405,6 +6486,7 @@
       "businessinsider.com"
     ],
     "jrs5.com": [
+      "nike.com",
       "coursera.org",
       "bostonglobe.com"
     ],
@@ -6442,9 +6524,9 @@
       "dzwww.com"
     ],
     "krxd.net": [
-      "slate.com",
-      "twitch.tv",
-      "nypost.com"
+      "cnn.com",
+      "theguardian.com",
+      "surveymonkey.com"
     ],
     "leadintel.io": [
       "nme.com"
@@ -6452,10 +6534,16 @@
     "leadlander.com": [
       "panasonic.com"
     ],
+    "lentainform.com": [
+      "rambler.ru"
+    ],
     "liadm.com": [
       "bloomberg.com",
       "time.com",
       "economist.com"
+    ],
+    "licasd.com": [
+      "time.com"
     ],
     "ligadx.com": [
       "telegraph.co.uk",
@@ -6468,8 +6556,8 @@
       "fastcompany.com"
     ],
     "lijit.com": [
+      "sourceforge.net",
       "deviantart.com",
-      "uci.edu",
       "mirror.co.uk"
     ],
     "link-page.info": [
@@ -6502,12 +6590,11 @@
       "livejournal.com"
     ],
     "liveperson.net": [
-      "talktalk.co.uk",
+      "virginmedia.com",
       "earthlink.net",
       "thetimes.co.uk"
     ],
     "loc.gov": [
-      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
@@ -6556,30 +6643,28 @@
     ],
     "marketlinc.com": [
       "teamviewer.us",
+      "norton.com",
       "eset.com"
     ],
     "marketo.com": [
+      "ubuntu.com",
       "nokia.com",
-      "panasonic.com",
-      "dyn.com"
+      "panasonic.com"
     ],
     "matheranalytics.com": [
-      "theglobeandmail.com",
       "thestar.com",
-      "mercurynews.com"
+      "mercurynews.com",
+      "seattletimes.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net"
     ],
-    "mct01.com": [
-      "zol.com.cn"
-    ],
     "media.net": [
       "nytimes.com",
-      "dropbox.com",
-      "forbes.com"
+      "forbes.com",
+      "reuters.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
@@ -6592,9 +6677,9 @@
       "bostonglobe.com"
     ],
     "mediaplex.com": [
+      "t-online.de",
       "economist.com",
-      "dell.com",
-      "shutterfly.com"
+      "dell.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
@@ -6606,10 +6691,14 @@
       "ctrip.com",
       "toutiao.com"
     ],
+    "mediawallahscript.com": [
+      "sourceforge.net"
+    ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
+      "thelancet.com",
       "cell.com"
     ],
     "metadsp.co.uk": [
@@ -6629,22 +6718,21 @@
       "pconline.com.cn"
     ],
     "microad.jp": [
-      "sakura.ne.jp",
-      "hatena.ne.jp"
+      "sakura.ne.jp"
     ],
     "microsoft.com": [
-      "msn.com",
       "live.com",
-      "skype.com"
+      "skype.com",
+      "office.com"
     ],
     "microsoftonline.com": [
       "office.com",
       "microsoft.com"
     ],
     "mktoresp.com": [
+      "parallels.com",
       "zend.com",
-      "prweb.com",
-      "techtarget.com"
+      "prweb.com"
     ],
     "ml314.com": [
       "sourceforge.net",
@@ -6661,9 +6749,9 @@
       "marriott.com"
     ],
     "mookie1.com": [
-      "t-online.de",
       "businessinsider.com",
-      "photobucket.com"
+      "photobucket.com",
+      "theglobeandmail.com"
     ],
     "mouseflow.com": [
       "nintendo.com"
@@ -6673,12 +6761,14 @@
       "heise.de"
     ],
     "mrpfd.com": [
+      "symantec.com",
       "hpe.com"
     ],
     "msgapp.com": [
       "post-gazette.com"
     ],
     "msn.com": [
+      "w3.org",
       "marketwatch.com"
     ],
     "mtvnservices.com": [
@@ -6699,13 +6789,17 @@
       "myspace.com"
     ],
     "myvisualiq.net": [
-      "surveymonkey.com",
-      "spotify.com",
-      "economist.com"
+      "soundcloud.com",
+      "paypal.com",
+      "surveymonkey.com"
     ],
     "nanigans.com": [
+      "squareup.com",
       "thinkgeek.com",
       "yellowpages.com"
+    ],
+    "narrative.io": [
+      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -6714,7 +6808,7 @@
       "foxnews.com"
     ],
     "native.ai": [
-      "cbslocal.com"
+      "billboard.com"
     ],
     "nativendo.de": [
       "t-online.de"
@@ -6732,6 +6826,8 @@
       "today.com"
     ],
     "netmng.com": [
+      "businessinsider.com",
+      "lemonde.fr",
       "theknot.com"
     ],
     "neweggimages.com": [
@@ -6760,9 +6856,9 @@
       "nypost.com"
     ],
     "newsinc.com": [
-      "latimes.com",
       "hollywoodreporter.com",
-      "thehill.com"
+      "thehill.com",
+      "billboard.com"
     ],
     "newsvine.com": [
       "nbcnews.com",
@@ -6786,7 +6882,7 @@
       "bell-labs.com"
     ],
     "nr-data.net": [
-      "sourceforge.net",
+      "vimeo.com",
       "wsj.com",
       "huffingtonpost.com"
     ],
@@ -6795,9 +6891,9 @@
       "liberation.fr"
     ],
     "nxtck.com": [
+      "nike.com",
       "coursera.org",
-      "bostonglobe.com",
-      "orange.fr"
+      "bostonglobe.com"
     ],
     "o0bg.com": [
       "bostonglobe.com"
@@ -6815,6 +6911,9 @@
     "office365.com": [
       "microsoftonline.com"
     ],
+    "ojrq.net": [
+      "autodesk.com"
+    ],
     "ok.ru": [
       "ria.ru"
     ],
@@ -6826,6 +6925,9 @@
     ],
     "omkt.co": [
       "prweb.com"
+    ],
+    "omnidsp.com": [
+      "rambler.ru"
     ],
     "omnitagjs.com": [
       "independent.co.uk",
@@ -6870,7 +6972,7 @@
     ],
     "openx.net": [
       "nytimes.com",
-      "dropbox.com",
+      "forbes.com",
       "telegraph.co.uk"
     ],
     "opinionstage.com": [
@@ -6884,8 +6986,8 @@
       "qianlong.com"
     ],
     "optimizely.com": [
+      "nytimes.com",
       "creativecommons.org",
-      "live.com",
       "ibm.com",
       "blizzard.com"
     ],
@@ -6900,16 +7002,15 @@
       "t-online.de"
     ],
     "outbrain.com": [
-      "cnn.com",
       "msn.com",
-      "wsj.com"
+      "wsj.com",
+      "washingtonpost.com"
     ],
     "ovh.com": [
       "ovh.co.uk"
     ],
     "owneriq.net": [
       "lg.com",
-      "washingtontimes.com",
       "acer.com"
     ],
     "owox.com": [
@@ -6929,15 +7030,13 @@
       "bloomberg.com"
     ],
     "paypal.com": [
+      "greenpeace.org",
       "paypal.me"
     ],
     "paypalobjects.com": [
       "paypal.com",
       "paypal.me",
       "freetype.org"
-    ],
-    "payroll.com": [
-      "intuit.com"
     ],
     "performgroup.com": [
       "goal.com"
@@ -6968,10 +7067,8 @@
     "placelocal.com": [
       "gopro.com"
     ],
-    "plista.com": [
-      "express.co.uk"
-    ],
     "po.st": [
+      "smithsonianmag.com",
       "nme.com"
     ],
     "popsugar-assets.com": [
@@ -6985,7 +7082,7 @@
     "powerlinks.com": [
       "variety.com",
       "lemonde.fr",
-      "howtogeek.com"
+      "accuweather.com"
     ],
     "pressboard.ca": [
       "thestar.com",
@@ -7001,7 +7098,6 @@
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
-      "denverpost.com",
       "ocregister.com"
     ],
     "provenpixel.com": [
@@ -7031,7 +7127,11 @@
       "variety.com"
     ],
     "purch.com": [
+      "livescience.com",
       "space.com"
+    ],
+    "purechat.com": [
+      "byu.edu"
     ],
     "pushanert.com": [
       "4shared.com"
@@ -7048,6 +7148,9 @@
       "tencent.com",
       "yesky.com",
       "bshare.cn"
+    ],
+    "qualia.id": [
+      "active.com"
     ],
     "qualtrics.com": [
       "techrepublic.com",
@@ -7066,9 +7169,9 @@
       "intuit.com"
     ],
     "quora.com": [
-      "weebly.com",
       "bloomberg.com",
-      "ning.com"
+      "ning.com",
+      "nypost.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -7085,7 +7188,7 @@
       "ria.ru"
     ],
     "reachmax.cn": [
-      "yesky.com",
+      "qq.com",
       "bshare.cn",
       "sohu.com"
     ],
@@ -7099,8 +7202,8 @@
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
-    "render.githubusercontent.com": [
-      "github.com"
+    "republer.com": [
+      "rambler.ru"
     ],
     "researchintel.com": [
       "intel.com"
@@ -7120,13 +7223,12 @@
     ],
     "rezync.com": [
       "economist.com",
-      "salon.com",
       "investopedia.com"
     ],
     "rfihub.com": [
-      "dropbox.com",
       "tinyurl.com",
-      "npr.org"
+      "npr.org",
+      "economist.com"
     ],
     "rhombusads.com": [
       "adweek.com"
@@ -7144,8 +7246,8 @@
     ],
     "rkdms.com": [
       "wired.com",
-      "cbsnews.com",
-      "gizmodo.com"
+      "npr.org",
+      "cbsnews.com"
     ],
     "rlcdn.com": [
       "adobe.com",
@@ -7163,13 +7265,17 @@
       "startribune.com",
       "azcentral.com"
     ],
-    "ru4.com": [
-      "uci.edu"
-    ],
     "rubiconproject.com": [
-      "yahoo.com",
-      "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "wsj.com"
+    ],
+    "rundsp.com": [
+      "pastebin.com"
+    ],
+    "rutarget.ru": [
+      "rambler.ru",
+      "ria.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "bell-labs.com"
@@ -7182,8 +7288,8 @@
     ],
     "salesforceliveagent.com": [
       "marriott.com",
-      "prweb.com",
-      "salesforce.com"
+      "teamviewer.us",
+      "prweb.com"
     ],
     "salesloft.com": [
       "wpengine.com",
@@ -7220,9 +7326,9 @@
       "cell.com"
     ],
     "scorecardresearch.com": [
-      "linkedin.com",
       "yahoo.com",
-      "tumblr.com"
+      "tumblr.com",
+      "flickr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
@@ -7261,9 +7367,9 @@
       "sciencedaily.com"
     ],
     "serving-sys.com": [
-      "dropbox.com",
-      "businessinsider.com",
-      "sciencemag.org"
+      "npr.org",
+      "news.com.au",
+      "businessinsider.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -7272,20 +7378,18 @@
     "sf14g.com": [
       "panasonic.com"
     ],
-    "shareaholic.com": [
-      "washingtontimes.com"
-    ],
     "sharethis.com": [
       "uk.com",
-      "uci.edu",
-      "us.org"
+      "us.org",
+      "www.vic.gov.au"
     ],
     "sharethrough.com": [
-      "springer.com",
-      "photobucket.com",
-      "cnbc.com"
+      "cnet.com",
+      "time.com",
+      "independent.co.uk"
     ],
     "shop.pe": [
+      "dyn.com",
       "bluehost.com"
     ],
     "siftscience.com": [
@@ -7310,16 +7414,16 @@
       "udel.edu"
     ],
     "siteimproveanalytics.io": [
-      "in.gov"
+      "jhu.edu"
     ],
     "sitelock.com": [
       "joomla.org",
       "netfirms.com"
     ],
     "sitescout.com": [
-      "barnesandnoble.com",
-      "tinypic.com",
-      "salon.com"
+      "tinyurl.com",
+      "time.com",
+      "sciencedaily.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
@@ -7348,9 +7452,9 @@
       "smithsonianmag.com"
     ],
     "snapchat.com": [
+      "wsj.com",
       "giphy.com",
-      "walmart.com",
-      "wpengine.com"
+      "walmart.com"
     ],
     "so.com": [
       "360.cn"
@@ -7367,18 +7471,20 @@
       "howstuffworks.com"
     ],
     "sogou.com": [
+      "ifeng.com",
       "soso.com"
     ],
     "sohu.com": [
+      "ifeng.com",
       "bshare.cn"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
     "sonobi.com": [
-      "usatoday.com",
-      "springer.com",
-      "deviantart.com"
+      "myspace.com",
+      "cnet.com",
+      "usatoday.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
@@ -7410,15 +7516,17 @@
       "denverpost.com"
     ],
     "spotxchange.com": [
-      "dailymotion.com",
       "express.co.uk",
-      "thenextweb.com"
+      "thenextweb.com",
+      "thestar.com"
     ],
     "spoutable.com": [
       "alternet.org",
       "dailydot.com"
     ],
     "springernature.com": [
+      "nature.com",
+      "springer.com",
       "biomedcentral.com"
     ],
     "springserve.com": [
@@ -7427,12 +7535,15 @@
     "springserve.net": [
       "tinypic.com"
     ],
+    "squarecdn.com": [
+      "squareup.com"
+    ],
     "srx.com.sg": [
       "straitstimes.com"
     ],
     "stackadapt.com": [
       "shopify.com",
-      "farfetch.com"
+      "politico.com"
     ],
     "statcounter.com": [
       "hugedomains.com",
@@ -7450,7 +7561,7 @@
     "stickyadstv.com": [
       "dailymotion.com",
       "discovery.com",
-      "thinkgeek.com"
+      "pastebin.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
@@ -7465,8 +7576,8 @@
     ],
     "sumo.com": [
       "snopes.com",
-      "studiopress.com",
-      "sitepoint.com"
+      "cdbaby.com",
+      "studiopress.com"
     ],
     "sundaysky.com": [
       "fiverr.com",
@@ -7487,6 +7598,9 @@
     "supplyframe.com": [
       "arduino.cc"
     ],
+    "survata.com": [
+      "tripadvisor.com"
+    ],
     "surveymonkey.com": [
       "cambridge.org",
       "iop.org",
@@ -7497,10 +7611,13 @@
       "thehindu.com",
       "coindesk.com"
     ],
+    "symantec.com": [
+      "norton.com"
+    ],
     "taboola.com": [
-      "weebly.com",
-      "dropbox.com",
-      "msn.com"
+      "msn.com",
+      "t-online.de",
+      "aol.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -7509,7 +7626,8 @@
       "uol.com.br"
     ],
     "tamgrt.com": [
-      "tripadvisor.com"
+      "tripadvisor.com",
+      "hotels.com"
     ],
     "tanx.com": [
       "sina.com.cn",
@@ -7522,9 +7640,9 @@
       "tmall.com"
     ],
     "tapad.com": [
-      "hp.com",
-      "wired.com",
-      "spotify.com"
+      "adobe.com",
+      "soundcloud.com",
+      "tinyurl.com"
     ],
     "tawk.to": [
       "cba.pl",
@@ -7551,8 +7669,8 @@
       "sueddeutsche.de"
     ],
     "thebrighttag.com": [
+      "netflix.com",
       "playstation.com",
-      "washingtontimes.com",
       "mercurynews.com"
     ],
     "theglobeandmail.ca": [
@@ -7561,11 +7679,11 @@
     "theguardian.com": [
       "videojs.com"
     ],
+    "thrtle.com": [
+      "sourceforge.net"
+    ],
     "tianqi.com": [
       "qianlong.com"
-    ],
-    "tidaltv.com": [
-      "dailymotion.com"
     ],
     "tidelinedata.io": [
       "deviantart.com"
@@ -7588,9 +7706,6 @@
       "cisco.com",
       "marketwatch.com"
     ],
-    "tmall.com": [
-      "taobao.com"
-    ],
     "tns-counter.ru": [
       "vk.com",
       "livejournal.com",
@@ -7600,7 +7715,6 @@
       "qualtrics.com"
     ],
     "tradelab.fr": [
-      "eklablog.com",
       "leparisien.fr"
     ],
     "traffic-media.co": [
@@ -7621,14 +7735,12 @@
       "baltimoresun.com"
     ],
     "treasuredata.com": [
-      "exblog.jp",
-      "hatena.ne.jp",
-      "nintendo.com"
+      "exblog.jp"
     ],
     "tribalfusion.com": [
-      "dailymotion.com",
       "marriott.com",
-      "pastebin.com"
+      "pastebin.com",
+      "liveleak.com"
     ],
     "tribl.io": [
       "prnewswire.com",
@@ -7643,8 +7755,7 @@
       "baltimoresun.com"
     ],
     "trumba.com": [
-      "ucdavis.edu",
-      "emory.edu"
+      "ucdavis.edu"
     ],
     "truoptik.com": [
       "slashdot.org"
@@ -7656,9 +7767,9 @@
       "theweek.com"
     ],
     "turn.com": [
+      "forbes.com",
       "tinyurl.com",
-      "hp.com",
-      "wired.com"
+      "hp.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
@@ -7674,9 +7785,9 @@
       "nytimes.com"
     ],
     "tynt.com": [
-      "salon.com",
       "investopedia.com",
-      "accuweather.com"
+      "accuweather.com",
+      "digital.com"
     ],
     "uc.se": [
       "jalbum.net"
@@ -7695,6 +7806,7 @@
       "nba.com"
     ],
     "undertone.com": [
+      "hpe.com",
       "dallasnews.com"
     ],
     "unicc.org": [
@@ -7708,9 +7820,11 @@
       "hbr.org",
       "boingboing.net"
     ],
+    "upravel.com": [
+      "rambler.ru"
+    ],
     "upsellit.com": [
       "samsung.com",
-      "motorola.com",
       "ccleaner.com"
     ],
     "urbandictionary.store": [
@@ -7769,18 +7883,16 @@
       "cbc.ca"
     ],
     "videohub.tv": [
-      "wsj.com",
-      "uci.edu"
+      "wsj.com"
     ],
     "vidible.tv": [
-      "huffingtonpost.com",
       "aol.com",
       "autoblog.com"
     ],
     "viglink.com": [
+      "cnet.com",
       "zdnet.com",
-      "thedailybeast.com",
-      "softonic.com"
+      "thedailybeast.com"
     ],
     "vilynx.com": [
       "cbsnews.com",
@@ -7790,7 +7902,7 @@
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "wufoo.com"
+      "princeton.edu"
     ],
     "vindicosuite.com": [
       "myspace.com",
@@ -7820,7 +7932,9 @@
       "recode.net"
     ],
     "w55c.net": [
-      "hpe.com"
+      "hp.com",
+      "businessinsider.com",
+      "npr.org"
     ],
     "wal.co": [
       "walmart.com"
@@ -7835,6 +7949,7 @@
       "tmz.com"
     ],
     "wbtrk.net": [
+      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
@@ -7847,7 +7962,8 @@
       "wunderground.com"
     ],
     "webmd.com": [
-      "medscape.com"
+      "medscape.com",
+      "medicinenet.com"
     ],
     "weborama.fr": [
       "lemonde.fr",
@@ -7955,12 +8071,16 @@
       "libero.it",
       "virgilio.it"
     ],
+    "wywyuserservice.com": [
+      "vmware.com"
+    ],
     "xad.com": [
       "vt.edu"
     ],
     "xg4ken.com": [
       "bluehost.com",
-      "kaspersky.com"
+      "kaspersky.com",
+      "udemy.com"
     ],
     "xinhuanet.com": [
       "news.cn"
@@ -7975,15 +8095,14 @@
       "ocn.ne.jp"
     ],
     "xplosion.de": [
-      "t-online.de",
       "spiegel.de",
-      "sueddeutsche.de"
+      "sueddeutsche.de",
+      "zeit.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
     ],
     "xtgreat.com": [
-      "qq.com",
       "sohu.com"
     ],
     "yadro.ru": [
@@ -7992,9 +8111,9 @@
       "rt.com"
     ],
     "yahoo.co.jp": [
-      "dropbox.com",
       "economist.com",
-      "exblog.jp"
+      "exblog.jp",
+      "shutterstock.com"
     ],
     "yahoo.com": [
       "vimeo.com",
@@ -8012,7 +8131,7 @@
     "yastatic.net": [
       "liveinternet.ru",
       "sputniknews.com",
-      "qip.ru"
+      "tass.ru"
     ],
     "yieldlab.net": [
       "t-online.de",
@@ -8023,9 +8142,9 @@
       "fourseasons.com"
     ],
     "yimg.com": [
-      "yahoo.com",
       "flickr.com",
-      "nytimes.com"
+      "nytimes.com",
+      "dropbox.com"
     ],
     "yldbt.com": [
       "biography.com",
@@ -8062,9 +8181,9 @@
       "infoplease.com"
     ],
     "zemanta.com": [
-      "variety.com",
-      "lemonde.fr",
-      "farfetch.com"
+      "forbes.com",
+      "paypal.com",
+      "variety.com"
     ],
     "zergnet.com": [
       "imdb.com",
@@ -8078,6 +8197,7 @@
       "coindesk.com"
     ],
     "ziffdavis.com": [
+      "ign.com",
       "extremetech.com"
     ],
     "zoomph.com": [
@@ -8092,5 +8212,5 @@
       "parallels.com"
     ]
   },
-  "version": "2018.9.27"
+  "version": "2018.9.28"
 }

--- a/results.json
+++ b/results.json
@@ -3,7 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535788795191,
+      "nextUpdateTime": 1535574366154,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,31 +27,37 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535401551141,
+      "nextUpdateTime": 1535940577860,
+      "userAction": ""
+    },
+    "1dmp.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535675926040,
+      "nextUpdateTime": 1535651482302,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526413536,
+      "nextUpdateTime": 1535556135314,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535446296434,
+      "nextUpdateTime": 1535695702688,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535464900319,
+      "nextUpdateTime": 1535927532754,
       "userAction": ""
     },
     "2o7.net": {
@@ -69,163 +75,157 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535761492828,
+      "nextUpdateTime": 1535895120778,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535388823758,
+      "nextUpdateTime": 1535610484977,
       "userAction": ""
     },
     "4303900.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535478816612,
+      "nextUpdateTime": 1535857837364,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535759188077,
+      "nextUpdateTime": 1535596840473,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535688182526,
+      "nextUpdateTime": 1535803262487,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535386344298,
+      "nextUpdateTime": 1535560640124,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535654852731,
+      "nextUpdateTime": 1535564507606,
       "userAction": ""
     },
     "516-dgm-318.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535777195298,
+      "nextUpdateTime": 1535612912168,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469873107,
+      "nextUpdateTime": 1535672353106,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535673581756,
+      "nextUpdateTime": 1535922487903,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389517664,
+      "nextUpdateTime": 1535748710087,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535862929541,
+      "nextUpdateTime": 1535720157703,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535450680018,
+      "nextUpdateTime": 1535922263721,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535699002706,
+      "nextUpdateTime": 1535558701365,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535735755008,
+      "nextUpdateTime": 1535705793636,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535856801759,
+      "nextUpdateTime": 1535729644705,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535737606634,
+      "nextUpdateTime": 1535817179790,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694525374,
+      "nextUpdateTime": 1535695345166,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535541776370,
+      "nextUpdateTime": 1535690460813,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535586462406,
+      "nextUpdateTime": 1535515726416,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535692286771,
+      "nextUpdateTime": 1535681555823,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535584735036,
-      "userAction": ""
-    },
-    "a6264210458.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535775205652,
+      "nextUpdateTime": 1535644294827,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535709114205,
+      "nextUpdateTime": 1535738145329,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535877883165,
+      "nextUpdateTime": 1535467395021,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535710239051,
+      "nextUpdateTime": 1535598814522,
       "userAction": ""
     },
     "aax.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526366481,
+      "nextUpdateTime": 1535901789257,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -237,13 +237,13 @@
     "accounts.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535397748018,
+      "nextUpdateTime": 1535736262835,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535499002047,
+      "nextUpdateTime": 1535895412521,
       "userAction": ""
     },
     "acpm.fr": {
@@ -255,37 +255,43 @@
     "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535492709945,
+      "nextUpdateTime": 1535510347212,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535703175969,
+      "nextUpdateTime": 1535451360532,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535624113348,
+      "nextUpdateTime": 1535546516924,
+      "userAction": ""
+    },
+    "ad-score.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535795181462,
+      "nextUpdateTime": 1535755342766,
       "userAction": ""
     },
-    "ad.turn.com": {
+    "ad.mail.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535645779490,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535793253863,
       "userAction": ""
     },
     "ad.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535465359379,
+      "nextUpdateTime": 1535951806065,
       "userAction": ""
     },
     "addthis.com": {
@@ -300,10 +306,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adlmerge.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535497530432,
       "userAction": ""
     },
     "adm.fwmrm.net": {
@@ -321,7 +339,7 @@
     "ado.pro-market.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535496181306,
+      "nextUpdateTime": 1535748637442,
       "userAction": ""
     },
     "adroll.com": {
@@ -330,57 +348,57 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.creative-serving.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535547437788,
-      "userAction": ""
-    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535622785616,
+      "nextUpdateTime": 1535458586592,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535644312504,
+      "nextUpdateTime": 1535871108745,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535374198969,
+      "nextUpdateTime": 1535471847357,
       "userAction": ""
     },
     "ads.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535698534424,
+      "nextUpdateTime": 1535837937648,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535762468415,
+      "nextUpdateTime": 1535522038868,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535801173589,
+      "nextUpdateTime": 1535535646707,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535805192169,
+      "nextUpdateTime": 1535549205489,
       "userAction": ""
     },
     "adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -396,10 +414,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adtags.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx.com.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535858535725,
       "userAction": ""
     },
     "agkn.com": {
@@ -408,10 +438,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aimfar.solution.weborama.fr": {
+    "aidata.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535411075710,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aimfar.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535679293961,
       "userAction": ""
     },
     "allure.com": {
@@ -435,31 +471,31 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535875271545,
+      "nextUpdateTime": 1535852651670,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535627226385,
+      "nextUpdateTime": 1535756031250,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535453996514,
+      "nextUpdateTime": 1535739670165,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535666267445,
+      "nextUpdateTime": 1535489431737,
       "userAction": ""
     },
     "analytics.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535406703135,
+      "nextUpdateTime": 1535497570934,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -471,61 +507,61 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535677918307,
+      "nextUpdateTime": 1535545407977,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535404214200,
+      "nextUpdateTime": 1535734725089,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535728889831,
+      "nextUpdateTime": 1535646885704,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535824772269,
+      "nextUpdateTime": 1535496392864,
       "userAction": ""
     },
     "api.adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535869432705,
+      "nextUpdateTime": 1535610556073,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535382298584,
+      "nextUpdateTime": 1535667795032,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535785037169,
+      "nextUpdateTime": 1535799853232,
       "userAction": ""
     },
     "api.nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535718185775,
+      "nextUpdateTime": 1535573272097,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535527024950,
+      "nextUpdateTime": 1535526188562,
       "userAction": ""
     },
     "api.viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535637161762,
+      "nextUpdateTime": 1535837253495,
       "userAction": ""
     },
     "apis.google.com": {
@@ -537,7 +573,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535495358983,
+      "nextUpdateTime": 1535705741301,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -549,7 +585,7 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535541366255,
+      "nextUpdateTime": 1535778737155,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -561,49 +597,49 @@
     "au.audience.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535814559640,
+      "nextUpdateTime": 1535493275684,
       "userAction": ""
     },
     "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535677376528,
+      "nextUpdateTime": 1535533997563,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535872214563,
+      "nextUpdateTime": 1535486459205,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535424935792,
+      "nextUpdateTime": 1535826163427,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535376045654,
+      "nextUpdateTime": 1535850919219,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517044616,
+      "nextUpdateTime": 1535503086090,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535856575288,
+      "nextUpdateTime": 1535857829768,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535852563130,
+      "nextUpdateTime": 1535588620683,
       "userAction": ""
     },
     "bfmio.com": {
@@ -615,19 +651,19 @@
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535415374852,
+      "nextUpdateTime": 1535918584905,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535474628495,
+      "nextUpdateTime": 1535462855319,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535431025536,
+      "nextUpdateTime": 1535847717423,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -675,7 +711,7 @@
     "boxinc.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535712697947,
+      "nextUpdateTime": 1535788486927,
       "userAction": ""
     },
     "brides.com": {
@@ -687,61 +723,73 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535842806454,
+      "nextUpdateTime": 1535882683488,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399016694,
+      "nextUpdateTime": 1535742566208,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535736023435,
+      "nextUpdateTime": 1535714537026,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535782500293,
+      "nextUpdateTime": 1535499348118,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535392363633,
+      "nextUpdateTime": 1535593788843,
+      "userAction": ""
+    },
+    "c.datpix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535929878835,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535786966647,
+      "nextUpdateTime": 1535843909307,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535852907247,
+      "nextUpdateTime": 1535745741276,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535445294990,
+      "nextUpdateTime": 1535633412069,
+      "userAction": ""
+    },
+    "c1.adform.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535883830729,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535750341028,
+      "nextUpdateTime": 1535694406005,
       "userAction": ""
     },
     "cache.vindicosuite.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535798036507,
+      "nextUpdateTime": 1535646678212,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -750,16 +798,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "caltat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535524141208,
+      "nextUpdateTime": 1535936828607,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434052072,
+      "nextUpdateTime": 1535585773243,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -771,31 +825,37 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535430074265,
+      "nextUpdateTime": 1535478492051,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535636853472,
+      "nextUpdateTime": 1535678194329,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535554773399,
+      "nextUpdateTime": 1535878784206,
+      "userAction": ""
+    },
+    "cdn.inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535620914588,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535689602008,
+      "nextUpdateTime": 1535489425202,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535464365388,
+      "nextUpdateTime": 1535640903944,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -807,31 +867,31 @@
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535592534219,
+      "nextUpdateTime": 1535916357377,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535840819214,
+      "nextUpdateTime": 1535647079432,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535447686266,
+      "nextUpdateTime": 1535754928056,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535589550351,
+      "nextUpdateTime": 1535598133851,
       "userAction": ""
     },
     "cdns.gigya.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535647245640,
+      "nextUpdateTime": 1535604636517,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -843,7 +903,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535574432947,
+      "nextUpdateTime": 1535912957647,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -861,13 +921,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535663337899,
+      "nextUpdateTime": 1535545995328,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535553091314,
+      "nextUpdateTime": 1535500216943,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -879,7 +939,7 @@
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535827604724,
+      "nextUpdateTime": 1535914813920,
       "userAction": ""
     },
     "company-target.com": {
@@ -891,7 +951,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535374260391,
+      "nextUpdateTime": 1535961983554,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -903,7 +963,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535847059054,
+      "nextUpdateTime": 1535610657582,
       "userAction": ""
     },
     "consensu.org": {
@@ -921,13 +981,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535761812068,
+      "nextUpdateTime": 1535644691945,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535878685866,
+      "nextUpdateTime": 1535769653005,
       "userAction": ""
     },
     "contextweb.com": {
@@ -939,18 +999,12 @@
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535679702748,
+      "nextUpdateTime": 1535484862572,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creative-serving.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -966,16 +1020,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "csm2waycm-atl.netmng.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535410980550,
-      "userAction": ""
-    },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535439755325,
+      "nextUpdateTime": 1535817088302,
       "userAction": ""
     },
     "cxense.com": {
@@ -987,67 +1035,91 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535430010745,
+      "nextUpdateTime": 1535892452597,
       "userAction": ""
     },
     "d.agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535878099411,
+      "nextUpdateTime": 1535636389666,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535631040531,
+      "nextUpdateTime": 1535557003597,
       "userAction": ""
     },
     "d.df-srv.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535827462928,
+      "nextUpdateTime": 1535942927369,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535848586849,
+      "nextUpdateTime": 1535683801735,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535668347467,
+      "nextUpdateTime": 1535759989893,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535504240917,
+      "nextUpdateTime": 1535711046845,
+      "userAction": ""
+    },
+    "data.ad-score.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535770730900,
+      "userAction": ""
+    },
+    "data.dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535762735169,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535749458146,
+      "nextUpdateTime": 1535857345882,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535454047672,
+      "nextUpdateTime": 1535789663952,
+      "userAction": ""
+    },
+    "datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "datpix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535863673793,
+      "nextUpdateTime": 1535873979413,
       "userAction": ""
     },
     "de.ioam.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535379626780,
+      "nextUpdateTime": 1535466422250,
       "userAction": ""
     },
     "deepintent.com": {
@@ -1080,6 +1152,24 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaladsystems.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaltarget.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1089,19 +1179,13 @@
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535628369138,
+      "nextUpdateTime": 1535670042661,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535449581444,
-      "userAction": ""
-    },
-    "districtm-match.dotomi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535854298539,
+      "nextUpdateTime": 1535720094693,
       "userAction": ""
     },
     "districtm.io": {
@@ -1110,10 +1194,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dm-us.hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535589581939,
+      "userAction": ""
+    },
+    "dm.hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535689555708,
+      "userAction": ""
+    },
+    "dmg.digitaltarget.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535852281239,
+      "userAction": ""
+    },
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535378721840,
+      "nextUpdateTime": 1535595988233,
       "userAction": ""
     },
     "docs.google.com": {
@@ -1137,7 +1239,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535831172248,
+      "nextUpdateTime": 1535607931755,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1149,13 +1251,7 @@
     "dsum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535678767436,
-      "userAction": ""
-    },
-    "dsum.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535609816884,
+      "nextUpdateTime": 1535938750810,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1167,7 +1263,7 @@
     "eb2.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535722569370,
+      "nextUpdateTime": 1535826511101,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1179,7 +1275,7 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535753398903,
+      "nextUpdateTime": 1535881020504,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1203,19 +1299,25 @@
     "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535856865212,
+      "nextUpdateTime": 1535674741536,
+      "userAction": ""
+    },
+    "eu.track.digitaladsystems.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535871670836,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535641546461,
+      "nextUpdateTime": 1535957567699,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535653806247,
+      "nextUpdateTime": 1535542299351,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1227,7 +1329,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535738201505,
+      "nextUpdateTime": 1535624124109,
       "userAction": ""
     },
     "exelator.com": {
@@ -1239,7 +1341,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535558917724,
+      "nextUpdateTime": 1535598114496,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1260,16 +1362,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "faggrim.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535612994323,
+      "userAction": ""
+    },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510602994,
+      "nextUpdateTime": 1535463240415,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535503704591,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535905176352,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1293,13 +1401,13 @@
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535786137485,
+      "nextUpdateTime": 1535788047904,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535672050463,
+      "nextUpdateTime": 1535744855557,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1317,55 +1425,61 @@
     "g.cn.miaozhen.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535453186928,
+      "nextUpdateTime": 1535694446011,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535882689211,
+      "nextUpdateTime": 1535682782409,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535656273590,
+      "nextUpdateTime": 1535628645321,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535727758035,
+      "nextUpdateTime": 1535579017912,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535797268646,
+      "nextUpdateTime": 1535532577705,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535705787427,
+      "nextUpdateTime": 1535738506516,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535540739730,
+      "nextUpdateTime": 1535558203644,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535730629382,
+      "nextUpdateTime": 1535485170416,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535626747902,
+      "nextUpdateTime": 1535563893270,
+      "userAction": ""
+    },
+    "geosync.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535926178244,
       "userAction": ""
     },
     "gigya.com": {
@@ -1401,7 +1515,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535826656370,
+      "nextUpdateTime": 1535598569331,
       "userAction": ""
     },
     "gq.com": {
@@ -1413,7 +1527,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535759414387,
+      "nextUpdateTime": 1535711236388,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1425,19 +1539,19 @@
     "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535507099814,
+      "nextUpdateTime": 1535770595777,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535649797924,
+      "nextUpdateTime": 1535871768873,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535648232623,
+      "nextUpdateTime": 1535579223748,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1455,49 +1569,73 @@
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535553980236,
+      "nextUpdateTime": 1535585198153,
+      "userAction": ""
+    },
+    "hgbn.rocks": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535863358694,
+      "userAction": ""
+    },
+    "hgbnr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535728786580,
       "userAction": ""
     },
     "hpr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535743743028,
+      "nextUpdateTime": 1535497040220,
+      "userAction": ""
+    },
+    "hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535512774273,
+      "nextUpdateTime": 1535739388610,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584943973,
+      "nextUpdateTime": 1535735230278,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535787032117,
+      "nextUpdateTime": 1535579900537,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535513900580,
+      "nextUpdateTime": 1535879292043,
       "userAction": ""
     },
     "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535842083486,
+      "nextUpdateTime": 1535551583447,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535758065418,
+      "nextUpdateTime": 1535730891780,
+      "userAction": ""
+    },
+    "images.taboola.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535479823214,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1509,13 +1647,19 @@
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535808038725,
+      "nextUpdateTime": 1535542941029,
+      "userAction": ""
+    },
+    "inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535671726914,
+      "nextUpdateTime": 1535576906508,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -1527,7 +1671,7 @@
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535612904028,
+      "nextUpdateTime": 1535916640573,
       "userAction": ""
     },
     "intercom.io": {
@@ -1539,13 +1683,7 @@
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535735061426,
-      "userAction": ""
-    },
-    "io.narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535606837889,
+      "nextUpdateTime": 1535958592894,
       "userAction": ""
     },
     "ioam.de": {
@@ -1563,13 +1701,19 @@
     "ips-invite.iperceptions.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535375027028,
+      "nextUpdateTime": 1535746109483,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535770127897,
+      "nextUpdateTime": 1535501210103,
+      "userAction": ""
+    },
+    "js.adsrvr.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535523156086,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1683,49 +1827,55 @@
     "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535428983326,
+      "nextUpdateTime": 1535541362768,
       "userAction": ""
     },
     "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535568292353,
+      "nextUpdateTime": 1535938747750,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535748410763,
+      "nextUpdateTime": 1535583123603,
       "userAction": ""
     },
     "log.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370949838,
+      "nextUpdateTime": 1535577619677,
       "userAction": ""
     },
     "login-ds.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535825469673,
+      "nextUpdateTime": 1535487720538,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535874272649,
+      "nextUpdateTime": 1535602940193,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535689077144,
+      "nextUpdateTime": 1535800795531,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535461732087,
+      "nextUpdateTime": 1535797170899,
+      "userAction": ""
+    },
+    "mail.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1749,19 +1899,25 @@
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535538905152,
+      "nextUpdateTime": 1535858739536,
       "userAction": ""
     },
     "match.deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535666184280,
+      "nextUpdateTime": 1535770736865,
       "userAction": ""
     },
     "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535472065106,
+      "nextUpdateTime": 1535669407198,
+      "userAction": ""
+    },
+    "matching.adtags.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535931796491,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1773,13 +1929,13 @@
     "mc.webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535487104791,
+      "nextUpdateTime": 1535584418815,
       "userAction": ""
     },
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535384523811,
+      "nextUpdateTime": 1535737532185,
       "userAction": ""
     },
     "media.net": {
@@ -1797,12 +1953,18 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535521562609,
+      "nextUpdateTime": 1535842898170,
       "userAction": ""
     },
     "mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mfadsrvr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1815,7 +1977,7 @@
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535678969255,
+      "nextUpdateTime": 1535865290211,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1827,7 +1989,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535583104262,
+      "nextUpdateTime": 1535541848986,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1878,22 +2040,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370153417,
-      "userAction": ""
-    },
-    "netmng.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535560186363,
       "userAction": ""
     },
     "newscgp.com": {
@@ -1905,7 +2055,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535570964190,
+      "nextUpdateTime": 1535858989061,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1917,13 +2067,13 @@
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535589900794,
+      "nextUpdateTime": 1535683012789,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535639927435,
+      "nextUpdateTime": 1535610146889,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1935,7 +2085,7 @@
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535764787069,
+      "nextUpdateTime": 1535501585551,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -1965,7 +2115,7 @@
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535776170008,
+      "nextUpdateTime": 1535895613989,
       "userAction": ""
     },
     "optimizely.com": {
@@ -1989,43 +2139,43 @@
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535464989725,
+      "nextUpdateTime": 1535495458906,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535587202023,
+      "nextUpdateTime": 1535875406126,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535753838397,
+      "nextUpdateTime": 1535716223948,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535599122136,
+      "nextUpdateTime": 1535555301108,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535416241814,
+      "nextUpdateTime": 1535760257854,
       "userAction": ""
     },
     "p.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535444945040,
+      "nextUpdateTime": 1535783323409,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535521835134,
+      "nextUpdateTime": 1535815373509,
       "userAction": ""
     },
     "pardot.com": {
@@ -2043,19 +2193,19 @@
     "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535764673436,
+      "nextUpdateTime": 1535792440906,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470402299,
+      "nextUpdateTime": 1535797919846,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535690679472,
+      "nextUpdateTime": 1535582597532,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -2073,73 +2223,73 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535419137841,
+      "nextUpdateTime": 1535876656131,
       "userAction": ""
     },
     "pixel-geo.prfct.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535473701074,
+      "nextUpdateTime": 1535836609372,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535791753209,
+      "nextUpdateTime": 1535531983715,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535454724028,
+      "nextUpdateTime": 1535859784800,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584375101,
+      "nextUpdateTime": 1535459106331,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535431775060,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535748451871,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470366014,
+      "nextUpdateTime": 1535639969032,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535494298982,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535645678163,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535827732761,
+      "nextUpdateTime": 1535635208019,
       "userAction": ""
     },
     "pixel.tapad.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535550390073,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535610784392,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535443656582,
+      "nextUpdateTime": 1535897272070,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535862853985,
+      "nextUpdateTime": 1535554574334,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2157,13 +2307,13 @@
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535634741658,
+      "nextUpdateTime": 1535916234173,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535602138418,
+      "nextUpdateTime": 1535930452354,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2175,13 +2325,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535694456088,
+      "nextUpdateTime": 1535756748496,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535608927078,
+      "nextUpdateTime": 1535710477120,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2193,7 +2343,7 @@
     "pr-bh.ybp.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535721998785,
+      "nextUpdateTime": 1535914334685,
       "userAction": ""
     },
     "prfct.co": {
@@ -2208,28 +2358,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "profile.justuno.com": {
+    "profile.ssp.rambler.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535868066793,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535789715456,
       "userAction": ""
     },
     "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535775857188,
+      "nextUpdateTime": 1535737146713,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535440273805,
+      "nextUpdateTime": 1535788753573,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535537986452,
+      "nextUpdateTime": 1535909696148,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2241,55 +2391,55 @@
     "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535447877021,
+      "nextUpdateTime": 1535842539658,
       "userAction": ""
     },
-    "purch-sync.go.sonobi.com": {
+    "px.adhigh.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535442782846,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535700996611,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535475285092,
+      "nextUpdateTime": 1535686118831,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535501609306,
+      "nextUpdateTime": 1535707783947,
       "userAction": ""
     },
     "px.owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535800014348,
+      "nextUpdateTime": 1535951971781,
       "userAction": ""
     },
     "px.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535366852912,
+      "nextUpdateTime": 1535887595495,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535668867614,
+      "nextUpdateTime": 1535801751541,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535644633942,
+      "nextUpdateTime": 1535857711077,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535552433183,
+      "nextUpdateTime": 1535884922283,
       "userAction": ""
     },
     "quantserve.com": {
@@ -2307,7 +2457,7 @@
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535814046934,
+      "nextUpdateTime": 1535790117318,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2319,31 +2469,43 @@
     "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535373600303,
+      "nextUpdateTime": 1535724135338,
       "userAction": ""
     },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535496894433,
+      "nextUpdateTime": 1535943279957,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535666183003,
+      "nextUpdateTime": 1535922335285,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535584949059,
+      "nextUpdateTime": 1535959894691,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711947766,
+      "nextUpdateTime": 1535760317951,
+      "userAction": ""
+    },
+    "relap.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535610652702,
+      "userAction": ""
+    },
+    "republer-sync.rutarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535696676261,
       "userAction": ""
     },
     "rfihub.com": {
@@ -2366,25 +2528,37 @@
     },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535845692253,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535789708558,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535583943990,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535574550900,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535699311885,
+      "nextUpdateTime": 1535878658398,
+      "userAction": ""
+    },
+    "rtb.mfadsrvr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535602308341,
       "userAction": ""
     },
     "rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rutarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2397,73 +2571,79 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535807522405,
+      "nextUpdateTime": 1535635426495,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535399131116,
+      "nextUpdateTime": 1535692857867,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535856992384,
+      "nextUpdateTime": 1535952869756,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535407116454,
+      "nextUpdateTime": 1535783451713,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517735871,
+      "nextUpdateTime": 1535498662982,
       "userAction": ""
     },
     "s.po.st": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535601704447,
+      "nextUpdateTime": 1535560094637,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470740234,
+      "nextUpdateTime": 1535860326137,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535548076811,
+      "nextUpdateTime": 1535818293290,
+      "userAction": ""
+    },
+    "s.yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535622978260,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535650294754,
+      "nextUpdateTime": 1535617312775,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535442162234,
+      "nextUpdateTime": 1535723340329,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535683133775,
+      "nextUpdateTime": 1535575485409,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436416136,
+      "nextUpdateTime": 1535580484432,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2472,28 +2652,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sape.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535554044154,
+      "nextUpdateTime": 1535700559367,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535640650960,
+      "nextUpdateTime": 1535725608507,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535622073754,
+      "nextUpdateTime": 1535951923078,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535641445518,
+      "nextUpdateTime": 1535728176589,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2505,7 +2691,7 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535699162400,
+      "nextUpdateTime": 1535742086735,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -2517,7 +2703,7 @@
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535406047367,
+      "nextUpdateTime": 1535520532074,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2529,85 +2715,85 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535475183501,
+      "nextUpdateTime": 1535677815299,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535590066515,
+      "nextUpdateTime": 1535800058823,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535681640966,
+      "nextUpdateTime": 1535465743467,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535516546452,
+      "nextUpdateTime": 1535785998221,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535508368840,
+      "nextUpdateTime": 1535914435468,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535791057311,
+      "nextUpdateTime": 1535948798377,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711269325,
+      "nextUpdateTime": 1535877945891,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535537879488,
+      "nextUpdateTime": 1535597555162,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535460219033,
+      "nextUpdateTime": 1535791667902,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535643556045,
+      "nextUpdateTime": 1535639340469,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535879474697,
+      "nextUpdateTime": 1535564812848,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535619679394,
+      "nextUpdateTime": 1535650108629,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535654613358,
+      "nextUpdateTime": 1535464387320,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535573504719,
+      "nextUpdateTime": 1535734903711,
       "userAction": ""
     },
     "self.com": {
@@ -2643,7 +2829,7 @@
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535633318133,
+      "nextUpdateTime": 1535730445037,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -2673,7 +2859,7 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535372330669,
+      "nextUpdateTime": 1535498866607,
       "userAction": ""
     },
     "snapchat.com": {
@@ -2697,7 +2883,7 @@
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535631243909,
+      "nextUpdateTime": 1535555922438,
       "userAction": ""
     },
     "spotxchange.com": {
@@ -2712,52 +2898,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-26-09.config.parsely.com": {
+    "srv-2018-08-27-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535415293805,
+      "nextUpdateTime": 1535606591829,
       "userAction": ""
     },
-    "srv-2018-08-26-09.pixel.parsely.com": {
+    "srv-2018-08-27-09.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535541971804,
+      "nextUpdateTime": 1535775011168,
       "userAction": ""
     },
-    "srv-2018-08-26-10.config.parsely.com": {
+    "srv-2018-08-27-10.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535427058911,
+      "nextUpdateTime": 1535756373485,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535673135301,
+      "nextUpdateTime": 1535710872574,
       "userAction": ""
     },
     "ssl.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535545018325,
+      "nextUpdateTime": 1535689859677,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535743749252,
+      "nextUpdateTime": 1535454314181,
+      "userAction": ""
+    },
+    "sso.caltat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535761951625,
+      "userAction": ""
+    },
+    "ssp-rtb.sape.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535766755060,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535749834287,
+      "nextUpdateTime": 1535761311673,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535393160160,
+      "nextUpdateTime": 1535924056645,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2772,22 +2970,28 @@
       "nextUpdateTime": 1529315030088,
       "userAction": ""
     },
+    "static.datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535845316114,
+      "userAction": ""
+    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535471382942,
+      "nextUpdateTime": 1535639204569,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535539060159,
+      "nextUpdateTime": 1535592093085,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535587267608,
+      "nextUpdateTime": 1535861273600,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2799,13 +3003,13 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535416632424,
+      "nextUpdateTime": 1535757740002,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535669657331,
+      "nextUpdateTime": 1535490242831,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -2823,7 +3027,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535410096945,
+      "nextUpdateTime": 1535936086555,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2835,61 +3039,91 @@
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535775576457,
+      "nextUpdateTime": 1535543303368,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535509470133,
+      "nextUpdateTime": 1535878443632,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535599232106,
+      "nextUpdateTime": 1535753717531,
+      "userAction": ""
+    },
+    "sync.1dmp.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535866711433,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535727505148,
+      "nextUpdateTime": 1535474216425,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535386374072,
+      "nextUpdateTime": 1535616105586,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535823492565,
+      "nextUpdateTime": 1535792114790,
+      "userAction": ""
+    },
+    "sync.datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535757781917,
+      "userAction": ""
+    },
+    "sync.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535699991298,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535499554312,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535939733228,
       "userAction": ""
     },
     "sync.multiview.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535446837680,
+      "nextUpdateTime": 1535809892152,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535533239526,
+      "nextUpdateTime": 1535465474316,
       "userAction": ""
     },
     "sync.teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535693045071,
+      "nextUpdateTime": 1535793050783,
+      "userAction": ""
+    },
+    "sync.upravel.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535705180457,
+      "userAction": ""
+    },
+    "sync3.adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535672244398,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2907,7 +3141,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695664896,
+      "nextUpdateTime": 1535701257955,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -2919,19 +3153,13 @@
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535750776402,
+      "nextUpdateTime": 1535764731289,
       "userAction": ""
     },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tapestry.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535791510610,
       "userAction": ""
     },
     "teads.tv": {
@@ -2967,13 +3195,13 @@
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535800953607,
+      "nextUpdateTime": 1535484616929,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535498571655,
+      "nextUpdateTime": 1535590619071,
       "userAction": ""
     },
     "tinypass.com": {
@@ -2985,7 +3213,7 @@
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535433221586,
+      "nextUpdateTime": 1535694887621,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -2997,25 +3225,25 @@
     "top100.rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535878948535,
+      "nextUpdateTime": 1535891887087,
       "userAction": ""
     },
     "tr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535529445629,
+      "nextUpdateTime": 1535664544534,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535691727010,
+      "nextUpdateTime": 1535741046224,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535502278546,
+      "nextUpdateTime": 1535674993267,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3027,7 +3255,7 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535381700109,
+      "nextUpdateTime": 1535758029438,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -3045,7 +3273,7 @@
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535459821318,
+      "nextUpdateTime": 1535677023679,
       "userAction": ""
     },
     "turn.com": {
@@ -3069,37 +3297,43 @@
     "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535420971761,
+      "nextUpdateTime": 1535606318085,
+      "userAction": ""
+    },
+    "upravel.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ups.xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483153937,
+      "nextUpdateTime": 1535897007154,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535571457788,
+      "nextUpdateTime": 1535697248099,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535862306211,
+      "nextUpdateTime": 1535464144110,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535560041560,
+      "nextUpdateTime": 1535699974981,
       "userAction": ""
     },
     "va.v.liveperson.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535510754633,
+      "nextUpdateTime": 1535466934945,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -3135,7 +3369,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535374260274,
+      "nextUpdateTime": 1535733808496,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -3147,7 +3381,7 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535879370927,
+      "nextUpdateTime": 1535601239497,
       "userAction": ""
     },
     "vogue.com": {
@@ -3159,7 +3393,7 @@
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535532865527,
+      "nextUpdateTime": 1535498479361,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3171,19 +3405,25 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535786495983,
+      "nextUpdateTime": 1535636170372,
+      "userAction": ""
+    },
+    "wam-yahoo.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535796722948,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535427771016,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535855791363,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535518923351,
+      "nextUpdateTime": 1535923593881,
       "userAction": ""
     },
     "weborama.fr": {
@@ -3207,7 +3447,7 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535766647842,
+      "nextUpdateTime": 1535670143608,
       "userAction": ""
     },
     "wired.com": {
@@ -3231,25 +3471,25 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445893357,
+      "nextUpdateTime": 1535840821698,
       "userAction": ""
     },
     "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535369602618,
+      "nextUpdateTime": 1535813179789,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535680288285,
+      "nextUpdateTime": 1535765401859,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535572118422,
+      "nextUpdateTime": 1535489564334,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3261,25 +3501,25 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535662491591,
+      "nextUpdateTime": 1535595495451,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535456082317,
+      "nextUpdateTime": 1535586988900,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535602597669,
+      "nextUpdateTime": 1535930397006,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535383347016,
+      "nextUpdateTime": 1535509674049,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -3291,13 +3531,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535684316433,
+      "nextUpdateTime": 1535739774613,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535777753978,
+      "nextUpdateTime": 1535560046524,
       "userAction": ""
     },
     "www.google.com": {
@@ -3309,97 +3549,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535533301706,
-      "userAction": ""
-    },
-    "www.justuno.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535835623263,
+      "nextUpdateTime": 1535756312610,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535634668073,
+      "nextUpdateTime": 1535879616929,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535647703467,
+      "nextUpdateTime": 1535800042571,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535713896951,
+      "nextUpdateTime": 1535800256120,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535717161877,
+      "nextUpdateTime": 1535749245992,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535472362868,
+      "nextUpdateTime": 1535728733870,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535775225012,
+      "nextUpdateTime": 1535468979631,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535779192331,
+      "nextUpdateTime": 1535776576351,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535854231963,
+      "nextUpdateTime": 1535467088529,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535683085556,
+      "nextUpdateTime": 1535653525547,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535492902964,
+      "nextUpdateTime": 1535873679290,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535633330954,
+      "nextUpdateTime": 1535804763970,
       "userAction": ""
     },
     "www.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535622719621,
+      "nextUpdateTime": 1535541713916,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535870220028,
+      "nextUpdateTime": 1535773470002,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535717582854,
+      "nextUpdateTime": 1535481472835,
+      "userAction": ""
+    },
+    "x01.aidata.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535957511051,
       "userAction": ""
     },
     "xiti.com": {
@@ -3411,7 +3651,7 @@
     "xpl.theadex.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535552741878,
+      "nextUpdateTime": 1535914264605,
       "userAction": ""
     },
     "xplosion.de": {
@@ -3450,6 +3690,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3459,19 +3705,19 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535731599614,
+      "nextUpdateTime": 1535571133437,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535474370166,
+      "nextUpdateTime": 1535964428669,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535712458694,
+      "nextUpdateTime": 1535649235764,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3494,7 +3740,8 @@
     ],
     "1dmp.io": [
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "1rx.io": [
       "tinyurl.com",
@@ -3512,6 +3759,9 @@
       "aappublications.org",
       "americanbar.org"
     ],
+    "254a.com": [
+      "thehindu.com"
+    ],
     "2mdnsys.com": [
       "liveuamap.com"
     ],
@@ -3523,7 +3773,6 @@
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
-      "philips.com",
       "oclc.org"
     ],
     "33across.com": [
@@ -3549,7 +3798,8 @@
       "nature.com",
       "springer.com",
       "theverge.com",
-      "deviantart.com",
+      "usatoday.com",
+      "infoworld.com",
       "focus.de"
     ],
     "4dsply.com": [
@@ -3628,6 +3878,9 @@
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
+    "ad-score.com": [
+      "infoplease.com"
+    ],
     "ad-stir.com": [
       "sakura.ne.jp",
       "biglobe.ne.jp",
@@ -3652,14 +3905,14 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com",
-      "tinypic.com"
+      "washingtonexaminer.com"
     ],
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
       "yahoo.com",
       "who.int",
+      "unenvironment.org",
       "gulfnews.com"
     ],
     "addtoany.com": [
@@ -3674,12 +3927,14 @@
       "bloomberg.com",
       "springer.com",
       "sciencemag.org",
+      "thehindu.com",
       "helsinki.fi"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "rambler.ru"
+      "rambler.ru",
+      "ria.ru"
     ],
     "adfront.org": [
       "joomla.org"
@@ -3687,7 +3942,8 @@
     "adhigh.net": [
       "rambler.ru",
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "adidas.fi": [
       "adidas.com"
@@ -3699,7 +3955,6 @@
       "bloomberg.com",
       "dailymotion.com",
       "spiegel.de",
-      "t-online.de",
       "lemonde.fr"
     ],
     "adjust-net.jp": [
@@ -3710,16 +3965,16 @@
       "venturebeat.com",
       "livescience.com",
       "space.com",
-      "t-online.de",
+      "xda-developers.com",
       "dailydot.com"
     ],
     "adlmerge.com": [
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "admaster.com.cn": [
       "autohome.com.cn",
-      "bshare.cn",
-      "youku.com"
+      "bshare.cn"
     ],
     "admission.net": [
       "edmunds.com"
@@ -3732,13 +3987,14 @@
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "telegraph.co.uk",
+      "thehindu.com",
       "rfi.fr"
     ],
     "adobe.com": [
       "wikipedia.org",
       "behance.net",
-      "history.com"
+      "history.com",
+      "fotolia.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
@@ -3749,24 +4005,28 @@
     "adotmob.com": [
       "standard.co.uk",
       "upwork.com",
-      "nypost.com"
+      "variety.com"
     ],
     "adriver.ru": [
       "ria.ru",
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "home.pl"
     ],
     "adroll.com": [
       "stumbleupon.com",
       "nature.com",
       "nginx.org",
       "cloudflare.com",
+      "sitepoint.com",
       "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com"
+      "springer.com",
+      "statista.com",
+      "home.pl"
     ],
     "adsnative.com": [
       "autodesk.com",
@@ -3775,15 +4035,16 @@
       "bostonherald.com"
     ],
     "adsniper.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "radikal.ru"
     ],
     "adsrvr.org": [
       "adobe.com",
       "yahoo.com",
       "googletagmanager.com",
       "sourceforge.net",
-      "cnet.com",
-      "gizmodo.com"
+      "thehindu.com",
+      "hgtv.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -3794,11 +4055,13 @@
       "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "economist.com",
+      "usatoday.com",
+      "thehindu.com",
       "realtor.com"
     ],
     "adtags.pro": [
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "adtdp.com": [
       "biglobe.ne.jp"
@@ -3808,7 +4071,7 @@
       "sourceforge.net",
       "dropbox.com",
       "wsj.com",
-      "dailymotion.com",
+      "home.pl",
       "walgreens.com"
     ],
     "advertur.ru": [
@@ -3819,7 +4082,8 @@
     ],
     "adx.com.ru": [
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "adx1.com": [
       "venturebeat.com",
@@ -3840,6 +4104,7 @@
       "t-online.de",
       "bloomberg.com",
       "cnet.com",
+      "bankrate.com",
       "gizmodo.com"
     ],
     "aid-ad.jp": [
@@ -3848,7 +4113,8 @@
     "aidata.io": [
       "rambler.ru",
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "aili.com": [
       "sina.com.cn"
@@ -3881,7 +4147,8 @@
       "alibaba.com",
       "youku.com",
       "aliexpress.com",
-      "1688.com"
+      "1688.com",
+      "2345.com"
     ],
     "alipay.com": [
       "alibaba.com",
@@ -3894,6 +4161,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "am15.net": [
@@ -3907,7 +4175,7 @@
       "nytimes.com",
       "reddit.com",
       "cnn.com",
-      "telegraph.co.uk",
+      "mentalfloss.com",
       "bostonherald.com"
     ],
     "amazon.co.uk": [
@@ -3923,6 +4191,9 @@
     "ameba.jp": [
       "ameblo.jp"
     ],
+    "analytics-egain.com": [
+      "virginmedia.com"
+    ],
     "and.co.uk": [
       "dailymail.co.uk"
     ],
@@ -3933,7 +4204,8 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "walgreens.com"
+      "nintendo.com",
+      "realtor.com"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -3962,7 +4234,7 @@
       "foursquare.com",
       "history.com",
       "nbc.com",
-      "airbnb.com",
+      "allrecipes.com",
       "strava.com"
     ],
     "appdynamics.com": [
@@ -3984,6 +4256,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "arcpublishing.com": [
@@ -4007,7 +4280,7 @@
       "facebook.com",
       "yahoo.com",
       "msn.com",
-      "t-online.de"
+      "upwork.com"
     ],
     "atemda.com": [
       "springer.com",
@@ -4043,13 +4316,11 @@
       "sina.com.cn",
       "163.com",
       "ifeng.com",
-      "sohu.com"
+      "sohu.com",
+      "2345.com"
     ],
     "bam-x.com": [
       "gq.com"
-    ],
-    "baur.de": [
-      "t-online.de"
     ],
     "bazaarvoice.com": [
       "target.com",
@@ -4106,15 +4377,16 @@
       "adobe.com",
       "dailymotion.com",
       "hootsuite.com",
-      "hp.com"
+      "hp.com",
+      "upwork.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
       "amazon.com",
-      "forbes.com",
-      "npr.org",
-      "newatlas.com"
+      "dropbox.com",
+      "thehindu.com",
+      "radikal.ru"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -4128,8 +4400,8 @@
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "telegraph.co.uk",
-      "office.com",
+      "motorola.com",
+      "microsoft.com",
       "pingdom.com"
     ],
     "bitbucket.org": [
@@ -4140,10 +4412,12 @@
       "cloudflare.com",
       "zendesk.com",
       "ibm.com",
+      "here.com",
       "gitlab.com"
     ],
     "bizibly.com": [
-      "eventbrite.com"
+      "eventbrite.com",
+      "cloudflare.com"
     ],
     "bizographics.com": [
       "zend.com",
@@ -4154,7 +4428,8 @@
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -4164,14 +4439,14 @@
     ],
     "bluecava.com": [
       "history.com",
-      "biography.com",
-      "jimdo.com"
+      "biography.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
       "sfgate.com",
-      "chron.com"
+      "chron.com",
+      "ajc.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -4193,6 +4468,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "boston.com": [
@@ -4212,6 +4488,7 @@
       "time.com",
       "wired.com",
       "usatoday.com",
+      "allrecipes.com",
       "pitchfork.com"
     ],
     "brandcdn.com": [
@@ -4221,6 +4498,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "brightcove.com": [
@@ -4228,12 +4506,14 @@
       "si.com",
       "federalreserve.gov",
       "theaustralian.com.au",
-      "informationweek.com"
+      "informationweek.com",
+      "straitstimes.com"
     ],
     "brightcove.net": [
       "lefigaro.fr",
       "politico.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "aljazeera.com"
     ],
     "bttrack.com": [
       "yahoo.com",
@@ -4264,7 +4544,8 @@
       "economist.com"
     ],
     "caltat.com": [
-      "live4fun.ru"
+      "live4fun.ru",
+      "radikal.ru"
     ],
     "candlewoodsuites.com": [
       "ihg.com"
@@ -4282,14 +4563,16 @@
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
-      "dailymail.co.uk",
+      "thehindu.com",
       "pitchfork.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
       "gamespot.com",
-      "cnet.com"
+      "cnet.com",
+      "cbsnews.com",
+      "cbssports.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -4310,6 +4593,9 @@
     ],
     "cdnwidget.com": [
       "photoshelter.com"
+    ],
+    "cedexis-test.com": [
+      "tumblr.com"
     ],
     "cern.ch": [
       "home.cern"
@@ -4386,6 +4672,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "cnzz.com": [
@@ -4419,6 +4706,7 @@
       "ibm.com",
       "redhat.com",
       "hp.com",
+      "upwork.com",
       "box.com"
     ],
     "complex.com": [
@@ -4434,6 +4722,7 @@
       "arstechnica.com",
       "nj.com",
       "newyorker.com",
+      "nola.com",
       "pitchfork.com"
     ],
     "conductrics.com": [
@@ -4450,14 +4739,11 @@
       "rollingstone.com",
       "variety.com",
       "adweek.com",
-      "buzzfeed.com",
+      "independent.co.uk",
       "nme.com"
     ],
     "consumable.com": [
       "xfinity.com"
-    ],
-    "content.ad": [
-      "tinypic.com"
     ],
     "contentabc.com": [
       "pornhub.com"
@@ -4467,7 +4753,7 @@
       "myspace.com",
       "bloomberg.com",
       "forbes.com",
-      "samsung.com",
+      "thehindu.com",
       "coindesk.com"
     ],
     "convertful.com": [
@@ -4490,6 +4776,9 @@
     "coxbusiness.com": [
       "cox.com"
     ],
+    "coxmediagroup.com": [
+      "ajc.com"
+    ],
     "cpex.cz": [
       "idnes.cz"
     ],
@@ -4498,6 +4787,7 @@
       "digitaltrends.com",
       "techradar.com",
       "independent.co.uk",
+      "allmusic.com",
       "rfi.fr"
     ],
     "cquotient.com": [
@@ -4505,9 +4795,6 @@
     ],
     "cr-nielsen.com": [
       "youku.com"
-    ],
-    "creative-serving.com": [
-      "newatlas.com"
     ],
     "creativecdn.com": [
       "ria.ru",
@@ -4521,7 +4808,7 @@
       "washingtonpost.com",
       "dailymail.co.uk",
       "dropbox.com",
-      "cnet.com",
+      "newegg.com",
       "sedo.com"
     ],
     "croissed.info": [
@@ -4534,6 +4821,9 @@
       "sourceforge.net",
       "slashdot.org",
       "bartleby.com"
+    ],
+    "crwdcntrl.net": [
+      "wunderground.com"
     ],
     "cssrvsync.com": [
       "springer.com",
@@ -4553,7 +4843,6 @@
       "talktalk.co.uk",
       "gizmodo.com",
       "wsj.com",
-      "cbc.ca",
       "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
@@ -4583,10 +4872,14 @@
     "datamind.ru": [
       "novostimira.com",
       "rambler.ru",
-      "kharkov.ua"
+      "kharkov.ua",
+      "radikal.ru"
     ],
     "datasteam.io": [
       "ama-assn.org"
+    ],
+    "datpix.net": [
+      "radikal.ru"
     ],
     "daum.net": [
       "shutterstock.com",
@@ -4617,7 +4910,7 @@
       "yahoo.com",
       "amazon.com",
       "soundcloud.com",
-      "telegraph.co.uk",
+      "thehindu.com",
       "skynet.be"
     ],
     "departapp.com": [
@@ -4651,18 +4944,21 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com"
+      "entrepreneur.com",
+      "zerohedge.com"
     ],
     "dictionary.com": [
       "thesaurus.com"
     ],
     "digitaladsystems.com": [
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "digitaltarget.ru": [
       "liveinternet.ru",
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "digitru.st": [
       "britannica.com",
@@ -4688,7 +4984,7 @@
       "barnesandnoble.com",
       "urbandictionary.com",
       "axs.com",
-      "timeanddate.com",
+      "thehindu.com",
       "newatlas.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
@@ -4715,7 +5011,7 @@
       "samsung.com",
       "webmd.com",
       "forbes.com",
-      "economist.com",
+      "thehindu.com",
       "walgreens.com"
     ],
     "dotsub.com": [
@@ -4726,7 +5022,7 @@
       "twitter.com",
       "linkedin.com",
       "sourceforge.net",
-      "telegraph.co.uk",
+      "haaretz.com",
       "focus.de"
     ],
     "doublemax.net": [
@@ -4744,6 +5040,9 @@
       "theregister.co.uk",
       "techtarget.com",
       "adweek.com"
+    ],
+    "dxpmedia.com": [
+      "sina.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4809,6 +5108,7 @@
       "cisco.com",
       "prnewswire.com",
       "redhat.com",
+      "infoworld.com",
       "eset.com"
     ],
     "elsevier.com": [
@@ -4837,7 +5137,11 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
+    ],
+    "epital.gdn": [
+      "4shared.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -4852,7 +5156,7 @@
       "over-blog.com",
       "canalblog.com",
       "lefigaro.fr",
-      "sfgate.com"
+      "tomshardware.com"
     ],
     "etracker.de": [
       "sedo.com"
@@ -4870,8 +5174,8 @@
       "adobe.com",
       "yahoo.com",
       "sourceforge.net",
-      "tinyurl.com",
-      "telegraph.co.uk",
+      "dropbox.com",
+      "thehindu.com",
       "newatlas.com"
     ],
     "everyaction.com": [
@@ -4904,7 +5208,8 @@
       "soundcloud.com",
       "forbes.com",
       "bloomberg.com",
-      "surveymonkey.com",
+      "businessinsider.com",
+      "genius.com",
       "gizmodo.com"
     ],
     "exosrv.com": [
@@ -4917,7 +5222,7 @@
       "sourceforge.net",
       "forbes.com",
       "bloomberg.com",
-      "news.com.au",
+      "gizmodo.com",
       "heraldsun.com.au"
     ],
     "eyereturn.com": [
@@ -4938,13 +5243,16 @@
       "wordpress.org",
       "adobe.com",
       "nytimes.com",
-      "telegraph.co.uk",
+      "haaretz.com",
       "focus.de"
     ],
     "facetz.net": [
       "novostimira.com",
       "rambler.ru",
       "kharkov.ua"
+    ],
+    "faggrim.com": [
+      "radikal.ru"
     ],
     "fairfax.com.au": [
       "smh.com.au",
@@ -4979,8 +5287,7 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu",
-      "bmj.com"
+      "msu.edu"
     ],
     "flickr.com": [
       "state.gov",
@@ -5006,16 +5313,15 @@
       "clinicaltrials.gov",
       "moonfruit.com",
       "webex.com",
+      "ucsc.edu",
       "sitepoint.com"
-    ],
-    "foreignpolicy.com": [
-      "onecount.net"
     ],
     "foresee.com": [
       "epa.gov",
       "si.edu",
       "theglobeandmail.com",
-      "sec.gov"
+      "sec.gov",
+      "worldcat.org"
     ],
     "formstack.com": [
       "in.gov"
@@ -5099,7 +5405,8 @@
     "getsmartcontent.com": [
       "pcworld.com",
       "computerworld.com",
-      "hpe.com"
+      "hpe.com",
+      "networkworld.com"
     ],
     "gfycat.com": [
       "reddit.com"
@@ -5108,7 +5415,8 @@
       "cnn.com",
       "independent.co.uk",
       "abc.net.au",
-      "sfgate.com",
+      "cbslocal.com",
+      "abc.es",
       "hgtv.com"
     ],
     "giphy.com": [
@@ -5123,12 +5431,14 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com"
+      "fortune.com",
+      "si.com"
     ],
     "gmossp-sp.jp": [
       "shinobi.jp",
@@ -5144,6 +5454,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "goo.ne.jp": [
@@ -5157,8 +5468,8 @@
       "linkedin.com",
       "google.de",
       "sourceforge.net",
-      "telegraph.co.uk",
       "scmp.com",
+      "sendspace.com",
       "chromium.org",
       "focus.de"
     ],
@@ -5191,6 +5502,7 @@
       "liveuamap.com",
       "colourlovers.com",
       "infoplease.com",
+      "thehindu.com",
       "coindesk.com"
     ],
     "guoshipartners.com": [
@@ -5228,6 +5540,12 @@
     "help.com": [
       "comodo.com",
       "couchsurfing.com"
+    ],
+    "hgbn.rocks": [
+      "radikal.ru"
+    ],
+    "hgbnr.com": [
+      "radikal.ru"
     ],
     "hiexpress.com": [
       "ihg.com"
@@ -5285,7 +5603,8 @@
     "hybrid.ai": [
       "rambler.ru",
       "tomsk.ru",
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "hypemarks.com": [
       "uchicago.edu",
@@ -5320,7 +5639,8 @@
       "bloomberg.com",
       "venturebeat.com",
       "dailymotion.com",
-      "livescience.com"
+      "livescience.com",
+      "xda-developers.com"
     ],
     "idealmedia.com": [
       "alternet.org",
@@ -5332,7 +5652,8 @@
     "igodigital.com": [
       "apa.org",
       "adidas.com",
-      "motorola.com"
+      "motorola.com",
+      "nintendo.com"
     ],
     "iheart.com": [
       "variety.com"
@@ -5361,14 +5682,15 @@
       "rakuten.co.jp",
       "yahoo.co.jp",
       "goo.ne.jp",
-      "economist.com"
+      "economist.com",
+      "ocn.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
       "bbc.com",
       "wsj.com",
-      "cnet.com",
+      "popsugar.com",
       "gizmodo.com"
     ],
     "infinity-tracking.net": [
@@ -5387,7 +5709,8 @@
       "ups.com"
     ],
     "inquisitr.com": [
-      "www.poznan.pl"
+      "www.poznan.pl",
+      "flipboard.com"
     ],
     "inside-graph.com": [
       "staples.com"
@@ -5403,8 +5726,7 @@
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu",
-      "tmz.com"
+      "arizona.edu"
     ],
     "instinctiveads.com": [
       "variety.com",
@@ -5426,7 +5748,7 @@
       "themeforest.net",
       "ft.com",
       "elegantthemes.com",
-      "bigcartel.com",
+      "codecanyon.net",
       "iconfinder.com"
     ],
     "intergient.com": [
@@ -5474,8 +5796,7 @@
       "indianexpress.com"
     ],
     "janrainsso.com": [
-      "vancouversun.com",
-      "nationalpost.com"
+      "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
@@ -5527,7 +5848,7 @@
       "nationalgeographic.com",
       "chicagotribune.com",
       "nytimes.com",
-      "rollingstone.com",
+      "complex.com",
       "zappos.com"
     ],
     "kinja.com": [
@@ -5543,7 +5864,7 @@
       "bgr.com",
       "jalopnik.com",
       "cnn.com",
-      "usatoday.com",
+      "allrecipes.com",
       "gizmodo.com"
     ],
     "ladsp.com": [
@@ -5569,14 +5890,15 @@
       "nj.com",
       "patch.com",
       "bloomberg.com",
-      "economist.com",
+      "cbssports.com",
       "washingtonexaminer.com"
     ],
     "libero.it": [
       "virgilio.it"
     ],
     "licasd.com": [
-      "nj.com"
+      "nj.com",
+      "cbssports.com"
     ],
     "licdn.com": [
       "linkedin.com"
@@ -5584,7 +5906,8 @@
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "home.pl"
+      "home.pl",
+      "orange.fr"
     ],
     "lightboxcdn.com": [
       "zdnet.com",
@@ -5598,6 +5921,7 @@
       "bloomberg.com",
       "deviantart.com",
       "uci.edu",
+      "zimbio.com",
       "infoplease.com"
     ],
     "lincoln.com": [
@@ -5611,14 +5935,15 @@
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "forbes.com",
-      "hp.com",
+      "dropbox.com",
+      "mentalfloss.com",
       "lexisnexis.com"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
       "pcworld.com",
-      "nike.com"
+      "nike.com",
+      "infoworld.com"
     ],
     "list-manage.com": [
       "boingboing.net"
@@ -5650,7 +5975,7 @@
       "apache.org",
       "prnewswire.com",
       "ibm.com",
-      "talktalk.co.uk",
+      "thetimes.co.uk",
       "lexisnexis.com"
     ],
     "lkqd.net": [
@@ -5698,7 +6023,11 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com"
+      "google.com",
+      "yandex.ru",
+      "ria.ru",
+      "ok.ru",
+      "radikal.ru"
     ],
     "mailchimp.com": [
       "colorlib.com",
@@ -5725,27 +6054,29 @@
       "nokia.com",
       "panasonic.com",
       "dyn.com",
+      "searchengineland.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
       "thestar.com",
-      "seattletimes.com"
+      "seattletimes.com",
+      "ajc.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
       "forbes.com",
-      "usatoday.com",
-      "pitchfork.com"
+      "thehindu.com",
+      "walgreens.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
       "forbes.com",
       "reuters.com",
-      "npr.org",
+      "medicinenet.com",
       "cracked.com"
     ],
     "media6degrees.com": [
@@ -5765,8 +6096,7 @@
     "mediaplex.com": [
       "dell.com",
       "shutterfly.com",
-      "military.com",
-      "economist.com"
+      "military.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
@@ -5801,12 +6131,13 @@
       "variety.com"
     ],
     "mfadsrvr.com": [
-      "forbes.com"
+      "infoplease.com"
     ],
     "mg2connext.com": [
       "mercurynews.com",
       "philly.com",
-      "denverpost.com"
+      "denverpost.com",
+      "ajc.com"
     ],
     "mgid.com": [
       "liveleak.com",
@@ -5848,6 +6179,7 @@
       "prnewswire.com",
       "zend.com",
       "oreilly.com",
+      "ebsco.com",
       "pingdom.com"
     ],
     "ml314.com": [
@@ -5855,7 +6187,7 @@
       "forbes.com",
       "bloomberg.com",
       "wsj.com",
-      "businessinsider.com",
+      "networkworld.com",
       "zerohedge.com"
     ],
     "mlb.com": [
@@ -5888,7 +6220,7 @@
       "t-online.de",
       "nbcnews.com",
       "theglobeandmail.com",
-      "thetimes.co.uk"
+      "businessinsider.com"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -5953,7 +6285,7 @@
       "surveymonkey.com",
       "spotify.com",
       "paypal.com",
-      "economist.com"
+      "redbubble.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
@@ -5963,7 +6295,7 @@
     ],
     "narrative.io": [
       "sourceforge.net",
-      "business2community.com"
+      "gizmodo.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -6007,7 +6339,8 @@
       "lenovo.com",
       "theknot.com",
       "shopko.com",
-      "pitchfork.com"
+      "usatoday.com",
+      "thehindu.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -6034,13 +6367,13 @@
       "nypost.com",
       "thesun.co.uk",
       "wsj.com",
-      "news.com.au",
       "heraldsun.com.au"
     ],
     "newsinc.com": [
       "latimes.com",
       "nydailynews.com",
-      "hollywoodreporter.com"
+      "hollywoodreporter.com",
+      "ajc.com"
     ],
     "newsmemory.com": [
       "cleveland.com"
@@ -6057,6 +6390,7 @@
       "wired.com",
       "vanityfair.com",
       "vogue.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "nexac.com": [
@@ -6080,7 +6414,7 @@
       "wsj.com",
       "oracle.com",
       "huffingtonpost.com",
-      "harvard.edu",
+      "allrecipes.com",
       "helsinki.fi"
     ],
     "nsaudience.pl": [
@@ -6098,7 +6432,8 @@
     "nxtck.com": [
       "nike.com",
       "shutterstock.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "orange.fr"
     ],
     "nymag.com": [
       "vulture.com"
@@ -6112,7 +6447,8 @@
     "oath.com": [
       "tumblr.com",
       "huffingtonpost.co.uk",
-      "techradar.com"
+      "techradar.com",
+      "autoblog.com"
     ],
     "ocdn.eu": [
       "onet.pl",
@@ -6160,6 +6496,7 @@
       "amazon.com",
       "telegraph.co.uk",
       "marriott.com",
+      "ancestry.com",
       "eset.com"
     ],
     "onclickmega.com": [
@@ -6176,7 +6513,7 @@
       "bitbucket.org",
       "namecheap.com",
       "cnn.com",
-      "thesun.co.uk",
+      "haaretz.com",
       "active.com"
     ],
     "onevision.com.tw": [
@@ -6210,8 +6547,8 @@
       "yahoo.com",
       "amazon.com",
       "nytimes.com",
-      "forbes.com",
-      "telegraph.co.uk",
+      "dropbox.com",
+      "thehindu.com",
       "active.com"
     ],
     "opinionstage.com": [
@@ -6227,21 +6564,24 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
-      "ibm.com",
-      "microsoft.com",
       "bbc.com",
+      "live.com",
+      "ibm.com",
+      "hp.com",
       "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
+      "foxnews.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
       "evernote.com",
+      "box.com",
       "prezi.com",
       "prweb.com",
-      "ign.com",
       "dictionary.com",
+      "ehow.com",
       "bitbucket.org",
       "gotomeeting.com",
       "accorhotels.com",
@@ -6250,26 +6590,24 @@
       "history.com",
       "bestbuy.com",
       "jamanetwork.com",
-      "www.nhs.uk",
       "imageshack.com",
-      "atlassian.com",
       "dallasnews.com",
       "metmuseum.org",
       "blizzard.com",
       "intuit.com",
       "starbucks.com",
       "squareup.com",
-      "ajc.com",
       "justgiving.com",
       "dreamhost.com",
       "edx.org",
+      "microsoft.com",
+      "cbssports.com",
       "bartleby.com",
       "theknot.com",
       "zenfolio.com",
       "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
-      "box.com",
       "fox.com"
     ],
     "optimove.events": [
@@ -6280,8 +6618,7 @@
       "alternet.org"
     ],
     "oracleimg.com": [
-      "dyn.com",
-      "oracle.com"
+      "dyn.com"
     ],
     "orangeads.fr": [
       "orange.fr"
@@ -6303,7 +6640,7 @@
       "scribd.com",
       "foxnews.com",
       "cnn.com",
-      "telegraph.co.uk",
+      "globalnews.ca",
       "focus.de"
     ],
     "ovh.com": [
@@ -6313,6 +6650,7 @@
       "lycos.com",
       "lg.com",
       "washingtontimes.com",
+      "thehindu.com",
       "pitchfork.com"
     ],
     "owox.com": [
@@ -6332,7 +6670,7 @@
       "wired.com",
       "wikia.com",
       "wsj.com",
-      "techcrunch.com",
+      "nola.com",
       "dezeen.com"
     ],
     "paypal.com": [
@@ -6362,13 +6700,11 @@
     "perimeterx.net": [
       "bloomberg.com",
       "pixnet.net",
-      "macrumors.com"
+      "macrumors.com",
+      "upwork.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
-    ],
-    "photobucket.com": [
-      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
@@ -6377,12 +6713,14 @@
       "huffingtonpost.com",
       "dailymail.co.uk",
       "nytimes.com",
-      "etsy.com"
+      "themeforest.net",
+      "popsugar.com"
     ],
     "pitchfork.com": [
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "epicurious.com"
     ],
     "pixanalytics.com": [
@@ -6427,14 +6765,15 @@
       "independent.co.uk",
       "chicagotribune.com",
       "wsj.com",
-      "marketwatch.com",
+      "ajc.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
       "livescience.com",
       "standard.co.uk",
-      "variety.com"
+      "variety.com",
+      "orange.fr"
     ],
     "pressboard.ca": [
       "observer.com"
@@ -6484,6 +6823,7 @@
       "tinyurl.com",
       "bloomberg.com",
       "usatoday.com",
+      "thehindu.com",
       "walgreens.com"
     ],
     "pubmine.com": [
@@ -6526,7 +6866,8 @@
     "qq.com": [
       "sina.com.cn",
       "ctrip.com",
-      "weather.com.cn"
+      "weather.com.cn",
+      "tencent.com"
     ],
     "qsstats.com": [
       "serverwatch.com",
@@ -6539,6 +6880,7 @@
       "adidas.com",
       "cnet.com",
       "babycenter.com",
+      "cbssports.com",
       "mayoclinic.org"
     ],
     "quantserve.com": [
@@ -6546,7 +6888,7 @@
       "vimeo.com",
       "reddit.com",
       "soundcloud.com",
-      "jimdo.com",
+      "thehindu.com",
       "gizmodo.com"
     ],
     "quantummetric.com": [
@@ -6563,6 +6905,7 @@
       "bloomberg.com",
       "ning.com",
       "nypost.com",
+      "thehindu.com",
       "eset.com"
     ],
     "rackcdn.com": [
@@ -6579,6 +6922,7 @@
       "washingtonpost.com",
       "novostimira.com",
       "ria.ru",
+      "radikal.ru",
       "kharkov.ua"
     ],
     "rbnt.org": [
@@ -6610,7 +6954,8 @@
       "theregister.co.uk"
     ],
     "relap.io": [
-      "diary.ru"
+      "diary.ru",
+      "radikal.ru"
     ],
     "republer.com": [
       "tomsk.ru",
@@ -6649,8 +6994,11 @@
       "tinyurl.com",
       "npr.org",
       "forbes.com",
-      "economist.com",
+      "yellowpages.com",
       "gopro.com"
+    ],
+    "rhombusads.com": [
+      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6658,7 +7006,8 @@
     "richmetrics.com": [
       "nj.com",
       "oregonlive.com",
-      "mlive.com"
+      "mlive.com",
+      "nola.com"
     ],
     "richrelevance.com": [
       "hbr.org",
@@ -6671,7 +7020,8 @@
       "time.com",
       "wired.com",
       "cbsnews.com",
-      "npr.org",
+      "zdnet.com",
+      "thebalance.com",
       "gizmodo.com"
     ],
     "rlcdn.com": [
@@ -6679,7 +7029,7 @@
       "yahoo.com",
       "sourceforge.net",
       "reddit.com",
-      "hp.com",
+      "thehindu.com",
       "box.com"
     ],
     "rnengage.com": [
@@ -6696,33 +7046,38 @@
     "roymorgan.com": [
       "smh.com.au"
     ],
+    "rqtrk.eu": [
+      "dropbox.com"
+    ],
     "rtb.com.ru": [
       "radikal.ru",
       "diary.ru"
     ],
     "rtk.io": [
       "post-gazette.com",
+      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
       "bloomberg.com",
-      "npr.org"
+      "uci.edu"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
       "sourceforge.net",
-      "nytimes.com",
-      "dailymail.co.uk",
-      "gizmodo.com"
+      "cnn.com",
+      "thehindu.com",
+      "pitchfork.com"
     ],
     "rundsp.com": [
       "hpe.com",
       "alternet.org"
     ],
     "rutarget.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "radikal.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "codepen.io",
@@ -6740,6 +7095,7 @@
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
+      "teamviewer.us",
       "salesforce.com",
       "eset.com"
     ],
@@ -6755,6 +7111,9 @@
       "imdb.com",
       "gizmodo.com",
       "lifehacker.com"
+    ],
+    "sape.ru": [
+      "radikal.ru"
     ],
     "sbal4kp.com": [
       "dropbox.com"
@@ -6790,7 +7149,7 @@
       "yahoo.com",
       "tumblr.com",
       "nytimes.com",
-      "telegraph.co.uk",
+      "thehindu.com",
       "gizmodo.com"
     ],
     "scribblelive.com": [
@@ -6800,9 +7159,6 @@
     ],
     "sddan.com": [
       "upwork.com"
-    ],
-    "sdp-campaign.de": [
-      "t-online.de"
     ],
     "seadform.net": [
       "bloomberg.com"
@@ -6824,12 +7180,14 @@
       "fortune.com",
       "people.com",
       "ew.com",
-      "time.com"
+      "time.com",
+      "allrecipes.com"
     ],
     "self.com": [
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "semasio.net": [
@@ -6843,6 +7201,7 @@
       "venturebeat.com",
       "livescience.com",
       "space.com",
+      "xda-developers.com",
       "dailydot.com"
     ],
     "servedby-buysellads.com": [
@@ -6856,6 +7215,7 @@
       "t-online.de",
       "nbcnews.com",
       "businessinsider.com",
+      "nintendo.com",
       "hgtv.com"
     ],
     "sessioncam.com": [
@@ -6878,7 +7238,7 @@
       "cnn.com",
       "time.com",
       "forbes.com",
-      "cnet.com",
+      "home.pl",
       "walgreens.com"
     ],
     "sheego.de": [
@@ -6921,8 +7281,8 @@
       "verisign.com",
       "udel.edu",
       "berkeley.edu",
-      "jhu.edu",
-      "ethz.ch",
+      "emory.edu",
+      "ucsc.edu",
       "helsinki.fi",
       "case.edu",
       "oclc.org"
@@ -6942,14 +7302,16 @@
       "barnesandnoble.com",
       "tinypic.com",
       "seattletimes.com",
-      "sciencedaily.com",
+      "usatoday.com",
+      "thehindu.com",
       "networksolutions.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
-      "jimdo.com",
+      "fastcompany.com",
+      "mentalfloss.com",
       "coindesk.com"
     ],
     "sky.com": [
@@ -6963,7 +7325,8 @@
       "springer.com",
       "skyrock.com",
       "sapo.pt",
-      "elpais.com"
+      "elpais.com",
+      "home.pl"
     ],
     "smartclip.net": [
       "infoplease.com"
@@ -6990,7 +7353,7 @@
       "overstock.com",
       "complex.com",
       "wsj.com",
-      "giphy.com",
+      "redbubble.com",
       "zappos.com"
     ],
     "snapwidget.com": [
@@ -7005,7 +7368,8 @@
     "socdm.com": [
       "rakuten.co.jp",
       "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "sociomantic.com": [
       "springer.com",
@@ -7044,8 +7408,8 @@
       "deviantart.com",
       "springer.com",
       "myspace.com",
-      "cnet.com",
-      "edmunds.com"
+      "home.pl",
+      "detroitnews.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -7054,7 +7418,6 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "irishtimes.com",
       "mo.gov"
     ],
     "sourceforge.net": [
@@ -7098,7 +7461,7 @@
       "amazon.com",
       "dropbox.com",
       "dailymotion.com",
-      "npr.org",
+      "express.co.uk",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -7152,6 +7515,7 @@
       "prezi.com",
       "wpengine.com",
       "istockphoto.com",
+      "newegg.com",
       "careerbuilder.com"
     ],
     "steepto.com": [
@@ -7190,13 +7554,11 @@
       "feedly.com",
       "documentcloud.org"
     ],
-    "stripe.network": [
-      "smashballoon.com"
-    ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
       "studiopress.com",
+      "sitepoint.com",
       "makezine.com"
     ],
     "sundaysky.com": [
@@ -7223,13 +7585,15 @@
     "surveymonkey.com": [
       "cambridge.org",
       "investopedia.com",
-      "foreignpolicy.com"
+      "foreignpolicy.com",
+      "iop.org"
     ],
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
       "indianexpress.com",
-      "springer.com"
+      "springer.com",
+      "thehindu.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -7243,8 +7607,8 @@
       "dropbox.com",
       "t-online.de",
       "msn.com",
-      "telegraph.co.uk",
-      "edmunds.com"
+      "ajc.com",
+      "infoplease.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -7266,21 +7630,23 @@
       "sina.com.cn",
       "alibaba.com",
       "ifeng.com",
-      "tmall.com"
+      "tmall.com",
+      "2345.com"
     ],
     "taobao.com": [
       "sina.com.cn",
       "1688.com",
       "tmall.com",
-      "alibaba.com"
+      "alibaba.com",
+      "2345.com"
     ],
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
       "soundcloud.com",
-      "paypal.com",
-      "jimdo.com",
-      "bostonherald.com"
+      "dropbox.com",
+      "globalnews.ca",
+      "networksolutions.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -7300,6 +7666,7 @@
       "cbsnews.com",
       "evernote.com",
       "cnet.com",
+      "ancestry.com",
       "usmagazine.com"
     ],
     "technolutions.net": [
@@ -7314,6 +7681,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "telegraph.co.uk": [
@@ -7340,6 +7708,9 @@
       "playstation.com",
       "zappos.com"
     ],
+    "thecut.com": [
+      "nymag.com"
+    ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
     ],
@@ -7363,7 +7734,9 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com",
+      "allrecipes.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -7373,7 +7746,7 @@
       "techcrunch.com",
       "kickstarter.com",
       "bloomberg.com",
-      "cnbc.com",
+      "thenation.com",
       "gizmodo.com"
     ],
     "tiqcdn.com": [
@@ -7381,8 +7754,8 @@
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
-      "marketwatch.com",
       "hpe.com",
+      "orange.fr",
       "francetvinfo.fr"
     ],
     "tl813.com": [
@@ -7400,6 +7773,7 @@
       "vk.com",
       "yandex.ru",
       "mail.ru",
+      "ria.ru",
       "radikal.ru"
     ],
     "toutapp.com": [
@@ -7458,7 +7832,8 @@
       "dailymotion.com",
       "pastebin.com",
       "liveleak.com",
-      "marriott.com"
+      "usatoday.com",
+      "thehindu.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -7504,8 +7879,8 @@
       "bloomberg.com",
       "wired.com",
       "webmd.com",
-      "tinyurl.com",
       "hp.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
@@ -7529,8 +7904,8 @@
       "nytimes.com",
       "cnn.com",
       "msn.com",
-      "hp.com",
-      "sfgate.com",
+      "haaretz.com",
+      "medicinenet.com",
       "lexisnexis.com",
       "edmunds.com"
     ],
@@ -7568,9 +7943,6 @@
       "cnn.com",
       "nba.com"
     ],
-    "ultimedia.com": [
-      "sfgate.com"
-    ],
     "undertone.com": [
       "dallasnews.com",
       "alternet.org"
@@ -7584,12 +7956,12 @@
     "unrulymedia.com": [
       "nypost.com",
       "earthlink.net",
-      "boingboing.net",
-      "networkadvertising.org"
+      "boingboing.net"
     ],
     "upravel.com": [
       "rambler.ru",
-      "tomsk.ru"
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "upsellit.com": [
       "samsung.com",
@@ -7642,6 +8014,7 @@
       "wired.com",
       "newyorker.com",
       "vogue.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "veinteractive.com": [
@@ -7665,7 +8038,8 @@
     "viafoura.co": [
       "cbc.ca",
       "columbia.edu",
-      "nj.com"
+      "nj.com",
+      "nola.com"
     ],
     "viafoura.net": [
       "cbc.ca"
@@ -7709,6 +8083,8 @@
       "myspace.com",
       "fortune.com",
       "people.com",
+      "time.com",
+      "allrecipes.com",
       "zappos.com"
     ],
     "virgilio.it": [
@@ -7723,7 +8099,9 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru"
+      "ria.ru",
+      "yandex.ru",
+      "sonymobile.com"
     ],
     "vmmpxl.com": [
       "networksolutions.com"
@@ -7732,6 +8110,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "volvelle.tech": [
@@ -7757,9 +8136,6 @@
       "sourceforge.net",
       "hp.com"
     ],
-    "wal.co": [
-      "walmart.com"
-    ],
     "wallst.com": [
       "reuters.com"
     ],
@@ -7778,7 +8154,8 @@
       "goethe.de"
     ],
     "wcfbc.net": [
-      "bild.de"
+      "bild.de",
+      "goethe.de"
     ],
     "weather.com": [
       "wunderground.com"
@@ -7810,13 +8187,13 @@
     "webtrekk.net": [
       "springer.com",
       "localiser-ip.com",
-      "welt.de"
+      "welt.de",
+      "goethe.de"
     ],
     "webtrendslive.com": [
       "nature.com",
       "abc.net.au",
       "oup.com",
-      "ethz.ch",
       "dhl.com"
     ],
     "webvisor.org": [
@@ -7845,6 +8222,7 @@
       "newyorker.com",
       "vanityfair.com",
       "vogue.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "wise.space": [
@@ -7883,6 +8261,7 @@
       "wired.com",
       "newyorker.com",
       "vanityfair.com",
+      "gq.com",
       "pitchfork.com"
     ],
     "wnyc.org": [
@@ -7907,8 +8286,7 @@
       "akismet.com",
       "nypost.com",
       "news.com.au",
-      "variety.com",
-      "metro.co.uk"
+      "variety.com"
     ],
     "wrating.com": [
       "163.com",
@@ -7953,12 +8331,14 @@
       "unblog.fr",
       "uefa.com",
       "skyrock.com",
+      "ovh.com",
       "leparisien.fr"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
       "biglobe.ne.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "ocn.ne.jp"
     ],
     "xplosion.de": [
       "t-online.de",
@@ -7976,21 +8356,23 @@
       "vk.com",
       "novostimira.com",
       "mail.ru",
-      "rt.com",
+      "narod.ru",
+      "ria.ru",
       "radikal.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
       "rakuten.co.jp",
-      "economist.com"
+      "economist.com",
+      "ocn.ne.jp"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
       "flickr.com",
       "sourceforge.net",
-      "hp.com",
+      "ancestry.com",
       "eset.com"
     ],
     "yandex.ru": [
@@ -7998,7 +8380,8 @@
       "opera.com",
       "stanford.edu",
       "ning.com",
-      "rt.com",
+      "ria.ru",
+      "qip.ru",
       "radikal.ru",
       "kharkov.ua"
     ],
@@ -8018,8 +8401,8 @@
       "spiegel.de",
       "heise.de",
       "faz.net",
-      "t-online.de",
       "springer.com",
+      "home.pl",
       "focus.de"
     ],
     "yieldoptimizer.com": [
@@ -8030,13 +8413,19 @@
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
-      "nytimes.com"
+      "nytimes.com",
+      "dropbox.com",
+      "iop.org",
+      "cnet.com",
+      "sbs.com.au",
+      "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
       "newyorker.com",
-      "pcworld.com"
+      "pcworld.com",
+      "infoworld.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -8061,9 +8450,9 @@
       "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
-      "harvard.edu",
       "caltech.edu",
-      "francetvinfo.fr",
+      "ucr.edu",
+      "onet.pl",
       "honeywell.com"
     ],
     "youvisit.com": [
@@ -8092,7 +8481,8 @@
       "independent.co.uk",
       "thehill.com",
       "farfetch.com",
-      "lemonde.fr",
+      "paypal.com",
+      "orange.fr",
       "infoplease.com"
     ],
     "zendesk.com": [
@@ -8136,5 +8526,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.26"
+  "version": "2018.8.27"
 }

--- a/results.json
+++ b/results.json
@@ -1,17 +1,5 @@
 {
   "action_map": {
-    "107-coj-713.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538180650544,
-      "userAction": ""
-    },
-    "112-tzm-766.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538394933849,
-      "userAction": ""
-    },
     "112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -42,34 +30,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "194-vvc-221.mktoresp.com": {
+    "247-inc.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538483514256,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "247realmedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "254a.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "2771890.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538368660302,
-      "userAction": ""
-    },
-    "2912a.v.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538256664930,
       "userAction": ""
     },
     "2o7.net": {
@@ -92,7 +62,7 @@
     },
     "360yield.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -108,58 +78,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "4139589.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538385347766,
-      "userAction": ""
-    },
-    "4272175.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538095276395,
-      "userAction": ""
-    },
-    "4292932.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538443166948,
-      "userAction": ""
-    },
-    "4635217.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538206007436,
-      "userAction": ""
-    },
-    "4645712.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538083902504,
-      "userAction": ""
-    },
-    "4d.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538456849026,
-      "userAction": ""
-    },
     "50bang.org": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "5420914.fls.doubleclick.net": {
+    "540-wem-854.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538323409082,
-      "userAction": ""
-    },
-    "5496506.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538531334136,
+      "nextUpdateTime": 1538343204573,
       "userAction": ""
     },
     "58.com": {
@@ -174,130 +102,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "5p4rk13.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "6126321.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538145560460,
-      "userAction": ""
-    },
-    "6901690.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538338401506,
-      "userAction": ""
-    },
     "6sc.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "8117415.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538334719410,
-      "userAction": ""
-    },
-    "8136595.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538150124402,
-      "userAction": ""
-    },
-    "8242400.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538132491651,
-      "userAction": ""
-    },
-    "8329645.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538200870446,
-      "userAction": ""
-    },
-    "899-ihp-202.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538500225994,
-      "userAction": ""
-    },
-    "a.postrelease.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538059890436,
-      "userAction": ""
-    },
-    "a.quora.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538122796132,
-      "userAction": ""
-    },
-    "a.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294298158,
-      "userAction": ""
-    },
-    "a.wishabi.com": {
+    "a8270235338.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538194589363,
-      "userAction": ""
-    },
-    "a2364010203.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538427938823,
-      "userAction": ""
-    },
-    "a6250770393.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538404954879,
-      "userAction": ""
-    },
-    "a6264210458.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538338901088,
-      "userAction": ""
-    },
-    "a7718922374.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538508807697,
-      "userAction": ""
-    },
-    "a8298190319.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538384086156,
-      "userAction": ""
-    },
-    "aa.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538142584062,
+      "nextUpdateTime": 1538228855491,
       "userAction": ""
     },
     "aamsitecertifier.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aax-eu.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538049200350,
       "userAction": ""
     },
     "aaxads.com": {
@@ -308,7 +128,7 @@
     },
     "abmr.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -330,18 +150,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538249417948,
-      "userAction": ""
-    },
-    "acdn.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538062628696,
-      "userAction": ""
-    },
     "acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
@@ -354,16 +162,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "activenetwork-d.openx.net": {
+    "actionnetwork.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538535925079,
-      "userAction": ""
-    },
-    "activenetworks-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538355264350,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acuityplatform.com": {
@@ -372,13 +174,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "acxiomapac.com": {
+    "ad-hatena.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ad-hatena.com": {
+    "ad-plus.cn": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -396,22 +198,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ad.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538277008771,
-      "userAction": ""
-    },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538242542788,
-      "userAction": ""
-    },
-    "ad.wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538425057023,
+      "nextUpdateTime": 1538275124714,
       "userAction": ""
     },
     "adapf.com": {
@@ -421,12 +211,6 @@
       "userAction": ""
     },
     "adc-srv.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adclear.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -450,6 +234,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adfarm.mediaplex.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538220421317,
+      "userAction": ""
+    },
     "adform.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -459,12 +249,6 @@
     "adfox.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -498,10 +282,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admiral.mgr.consensu.org": {
+    "admaster.com.cn": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538420953790,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "admission.net": {
@@ -522,6 +306,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adobecqms.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adobedtm.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -530,7 +320,7 @@
     },
     "adotmob.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -552,64 +342,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538447339353,
-      "userAction": ""
-    },
-    "ads.pubmatic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538496601089,
-      "userAction": ""
-    },
-    "ads.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538445794602,
-      "userAction": ""
-    },
-    "ads.servebom.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538373205501,
-      "userAction": ""
-    },
-    "ads.yap.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538418132951,
-      "userAction": ""
-    },
-    "adsafety.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adscale.de": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adserver-us.adtech.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538488159302,
-      "userAction": ""
-    },
-    "adserver.intentiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538557381542,
-      "userAction": ""
-    },
-    "adservice.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538153556785,
       "userAction": ""
     },
     "adsnative.com": {
@@ -636,21 +372,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtng.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx.com.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -722,7 +446,13 @@
     },
     "allure.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "amap.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -750,46 +480,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "amazonwebservices.d2.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538516307010,
-      "userAction": ""
-    },
-    "amazonwebservicesinc.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538414598582,
-      "userAction": ""
-    },
     "ameba.jp": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ampcid.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538212864175,
-      "userAction": ""
-    },
-    "amplify.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538500466583,
-      "userAction": ""
-    },
-    "amplifypixel.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538293517643,
-      "userAction": ""
-    },
-    "an.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538328395538,
       "userAction": ""
     },
     "ancestry.ca": {
@@ -864,64 +558,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ap.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538225149247,
-      "userAction": ""
-    },
-    "apester.com": {
+    "aol.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "apex.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538364760079,
-      "userAction": ""
-    },
-    "api.adsnative.com": {
+    "apester.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538168277917,
-      "userAction": ""
-    },
-    "api.adsymptotic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538545671107,
-      "userAction": ""
-    },
-    "api.circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538545915720,
-      "userAction": ""
-    },
-    "api.company-target.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538204919804,
-      "userAction": ""
-    },
-    "api.flyertown.ca": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538343500501,
-      "userAction": ""
-    },
-    "api.pymx5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538328923918,
-      "userAction": ""
-    },
-    "api.sabavision.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538058807775,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apis.google.com": {
@@ -939,13 +585,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538267380235,
-      "userAction": ""
-    },
-    "app.vssps.visualstudio.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538349547779,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apple.com": {
@@ -954,15 +594,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aps.hearstnp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538071048301,
-      "userAction": ""
-    },
     "architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -976,36 +610,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "as-sec.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538321865785,
-      "userAction": ""
-    },
-    "as.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538094506065,
-      "userAction": ""
-    },
-    "assets-gulfnews.sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538268936081,
-      "userAction": ""
-    },
-    "assets.adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538518662620,
-      "userAction": ""
-    },
-    "assets.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538397145272,
       "userAction": ""
     },
     "atdmt.com": {
@@ -1022,14 +626,8 @@
     },
     "ati-host.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atlasobscura-travel.t.domdex.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538333342983,
       "userAction": ""
     },
     "att.com": {
@@ -1044,13 +642,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.tags.newscgp.com": {
+    "attvlt2.azurewebsites.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538525497075,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "audtd.com": {
+    "audiencemanager.de": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1064,26 +662,8 @@
     },
     "autopilothq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "b-code.liadm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538297140111,
-      "userAction": ""
-    },
-    "b.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294619765,
-      "userAction": ""
-    },
-    "b1sync.zemanta.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538132077041,
       "userAction": ""
     },
     "baidu.com": {
@@ -1101,13 +681,7 @@
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538443530778,
-      "userAction": ""
-    },
-    "bat.bing.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538247008130,
+      "nextUpdateTime": 1538523364120,
       "userAction": ""
     },
     "baur.de": {
@@ -1128,12 +702,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bdimg.share.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538404525556,
-      "userAction": ""
-    },
     "beemray.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -1141,6 +709,12 @@
       "userAction": ""
     },
     "beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "betrad.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1152,28 +726,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bh.contextweb.com": {
+    "bfmtv.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421717180,
-      "userAction": ""
-    },
-    "bid.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538470282368,
-      "userAction": ""
-    },
-    "bid.g.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538243655658,
-      "userAction": ""
-    },
-    "bidder.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538449269932,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "biddingx.com": {
@@ -1200,6 +756,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bitbucket.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1218,15 +780,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "block.lp1block.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538176389447,
-      "userAction": ""
-    },
     "bluecava.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1254,12 +810,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bobo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1268,7 +818,7 @@
     },
     "bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1304,7 +854,7 @@
     },
     "brides.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1320,28 +870,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bs.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538238980390,
-      "userAction": ""
-    },
     "bshare.cn": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bshare.optimix.asia": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538143370691,
-      "userAction": ""
-    },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538135297080,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "btttag.com": {
@@ -1356,46 +894,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "c.adsymptotic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538456439921,
-      "userAction": ""
-    },
-    "c.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538109343951,
-      "userAction": ""
-    },
-    "c.deployads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538317787251,
-      "userAction": ""
-    },
-    "c.jsrdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538549605036,
-      "userAction": ""
-    },
-    "c.pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538231054008,
-      "userAction": ""
-    },
     "c1.neweggimages.com": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538193299183,
-      "userAction": ""
-    },
-    "c2.taboola.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538552135048,
+      "nextUpdateTime": 1538335697441,
       "userAction": ""
     },
     "c212.net": {
@@ -1422,10 +924,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "capture.condenastdigital.com": {
+    "capturehighered.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538149772927,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "carambo.la": {
@@ -1458,106 +960,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cdn-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538505275561,
-      "userAction": ""
-    },
-    "cdn.bizible.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538183210921,
-      "userAction": ""
-    },
-    "cdn.blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538409772024,
-      "userAction": ""
-    },
-    "cdn.digitru.st": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538464924771,
-      "userAction": ""
-    },
-    "cdn.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538502123391,
-      "userAction": ""
-    },
-    "cdn.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538054972489,
-      "userAction": ""
-    },
-    "cdn.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538056897091,
-      "userAction": ""
-    },
     "cdn.native.ai": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538112716764,
-      "userAction": ""
-    },
-    "cdn.oas-c18.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538491657369,
-      "userAction": ""
-    },
-    "cdn.selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538325259903,
-      "userAction": ""
-    },
-    "cdn.siftscience.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538255124011,
-      "userAction": ""
-    },
-    "cdn.static.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538423691203,
-      "userAction": ""
-    },
-    "cdn.taboola.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538052152256,
-      "userAction": ""
-    },
-    "cdn.tinypass.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538350048168,
-      "userAction": ""
-    },
-    "cdn.tynt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538121563634,
-      "userAction": ""
-    },
-    "cdn.viglink.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538552819503,
-      "userAction": ""
-    },
-    "cdn1-res.sundaysky.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538331283935,
+      "nextUpdateTime": 1538359925677,
       "userAction": ""
     },
     "cdnwidget.com": {
@@ -1572,16 +978,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "changeagain.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "checkout.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "checkout.stripe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538056961121,
       "userAction": ""
     },
     "chei.com.cn": {
@@ -1614,16 +1020,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ck.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538079083152,
-      "userAction": ""
-    },
     "ckies.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538290612775,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "clickability.com": {
@@ -1662,16 +1062,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cm.g.doubleclick.net": {
+    "cmgdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538084946321,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cms.tanx.com": {
+    "cmp.smartadserver.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538314445492,
+      "nextUpdateTime": 1538208881807,
+      "userAction": ""
+    },
+    "cmsadmin30.convio.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538440206675,
       "userAction": ""
     },
     "cnet.com": {
@@ -1680,21 +1086,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cnid.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538212613316,
-      "userAction": ""
-    },
-    "cnn.net": {
+    "cntraveler.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cntraveler.com": {
+    "cnzz.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1708,24 +1108,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collecte.audience.acpm.fr": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538216572940,
-      "userAction": ""
-    },
-    "collector-963.tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538075212407,
-      "userAction": ""
-    },
-    "collector-pxbecn7fqx.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538178626553,
       "userAction": ""
     },
     "collegenet.com": {
@@ -1746,28 +1128,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "complex.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "conative.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "config.lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538224661599,
-      "userAction": ""
-    },
     "connatix.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "connect.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538044706175,
       "userAction": ""
     },
     "connexity.net": {
@@ -1782,12 +1164,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consent-pref.trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538382256612,
-      "userAction": ""
-    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1800,16 +1176,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "contextual.media.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538123517033,
-      "userAction": ""
-    },
     "contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "conv-blizzard-emea.cd.serving-sys.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538493335476,
+      "userAction": ""
+    },
+    "conv-blizzard-na.cd.serving-sys.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538480483471,
       "userAction": ""
     },
     "convertro.com": {
@@ -1818,22 +1200,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "core.connatix.com": {
+    "convio.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538077162990,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cornell.edu": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "counter.yadro.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538315953930,
       "userAction": ""
     },
     "coxmediagroup.com": {
@@ -1849,6 +1225,12 @@
       "userAction": ""
     },
     "creativecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecommons.org": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1878,40 +1260,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ct.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538334484197,
-      "userAction": ""
-    },
-    "cx.atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538107799509,
-      "userAction": ""
-    },
     "cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d.company-target.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538510704544,
-      "userAction": ""
-    },
-    "d.la1-c2-dfw.salesforceliveagent.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538196982209,
-      "userAction": ""
-    },
-    "d.turn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294378750,
       "userAction": ""
     },
     "d1af033869koo7.cloudfront.net": {
@@ -1944,13 +1296,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "data.dianomi.com": {
+    "datamind.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538215972432,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datamind.ru": {
+    "daum.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1960,24 +1312,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dc.ads.linkedin.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538143536390,
-      "userAction": ""
-    },
-    "decajo.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538503040838,
-      "userAction": ""
-    },
-    "delivery.zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538180066266,
       "userAction": ""
     },
     "demdex.net": {
@@ -2016,22 +1350,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "display.apester.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538272371129,
       "userAction": ""
     },
     "disqus.com": {
@@ -2052,13 +1374,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dmx.districtm.io": {
+    "dmxleo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538077158657,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dmxleo.com": {
+    "dnnapi.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2067,12 +1389,6 @@
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dol.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2106,12 +1422,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dpm.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538127110451,
-      "userAction": ""
-    },
     "dpmsrv.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -2124,22 +1434,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dt.admission.net": {
+    "dsp.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538348346597,
-      "userAction": ""
-    },
-    "dt.cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538296791629,
-      "userAction": ""
-    },
-    "dx.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538412044496,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynad.net": {
@@ -2160,10 +1458,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "e-2072.adzerk.net": {
+    "ebay-us.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538325723457,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ebay.com": {
@@ -2174,7 +1472,7 @@
     },
     "ebayrtm.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2184,28 +1482,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "echo.intergient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538161191136,
-      "userAction": ""
-    },
-    "eclick.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421526521,
-      "userAction": ""
-    },
     "edge-cdn.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "edge.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538303768684,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -2232,33 +1512,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "embed.sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538199320008,
-      "userAction": ""
-    },
     "emlgrid.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "engage.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538534356108,
-      "userAction": ""
-    },
-    "engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538467483460,
-      "userAction": ""
-    },
     "epicurious.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2268,28 +1530,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eset.marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538430898085,
-      "userAction": ""
-    },
-    "eset.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538356537340,
-      "userAction": ""
-    },
     "estat.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "events.mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538345920195,
       "userAction": ""
     },
     "everesttech.net": {
@@ -2298,10 +1542,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "everydayhealth.demdex.net": {
+    "everyaction.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538552306958,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "evise.com": {
@@ -2313,13 +1557,13 @@
     "evvnt-api.global.ssl.fastly.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538336434789,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ewscripps.hb.omtrdc.net": {
+    "ew3.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538506157825,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "exactag.com": {
@@ -2338,12 +1582,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "experience.tinypass.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538171166728,
       "userAction": ""
     },
     "eyeota.net": {
@@ -2382,18 +1620,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fastlane-adv.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538455076395,
-      "userAction": ""
-    },
-    "fastlane.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538277861999,
-      "userAction": ""
-    },
     "fdlstatic.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2426,7 +1652,7 @@
     },
     "firstimpression.io": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2448,12 +1674,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538174863248,
-      "userAction": ""
-    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -2472,12 +1692,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "forms.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538138908700,
-      "userAction": ""
-    },
     "formstack.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2490,6 +1704,18 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "foxbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxsports.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "foxycart.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2497,6 +1723,18 @@
       "userAction": ""
     },
     "freshdesk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "friendbuy.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "funnyordie.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2514,43 +1752,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.3gl.net": {
+    "g.cn.miaozhen.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538410704427,
+      "nextUpdateTime": 1538491763887,
       "userAction": ""
     },
-    "g.ign.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538148864057,
-      "userAction": ""
-    },
-    "gateway.answerscloud.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538395883518,
-      "userAction": ""
-    },
-    "gemius.pl": {
+    "geetest.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "geocoding.internetbrands.com": {
+    "gemius.pl": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538536149847,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "geolocation.onetrust.com": {
+    "gentags.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538218189361,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "getclicky.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getsmartcontent.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2570,7 +1802,7 @@
     },
     "glamour.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2578,6 +1810,12 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gmglobalcorporatefunctions.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538558542584,
       "userAction": ""
     },
     "go.com": {
@@ -2588,7 +1826,7 @@
     },
     "golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2607,19 +1845,13 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538370377555,
+      "nextUpdateTime": 1538340601964,
       "userAction": ""
     },
     "gq.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "graph.facebook.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538295132337,
       "userAction": ""
     },
     "gridsumdissector.com": {
@@ -2640,15 +1872,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gslbeacon.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538471693280,
-      "userAction": ""
-    },
     "gtags.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2664,10 +1890,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gwiqcdn.globalwebindex.net": {
+    "gxbr.cnzz.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538329164909,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538181812392,
       "userAction": ""
     },
     "hatena.com": {
@@ -2682,10 +1908,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hbopenbid.pubmatic.com": {
+    "hdslb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538228306081,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "healte.de": {
@@ -2718,10 +1944,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hm.baidu.com": {
+    "hiwoenrep.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538383968817,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "horyzon-media.com": {
@@ -2730,9 +1956,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "huanqiu.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hubpd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "hubspot.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huffingtonpost.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2754,34 +1998,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "i.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538433396017,
-      "userAction": ""
-    },
-    "i.tianqi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538262509948,
-      "userAction": ""
-    },
     "iasds01.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ib.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538182536434,
       "userAction": ""
     },
     "ibclick.stream": {
@@ -2802,34 +2022,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "id.rlcdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538459618997,
-      "userAction": ""
-    },
     "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "idealmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "identityssl.newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538550188509,
-      "userAction": ""
-    },
-    "idsync.rlcdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538467403404,
       "userAction": ""
     },
     "ign.com": {
@@ -2856,12 +2052,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "img.purch.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "imgur.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2880,22 +2070,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "in.getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538484989853,
-      "userAction": ""
-    },
     "infinity-tracking.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "infinityid.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538163838777,
       "userAction": ""
     },
     "inq.com": {
@@ -2904,10 +2082,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "insight.adsrvr.org": {
+    "inquisitr.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538092323704,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -2922,15 +2100,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "insticator-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538177453642,
-      "userAction": ""
-    },
     "instinctiveads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2964,12 +2136,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "investing-channel-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538398006786,
-      "userAction": ""
-    },
     "investingchannel.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -2996,38 +2162,26 @@
     },
     "iperceptions.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ipinyou.com": {
+      "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "ipredictive.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ips-invite.iperceptions.com": {
-      "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538513891249,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "irs01.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "italiaonline01.wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538262101357,
-      "userAction": ""
-    },
-    "jadserve.postrelease.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538426276329,
       "userAction": ""
     },
     "janrainsso.com": {
@@ -3050,20 +2204,14 @@
     },
     "jrs5.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "js.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538190129186,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1538279062905,
+      "nextUpdateTime": 1538500509571,
       "userAction": ""
     },
     "jsrdn.com": {
@@ -3073,6 +2221,12 @@
       "userAction": ""
     },
     "justuno.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kakao.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3159,7 +2313,7 @@
     "leadintel.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538046595757,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "leadlander.com": {
@@ -3168,21 +2322,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "legocdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licasd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3234,12 +2376,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "live.sekindo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538332400243,
-      "userAction": ""
-    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3258,18 +2394,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load.sumo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538194386904,
-      "userAction": ""
-    },
-    "loadus.exelator.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538189709302,
-      "userAction": ""
-    },
     "loc.gov": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3279,19 +2403,7 @@
     "lockerdome.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538146284566,
-      "userAction": ""
-    },
-    "log.mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538355091856,
-      "userAction": ""
-    },
-    "login.dotomi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538513913912,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "logly.co.jp": {
@@ -3300,28 +2412,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "logs11.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538403190845,
-      "userAction": ""
-    },
-    "logs1136.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538251719016,
-      "userAction": ""
-    },
     "lp1block.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lptag.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538533427768,
       "userAction": ""
     },
     "lqm.io": {
@@ -3348,9 +2442,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "madeleine.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mail.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mailchimp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3380,7 +2486,7 @@
     },
     "marketlinc.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3388,18 +2494,6 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "match.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538200836706,
-      "userAction": ""
-    },
-    "match.prod.bidr.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538339384874,
       "userAction": ""
     },
     "matheranalytics.com": {
@@ -3414,6 +2508,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mct01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "media.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3424,12 +2524,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediadc-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538439252020,
       "userAction": ""
     },
     "mediaforge.com": {
@@ -3446,19 +2540,13 @@
     },
     "mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "mediav.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediawallahscript.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3481,12 +2569,6 @@
       "userAction": ""
     },
     "metadsp.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mfadsrvr.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3528,12 +2610,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mid.rkdms.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538247909740,
-      "userAction": ""
-    },
     "mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3543,7 +2619,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538394141616,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mmstat.com": {
@@ -3594,12 +2670,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mssl.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538487358307,
-      "userAction": ""
-    },
     "mt0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3610,12 +2680,6 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtrx.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538555902065,
       "userAction": ""
     },
     "mts0.google.com": {
@@ -3654,6 +2718,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "myhard.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mynativeplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3678,12 +2748,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "nasdaq.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -3700,12 +2764,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "native.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538320667027,
       "userAction": ""
     },
     "nativendo.de": {
@@ -3726,15 +2784,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nbcu.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538463121539,
-      "userAction": ""
-    },
     "nbcuni.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "netmng.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3758,13 +2816,13 @@
     },
     "news.com.au": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "newscdn.com.au": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3772,12 +2830,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newscorpau.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421923960,
       "userAction": ""
     },
     "newsinc.com": {
@@ -3800,7 +2852,7 @@
     },
     "newyorker.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3820,6 +2872,12 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "now.eloqua.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538366209349,
       "userAction": ""
     },
     "nr-data.net": {
@@ -3846,10 +2904,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oasc10.247realmedia.com": {
+    "oath.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538268830533,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ocdn.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "office.com": {
@@ -3859,12 +2923,6 @@
       "userAction": ""
     },
     "office365.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ojrq.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3894,12 +2952,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "omnidsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "omnitagjs.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3922,12 +2974,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onetag.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538426323108,
       "userAction": ""
     },
     "onetrust.com": {
@@ -3978,12 +3024,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ophan.theguardian.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538371630281,
-      "userAction": ""
-    },
     "opinionstage.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4006,6 +3046,12 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optout.betrad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538300013262,
       "userAction": ""
     },
     "ora.tv": {
@@ -4050,22 +3096,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "p.dlx.addthis.com": {
+    "paddle.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538076392629,
-      "userAction": ""
-    },
-    "p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538159006482,
-      "userAction": ""
-    },
-    "p2.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538075969602,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pardot.com": {
@@ -4098,12 +3132,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pd.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538125278981,
-      "userAction": ""
-    },
     "performgroup.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4116,28 +3144,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "phonograph2.voxmedia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538254593492,
-      "userAction": ""
-    },
     "photobucket.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pi.pardot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538374590064,
-      "userAction": ""
-    },
-    "pic.fastapi.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538255329652,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -4170,36 +3180,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pixel.condenastdigital.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538133315883,
-      "userAction": ""
-    },
-    "pixel.keywee.co": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538133366404,
-      "userAction": ""
-    },
-    "pixel.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538522752196,
-      "userAction": ""
-    },
-    "pixel.sitescout.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538192671832,
-      "userAction": ""
-    },
-    "pixel.zprk.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538486726252,
-      "userAction": ""
-    },
     "piximedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4210,18 +3190,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "platform-api.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538056097475,
-      "userAction": ""
-    },
-    "platform.linkedin.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538260131857,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -4236,28 +3204,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.performgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538214631976,
-      "userAction": ""
-    },
-    "player.vimeo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538362569129,
-      "userAction": ""
-    },
     "players.brightcove.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "playwire-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538319307097,
       "userAction": ""
     },
     "plista.com": {
@@ -4275,25 +3225,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538187345852,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "popsugar-assets.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538418412765,
-      "userAction": ""
-    },
-    "postmedia.us.janrainsso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538174985349,
       "userAction": ""
     },
     "postrelease.com": {
@@ -4309,12 +3247,6 @@
       "userAction": ""
     },
     "pressboard.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "prfct.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4356,22 +3288,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "proximus.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538427583405,
-      "userAction": ""
-    },
     "pub.network": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubads.g.doubleclick.net": {
+    "publishme.se": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538202489440,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -4394,12 +3320,6 @@
     },
     "purch.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "purechat.com": {
-      "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
@@ -4413,13 +3333,7 @@
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538206203762,
-      "userAction": ""
-    },
-    "px.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538460515426,
+      "nextUpdateTime": 1538262359887,
       "userAction": ""
     },
     "pxi.pub": {
@@ -4431,12 +3345,12 @@
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538200483882,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "qq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4444,12 +3358,6 @@
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantcast.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538327762416,
       "userAction": ""
     },
     "quantserve.com": {
@@ -4476,12 +3384,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.turn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538114432566,
-      "userAction": ""
-    },
     "rackcdn.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -4494,21 +3396,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "rakuten.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rcom.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538208445032,
-      "userAction": ""
-    },
     "reachmax.cn": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4530,7 +3432,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "republer.com": {
+    "render.githubusercontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "researchintel.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4548,15 +3456,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "reutersmedia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "revcontent.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4568,7 +3470,7 @@
     },
     "rezync.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4626,46 +3528,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rp.gwallet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538294745257,
-      "userAction": ""
-    },
-    "rqtrk.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rs.gwallet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538129421105,
-      "userAction": ""
-    },
-    "rss.art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538167421505,
-      "userAction": ""
-    },
-    "rtb.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538352452690,
-      "userAction": ""
-    },
     "rtk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtve.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538202862196,
       "userAction": ""
     },
     "ru4.com": {
@@ -4680,88 +3546,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rudy.adsnative.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538152569067,
-      "userAction": ""
-    },
-    "rutarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "s-static.ak.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "s.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538369224004,
-      "userAction": ""
-    },
-    "s.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538062771361,
-      "userAction": ""
-    },
-    "s.clickability.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538478226394,
-      "userAction": ""
-    },
-    "s.effectivemeasure.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538149322611,
-      "userAction": ""
-    },
-    "s.nexac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538515216122,
-      "userAction": ""
-    },
-    "s.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538221863124,
-      "userAction": ""
-    },
-    "s.spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538331458176,
-      "userAction": ""
-    },
-    "s.thebrighttag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538183045497,
-      "userAction": ""
-    },
-    "s1061485456.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538180635780,
-      "userAction": ""
-    },
-    "s118899503.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538367243127,
-      "userAction": ""
-    },
-    "s2208.t.eloqua.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538366295174,
       "userAction": ""
     },
     "s3-us-west-2.amazonaws.com": {
@@ -4770,10 +3558,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "s7.addthis.com": {
+    "s3xified.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538491765915,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sabavision.com": {
@@ -4806,34 +3594,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "samplicio.us": {
+    "scarabresearch.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sb-stage.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538303818062,
-      "userAction": ""
-    },
-    "sb.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538237980451,
-      "userAction": ""
-    },
-    "sbnationbidder-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538343887161,
-      "userAction": ""
-    },
-    "scdn.cxense.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538475610945,
       "userAction": ""
     },
     "scholarlyiq.com": {
@@ -4878,34 +3642,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "scribd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scripps.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538500013668,
-      "userAction": ""
-    },
-    "scripps.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538350668625,
-      "userAction": ""
-    },
     "script.ioam.de": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sdc-qczj.pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538490872689,
       "userAction": ""
     },
     "sdp-campaign.de": {
@@ -4914,100 +3654,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "search.spotxchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538422064517,
-      "userAction": ""
-    },
     "search.yahoo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "seccdn-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538546208242,
-      "userAction": ""
-    },
-    "secure-assets.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538187034130,
-      "userAction": ""
-    },
-    "secure-dcr.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538214152681,
-      "userAction": ""
-    },
-    "secure-ds.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538262143169,
-      "userAction": ""
-    },
-    "secure-gl.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538371117898,
-      "userAction": ""
-    },
-    "secure-it.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538367254534,
-      "userAction": ""
-    },
-    "secure-us.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538062926851,
-      "userAction": ""
-    },
-    "secure.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538515294111,
-      "userAction": ""
-    },
-    "secure.livechatinc.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538269531819,
-      "userAction": ""
-    },
-    "secure.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538219869201,
-      "userAction": ""
-    },
-    "secure.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538453154129,
-      "userAction": ""
-    },
     "securedvisit.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "securepubads.g.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538165745281,
-      "userAction": ""
-    },
-    "segapi.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538077819865,
       "userAction": ""
     },
     "sekindo.com": {
@@ -5024,7 +3680,7 @@
     },
     "self.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5040,10 +3696,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servedby.flashtalking.com": {
+    "servedby-buysellads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538477934971,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "serverbid.com": {
@@ -5056,12 +3712,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "session.timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538421892505,
       "userAction": ""
     },
     "sessioncam.com": {
@@ -5108,7 +3758,7 @@
     },
     "simpli.fi": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5157,7 +3807,7 @@
     "sjs.bizographics.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538374333246,
+      "nextUpdateTime": 1538321907146,
       "userAction": ""
     },
     "skimresources.com": {
@@ -5182,12 +3832,6 @@
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartlock.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538354484555,
       "userAction": ""
     },
     "smashing-delivery.herokuapp.com": {
@@ -5244,22 +3888,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sohu.irs01.com": {
+    "sohu.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538175757124,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sokrati.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solarwinds.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538167927210,
       "userAction": ""
     },
     "sonobi.com": {
@@ -5274,12 +3912,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sp.analytics.yahoo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538339922746,
-      "userAction": ""
-    },
     "sphereup.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5289,6 +3921,18 @@
     "spiceworks.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spineuniverse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spingo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5330,7 +3974,7 @@
     },
     "springernature.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5346,46 +3990,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-09-26-09.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538359586941,
-      "userAction": ""
-    },
-    "srv-2018-09-26-09.pixel.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538445425688,
-      "userAction": ""
-    },
-    "srv-2018-09-26-10.config.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538474458903,
-      "userAction": ""
-    },
-    "srv.au.ebayrtm.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538460842793,
-      "userAction": ""
-    },
     "srx.com.sg": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sslwidget.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538250386292,
-      "userAction": ""
-    },
-    "st.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538512151649,
       "userAction": ""
     },
     "stackadapt.com": {
@@ -5394,34 +4002,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "stanza-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538238071781,
-      "userAction": ""
-    },
     "statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "static.bshare.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538407047481,
-      "userAction": ""
-    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538438476744,
-      "userAction": ""
-    },
-    "static.parsely.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538374661983,
+      "nextUpdateTime": 1538398711735,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -5433,13 +4023,7 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1538123969054,
-      "userAction": ""
-    },
-    "statse.webtrendslive.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538383272999,
+      "nextUpdateTime": 1538480363136,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -5490,7 +4074,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "suning.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "suning.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sunrtb.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5502,64 +4098,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "survata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "survey.g.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538409550581,
-      "userAction": ""
-    },
     "surveymonkey.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "svcs.ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538325865068,
-      "userAction": ""
-    },
-    "sw88.go.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538045911214,
-      "userAction": ""
-    },
     "switchadhub.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "symantec.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sync.adaptv.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538159389370,
-      "userAction": ""
-    },
-    "sync.graph.bluecava.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538100879756,
-      "userAction": ""
-    },
-    "sync.search.spotxchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538407016386,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -5578,30 +4126,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tag.bounceexchange.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538489495789,
-      "userAction": ""
-    },
-    "tag.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538210741846,
-      "userAction": ""
-    },
-    "tag.placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538095525832,
-      "userAction": ""
-    },
-    "tags.news.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538246007029,
       "userAction": ""
     },
     "tailtarget.com": {
@@ -5634,28 +4158,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tap-secure.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538492207266,
-      "userAction": ""
-    },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tapestry.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538235641061,
-      "userAction": ""
-    },
-    "target.smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538428202945,
       "userAction": ""
     },
     "tawk.to": {
@@ -5664,7 +4170,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "taylorandfrancis.com": {
+    "teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5684,7 +4190,7 @@
     },
     "teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5712,18 +4218,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thrtle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thunder.adnxs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538123580474,
-      "userAction": ""
-    },
     "tianqi.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5748,12 +4242,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "timeinc.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538072239103,
-      "userAction": ""
-    },
     "timewarnercable.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5769,18 +4257,6 @@
     "tiqcdn.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tlx.3lift.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538202979002,
-      "userAction": ""
-    },
-    "tm-awx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5802,19 +4278,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "track.adform.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538111155067,
-      "userAction": ""
-    },
-    "track.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538073273875,
-      "userAction": ""
-    },
     "tradelab.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "traffic-media.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -5862,12 +4332,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trends.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538067659492,
-      "userAction": ""
-    },
     "tribalfusion.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -5880,22 +4344,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "triblive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tripadvisor.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trk.connatix.com": {
+    "trk.mct01.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538056981974,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538388427712,
       "userAction": ""
     },
     "tronc.com": {
@@ -5922,16 +4380,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trustpilot.com": {
+    "tumblr.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tt.onthe.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538407164376,
       "userAction": ""
     },
     "turn.com": {
@@ -5949,12 +4401,6 @@
     "tvsquared.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "twimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5982,12 +4428,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "uconnect.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538086919054,
-      "userAction": ""
-    },
     "ucoz.net": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -5997,19 +4437,13 @@
     "udmserve.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538457145899,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ugdturner.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unagi-eu.amazon.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538257470790,
       "userAction": ""
     },
     "undertone.com": {
@@ -6038,7 +4472,7 @@
     },
     "upsellit.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6048,13 +4482,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us-u.openx.net": {
+    "usa.gov": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538339771741,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "usa.gov": {
+    "useproof.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -6081,19 +4515,19 @@
     "utarget.pro": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538409562664,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "utarget.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538382140645,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "uuidksinc.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1538344768057,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "v-biz.com.ua": {
@@ -6102,9 +4536,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "v.admaster.com.cn": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538367082123,
+      "userAction": ""
+    },
     "vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6120,10 +4560,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vendorlist.consensu.org": {
+    "verticalhealth.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538143303737,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "viafoura.co": {
@@ -6210,10 +4650,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vop.sundaysky.com": {
+    "volvelle.tech": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538418284544,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -6222,15 +4662,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "w.soundcloud.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538264689912,
-      "userAction": ""
-    },
     "w55c.net": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6240,22 +4674,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wal.wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538507015629,
-      "userAction": ""
-    },
     "wallst.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wamfactory.solution.weborama.fr": {
+    "waptime.cn": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538404424123,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "warnerbros.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wbtrk.net": {
@@ -6300,12 +4734,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "webservices.webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538420584854,
-      "userAction": ""
-    },
     "websimages.com": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6336,22 +4764,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "welt.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "whistleout.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "widget.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538468993614,
       "userAction": ""
     },
     "wikia-services.com": {
@@ -6384,6 +4800,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wishpond.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "wistia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6410,14 +4832,8 @@
     },
     "wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wms-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538561096392,
       "userAction": ""
     },
     "wnyc.org": {
@@ -6456,18 +4872,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ws.sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538093572796,
-      "userAction": ""
-    },
-    "ws.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538495803032,
-      "userAction": ""
-    },
     "wsj.net": {
       "dnt": false,
       "heuristicAction": "allow",
@@ -6486,58 +4890,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "www.allure.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538510946198,
-      "userAction": ""
-    },
-    "www.architecturaldigest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538087322367,
-      "userAction": ""
-    },
-    "www.beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538073326388,
-      "userAction": ""
-    },
     "www.bing.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "www.bonappetit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538446372221,
-      "userAction": ""
-    },
-    "www.brides.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538493655891,
-      "userAction": ""
-    },
-    "www.cntraveler.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538123690650,
-      "userAction": ""
-    },
-    "www.dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538195644309,
-      "userAction": ""
-    },
-    "www.epicurious.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538168960663,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -6546,100 +4902,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "www.glamour.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538116834884,
-      "userAction": ""
-    },
-    "www.golfdigest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538157891279,
-      "userAction": ""
-    },
     "www.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "www.gq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538093232146,
-      "userAction": ""
-    },
-    "www.iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538193507860,
-      "userAction": ""
-    },
-    "www.lightboxcdn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538121151651,
-      "userAction": ""
-    },
-    "www.newyorker.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538278936690,
-      "userAction": ""
-    },
-    "www.proximus.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538480707132,
-      "userAction": ""
-    },
-    "www.self.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538341119642,
-      "userAction": ""
-    },
-    "www.teenvogue.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538191505978,
-      "userAction": ""
-    },
-    "www.tns-counter.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538165597564,
-      "userAction": ""
-    },
-    "www.vanityfair.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538511390052,
-      "userAction": ""
-    },
-    "www.vogue.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538445532831,
-      "userAction": ""
-    },
-    "www.wired.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1538290704894,
-      "userAction": ""
-    },
-    "www.wmagazine.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1538343058111,
-      "userAction": ""
-    },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1538182668807,
+      "nextUpdateTime": 1538427419875,
       "userAction": ""
     },
     "wwwimages.adobe.com": {
@@ -6648,13 +4920,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "x.bidswitch.net": {
+    "xad.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538550095595,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "xad.com": {
+    "xg4ken.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xinhuanet.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -6690,6 +4968,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "xtgreat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "y3.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6714,6 +4998,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yahoosmallbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -6723,7 +5013,7 @@
     "yastatic.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1538421382254,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "yieldlab.net": {
@@ -6764,7 +5054,7 @@
     },
     "youvisit.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6772,18 +5062,6 @@
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "z-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538367319132,
-      "userAction": ""
-    },
-    "za-cdn.effectivemeasure.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1538234483947,
       "userAction": ""
     },
     "zdbb.net": {
@@ -6794,7 +5072,7 @@
     },
     "zedo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6807,6 +5085,12 @@
     "zergnet.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zhaopin.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6848,12 +5132,12 @@
     "15gifts.com": [
       "thetimes.co.uk"
     ],
+    "247-inc.net": [
+      "marriott.com"
+    ],
     "247realmedia.com": [
       "bmj.com",
       "americanbar.org"
-    ],
-    "254a.com": [
-      "tinyurl.com"
     ],
     "2o7.net": [
       "cdc.gov",
@@ -6861,19 +5145,20 @@
       "fastcompany.com"
     ],
     "33across.com": [
-      "accuweather.com"
+      "salon.com"
     ],
     "360.cn": [
       "so.com"
     ],
     "360yield.com": [
+      "telegraph.co.uk",
       "springer.com",
       "home.pl"
     ],
     "3gl.net": [
       "go.com",
       "economist.com",
-      "sfgate.com"
+      "thedailybeast.com"
     ],
     "3lift.com": [
       "msn.com",
@@ -6889,9 +5174,6 @@
     "58cdn.com.cn": [
       "ganji.com"
     ],
-    "5p4rk13.com": [
-      "sfu.ca"
-    ],
     "6sc.co": [
       "brightcove.com"
     ],
@@ -6901,10 +5183,10 @@
       "post-gazette.com"
     ],
     "aaxads.com": [
-      "forbes.com",
       "speedtest.net"
     ],
     "abmr.net": [
+      "paypal.com",
       "nike.com",
       "freetype.org"
     ],
@@ -6917,29 +5199,32 @@
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "leparisien.fr"
+      "liberation.fr"
     ],
     "acquia.com": [
       "panasonic.com",
       "osu.edu",
       "amd.com"
     ],
+    "actionnetwork.org": [
+      "dailykos.com"
+    ],
     "acuityplatform.com": [
       "medscape.com"
     ],
-    "acxiomapac.com": [
-      "businessinsider.com",
-      "npr.org"
-    ],
     "ad-hatena.com": [
       "hatena.ne.jp"
+    ],
+    "ad-plus.cn": [
+      "sohu.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com"
+      "huanqiu.com",
+      "yesky.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
@@ -6947,33 +5232,27 @@
     "adc-srv.net": [
       "autodesk.com"
     ],
-    "adclear.net": [
-      "t-online.de"
-    ],
     "addroplet.com": [
-      "tinypic.com",
+      "wallinside.com",
       "washingtonexaminer.com"
     ],
     "addthis.com": [
-      "nasa.gov",
       "who.int",
-      "npr.org"
+      "columbia.edu",
+      "uci.edu"
     ],
     "adentifi.com": [
       "metmuseum.org"
     ],
     "adform.net": [
-      "forbes.com",
-      "imdb.com",
-      "t-online.de"
+      "t-online.de",
+      "bloomberg.com",
+      "telegraph.co.uk"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
       "sputniknews.com"
-    ],
-    "adhigh.net": [
-      "rambler.ru"
     ],
     "adingo.jp": [
       "seesaa.jp"
@@ -6981,7 +5260,7 @@
     "adition.com": [
       "t-online.de",
       "dailymotion.com",
-      "lemonde.fr"
+      "spiegel.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -6992,57 +5271,63 @@
       "space.com",
       "howtogeek.com"
     ],
+    "admaster.com.cn": [
+      "sohu.com",
+      "yesky.com",
+      "bshare.cn"
+    ],
     "admission.net": [
       "edmunds.com"
     ],
     "adnxs.com": [
       "sourceforge.net",
       "nytimes.com",
-      "forbes.com"
+      "dropbox.com"
     ],
     "adobe.com": [
       "behance.net",
       "history.com",
       "nbc.com"
     ],
+    "adobecqms.net": [
+      "gopro.com"
+    ],
     "adobedtm.com": [
       "newyorker.com",
-      "symantec.com",
-      "worldbank.org"
+      "worldbank.org",
+      "nbcnews.com"
     ],
     "adotmob.com": [
-      "variety.com",
-      "standard.co.uk"
+      "dailymotion.com",
+      "nypost.com",
+      "variety.com"
     ],
     "adriver.ru": [
       "liveinternet.ru",
       "sputniknews.com",
-      "rambler.ru"
+      "ria.ru"
     ],
     "adroll.com": [
+      "nginx.org",
       "photobucket.com",
-      "cloudflare.com",
-      "ning.com"
+      "cloudflare.com"
     ],
     "adrta.com": [
       "seesaa.jp"
     ],
-    "adsafety.net": [
-      "npr.org"
-    ],
     "adscale.de": [
       "t-online.de",
-      "springer.com",
-      "home.pl"
+      "telegraph.co.uk",
+      "springer.com"
     ],
     "adsnative.com": [
+      "thehill.com",
       "squareup.com",
-      "informationweek.com",
-      "bostonherald.com"
+      "informationweek.com"
     ],
     "adsrvr.org": [
+      "adobe.com",
       "sourceforge.net",
-      "nytimes.com",
       "forbes.com"
     ],
     "adswizz.com": [
@@ -7051,20 +5336,14 @@
       "tunein.com"
     ],
     "adsymptotic.com": [
-      "forbes.com",
-      "wsj.com",
-      "etsy.com"
-    ],
-    "adtng.com": [
-      "pornhub.com"
+      "tinyurl.com",
+      "etsy.com",
+      "tripadvisor.com"
     ],
     "advertising.com": [
       "yahoo.com",
-      "nytimes.com",
-      "msn.com"
-    ],
-    "adx.com.ru": [
-      "rambler.ru"
+      "wsj.com",
+      "huffingtonpost.com"
     ],
     "adzerk.net": [
       "asp.net"
@@ -7076,9 +5355,9 @@
       "autodesk.com"
     ],
     "agkn.com": [
-      "imdb.com",
-      "bloomberg.com",
-      "cnet.com"
+      "cnet.com",
+      "businessinsider.com",
+      "dailymotion.com"
     ],
     "akamaihd.net": [
       "forbes.com",
@@ -7103,7 +5382,8 @@
       "sohu.com"
     ],
     "alipay.com": [
-      "youku.com"
+      "youku.com",
+      "taobao.com"
     ],
     "aliyun.com": [
       "alibabacloud.com",
@@ -7111,13 +5391,15 @@
     ],
     "allure.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
+    ],
+    "amap.com": [
+      "zhaopin.com"
     ],
     "amazon-adsystem.com": [
-      "forbes.com",
-      "imdb.com",
-      "washingtonpost.com"
+      "amazon.com",
+      "vimeo.com",
+      "nytimes.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -7125,8 +5407,7 @@
     "amazon.com": [
       "imdb.com",
       "amazon.co.uk",
-      "amazon.de",
-      "amazon.es"
+      "amazon.de"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -7162,14 +5443,19 @@
       "answers.com"
     ],
     "answerscloud.com": [
+      "worldbank.org",
       "acs.org",
-      "fbi.gov",
-      "uscourts.gov"
+      "fbi.gov"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
+    "aol.com": [
+      "techcrunch.com"
+    ],
     "apester.com": [
+      "inquisitr.com",
+      "searchenginewatch.com",
       "nme.com"
     ],
     "apn.co.nz": [
@@ -7187,8 +5473,7 @@
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
@@ -7207,16 +5492,22 @@
     ],
     "ati-host.net": [
       "bbc.com",
-      "straitstimes.com"
+      "straitstimes.com",
+      "thestar.com.my"
     ],
     "att.com": [
       "att.net"
     ],
-    "audtd.com": [
-      "rambler.ru"
+    "attvlt2.azurewebsites.net": [
+      "att.com"
+    ],
+    "audiencemanager.de": [
+      "macrumors.com"
     ],
     "autopilothq.com": [
-      "typeform.com"
+      "bitbucket.org",
+      "typeform.com",
+      "atlassian.com"
     ],
     "baidu.com": [
       "sina.com.cn",
@@ -7241,15 +5532,23 @@
     ],
     "beian.gov.cn": [
       "dzwww.com",
+      "ku6.com",
       "qianlong.com"
+    ],
+    "betrad.com": [
+      "gm.com"
     ],
     "bfmio.com": [
       "tinypic.com",
       "livescience.com",
       "space.com"
     ],
+    "bfmtv.com": [
+      "liberation.fr"
+    ],
     "biddingx.com": [
-      "sina.com.cn"
+      "sina.com.cn",
+      "sohu.com"
     ],
     "bidr.io": [
       "adobe.com",
@@ -7257,14 +5556,17 @@
       "dailymotion.com"
     ],
     "bidswitch.net": [
-      "forbes.com",
-      "tinyurl.com",
-      "imdb.com"
+      "dropbox.com",
+      "telegraph.co.uk",
+      "time.com"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
       "weebly.com"
+    ],
+    "bitbucket.org": [
+      "atlassian.com"
     ],
     "bizible.com": [
       "cloudflare.com",
@@ -7282,9 +5584,8 @@
       "people.com"
     ],
     "bluecava.com": [
-      "wsj.com",
       "giphy.com",
-      "active.com"
+      "walmart.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
@@ -7301,9 +5602,6 @@
       "bravenet.com",
       "jigsy.com"
     ],
-    "bobo.com": [
-      "163.com"
-    ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
@@ -7311,8 +5609,7 @@
     ],
     "bonappetit.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "boston.com": [
       "bostonglobe.com"
@@ -7330,8 +5627,7 @@
     ],
     "brides.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "brightcove.com": [
       "aarp.org",
@@ -7340,16 +5636,16 @@
     ],
     "brightcove.net": [
       "lonelyplanet.com",
-      "thetimes.co.uk",
-      "thenational.ae"
+      "techtarget.com",
+      "thetimes.co.uk"
     ],
     "bshare.cn": [
       "qianlong.com"
     ],
     "bttrack.com": [
+      "nypost.com",
       "livescience.com",
-      "variety.com",
-      "hpe.com"
+      "variety.com"
     ],
     "btttag.com": [
       "samsung.com",
@@ -7367,13 +5663,18 @@
     "cadreon.com": [
       "economist.com"
     ],
+    "capturehighered.net": [
+      "ku.edu",
+      "unm.edu"
+    ],
     "carambo.la": [
+      "salon.com",
       "accuweather.com"
     ],
     "casalemedia.com": [
-      "imdb.com",
       "washingtonpost.com",
-      "bloomberg.com"
+      "myspace.com",
+      "telegraph.co.uk"
     ],
     "cbsi.com": [
       "cnet.com",
@@ -7393,6 +5694,9 @@
     "cern.ch": [
       "home.cern"
     ],
+    "changeagain.me": [
+      "iconosquare.com"
+    ],
     "chei.com.cn": [
       "chsi.com.cn"
     ],
@@ -7410,7 +5714,8 @@
       "stltoday.com"
     ],
     "civicscience.com": [
-      "post-gazette.com"
+      "post-gazette.com",
+      "knowyourmeme.com"
     ],
     "ckies.net": [
       "abril.com.br"
@@ -7431,16 +5736,18 @@
       "sciencemag.org",
       "uci.edu"
     ],
+    "cmgdigital.com": [
+      "ajc.com"
+    ],
     "cnet.com": [
       "zdnet.com"
     ],
-    "cnn.net": [
-      "cnn.com"
-    ],
     "cntraveler.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
+    ],
+    "cnzz.com": [
+      "zol.com.cn"
     ],
     "cobaltgroup.com": [
       "edmunds.com"
@@ -7461,6 +5768,13 @@
       "ibm.com",
       "hp.com"
     ],
+    "complex.com": [
+      "knowyourmeme.com",
+      "dailydot.com"
+    ],
+    "conative.de": [
+      "focus.de"
+    ],
     "condenastdigital.com": [
       "wired.com",
       "newyorker.com",
@@ -7475,20 +5789,23 @@
       "sourceforge.net"
     ],
     "consensu.org": [
+      "buzzfeed.com",
       "pcworld.com",
-      "us.org",
-      "rollingstone.com"
+      "us.org"
     ],
     "content.ad": [
       "tinypic.com"
     ],
     "contextweb.com": [
       "sourceforge.net",
-      "forbes.com",
-      "imdb.com"
+      "myspace.com",
+      "uci.edu"
     ],
     "convertro.com": [
       "slack.com"
+    ],
+    "convio.net": [
+      "convio.com"
     ],
     "cornell.edu": [
       "arxiv.org"
@@ -7504,10 +5821,13 @@
     "creativecdn.com": [
       "ria.ru"
     ],
+    "creativecommons.org": [
+      "perl.com"
+    ],
     "criteo.com": [
-      "dropbox.com",
-      "forbes.com",
-      "reuters.com"
+      "washingtonpost.com",
+      "telegraph.co.uk",
+      "dailymail.co.uk"
     ],
     "crsspxl.com": [
       "sourceforge.net",
@@ -7518,9 +5838,9 @@
       "home.pl"
     ],
     "cxense.com": [
-      "wsj.com",
       "opera.com",
-      "talktalk.co.uk"
+      "talktalk.co.uk",
+      "gizmodo.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -7540,21 +5860,21 @@
       "metro.co.uk"
     ],
     "datamind.ru": [
-      "rambler.ru",
       "novostimira.com"
+    ],
+    "daum.net": [
+      "shutterstock.com",
+      "tistory.com"
     ],
     "dc-storm.com": [
       "nike.com",
       "alibabacloud.com",
       "coursera.org"
     ],
-    "decajo.ru": [
-      "radikal.ru"
-    ],
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "soundcloud.com"
+      "amazon.com"
     ],
     "deployads.com": [
       "tinyurl.com",
@@ -7565,16 +5885,13 @@
       "dezeen.com"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
-      "disney.com",
+      "go.com",
       "starwars.com"
     ],
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
       "zerohedge.com"
-    ],
-    "digitaltarget.ru": [
-      "rambler.ru"
     ],
     "digitru.st": [
       "britannica.com",
@@ -7592,25 +5909,25 @@
       "washingtontimes.com"
     ],
     "districtm.io": [
-      "forbes.com",
       "barnesandnoble.com",
-      "timeanddate.com"
+      "scmp.com",
+      "seattletimes.com"
     ],
     "dmxleo.com": [
       "dailymotion.com"
     ],
-    "dol.gov": [
-      "osha.gov"
+    "dnnapi.com": [
+      "zenfolio.com"
     ],
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "wsj.com"
+      "tinypic.com"
     ],
     "dotomi.com": [
-      "forbes.com",
       "samsung.com",
-      "economist.com"
+      "economist.com",
+      "barnesandnoble.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -7628,24 +5945,30 @@
       "theregister.co.uk",
       "adweek.com"
     ],
+    "dsp.com": [
+      "qq.com"
+    ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
       "cnbc.com",
-      "norton.com",
+      "nbcnews.com",
       "washingtonexaminer.com"
     ],
     "dyntrk.com": [
       "dailymotion.com"
     ],
-    "ebay.com": [
-      "ebay.co.uk",
-      "ebay.de",
+    "ebay-us.com": [
+      "ebay.com",
       "ebay.com.au"
     ],
-    "ebayrtm.com": [
+    "ebay.com": [
+      "t-online.de",
       "ebay.co.uk",
+      "ebay.de"
+    ],
+    "ebayrtm.com": [
       "ebay.de",
       "ebay.com.au"
     ],
@@ -7678,8 +6001,7 @@
     ],
     "epicurious.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -7687,12 +6009,15 @@
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "tomshardware.com"
+      "eklablog.com"
     ],
     "everesttech.net": [
       "adobe.com",
       "sourceforge.net",
-      "nytimes.com"
+      "dropbox.com"
+    ],
+    "everyaction.com": [
+      "greenpeace.org"
     ],
     "evise.com": [
       "thelancet.com",
@@ -7701,6 +6026,9 @@
     "evvnt-api.global.ssl.fastly.net": [
       "seattlepi.com"
     ],
+    "ew3.io": [
+      "liberation.fr"
+    ],
     "exactag.com": [
       "t-online.de"
     ],
@@ -7708,20 +6036,20 @@
       "exblog.jp"
     ],
     "exelator.com": [
-      "soundcloud.com",
-      "forbes.com",
-      "businessinsider.com"
+      "businessinsider.com",
+      "surveymonkey.com",
+      "talktalk.co.uk"
     ],
     "eyeota.net": [
       "sourceforge.net",
       "wsj.com",
-      "npr.org"
+      "scientificamerican.com"
     ],
     "eyereturn.com": [
       "thestar.com"
     ],
     "eyeviewads.com": [
-      "boingboing.net"
+      "nypost.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -7747,7 +6075,8 @@
     ],
     "firstimpression.io": [
       "jpost.com",
-      "haaretz.com"
+      "haaretz.com",
+      "zerohedge.com"
     ],
     "flashtalking.com": [
       "adobe.com",
@@ -7784,7 +6113,13 @@
     "fout.jp": [
       "economist.com",
       "exblog.jp",
-      "biglobe.ne.jp"
+      "seesaa.jp"
+    ],
+    "foxbusiness.com": [
+      "fox.com"
+    ],
+    "foxsports.com": [
+      "fox.com"
     ],
     "foxycart.com": [
       "brookings.edu"
@@ -7792,18 +6127,34 @@
     "freshdesk.com": [
       "podbean.com"
     ],
+    "friendbuy.com": [
+      "lulu.com"
+    ],
+    "funnyordie.com": [
+      "videojs.com"
+    ],
     "fwmrm.net": [
       "go.com",
       "discovery.com",
       "foodnetwork.com"
     ],
+    "geetest.com": [
+      "axs.com"
+    ],
     "gemius.pl": [
       "sapo.pt",
-      "ria.ru"
+      "ria.ru",
+      "onet.pl"
+    ],
+    "gentags.net": [
+      "sohu.com"
     ],
     "getclicky.com": [
       "newatlas.com",
       "cyberchimps.com"
+    ],
+    "getsmartcontent.com": [
+      "pcworld.com"
     ],
     "gigya.com": [
       "cnn.com",
@@ -7815,8 +6166,7 @@
     ],
     "glamour.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
@@ -7830,21 +6180,19 @@
     ],
     "golfdigest.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
     "google.com": [
       "youtube.com",
-      "vimeo.com",
-      "goo.gl"
+      "linkedin.com",
+      "vimeo.com"
     ],
     "gq.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "gridsumdissector.com": [
       "www.gov.cn"
@@ -7853,27 +6201,31 @@
       "groupon.com"
     ],
     "gtags.net": [
-      "ctrip.com"
+      "ctrip.com",
+      "sina.com.cn",
+      "suning.com"
     ],
     "gumgum.com": [
-      "snopes.com",
       "thehindu.com",
-      "home.pl"
+      "home.pl",
+      "zimbio.com"
     ],
     "gwallet.com": [
+      "adobe.com",
       "economist.com",
-      "ox.ac.uk",
-      "smithsonianmag.com"
+      "ox.ac.uk"
     ],
     "hatena.com": [
       "hatena.ne.jp"
     ],
     "hatena.ne.jp": [
-      "hatenablog.com",
-      "cronolog.org"
+      "hatenablog.com"
+    ],
+    "hdslb.com": [
+      "bilibili.com"
     ],
     "healte.de": [
-      "reuters.com"
+      "spiegel.de"
     ],
     "hearstnp.com": [
       "sfgate.com",
@@ -7889,13 +6241,25 @@
     "hive.co": [
       "complex.com"
     ],
+    "hiwoenrep.ru": [
+      "radikal.ru"
+    ],
     "horyzon-media.com": [
       "skyrock.com"
+    ],
+    "huanqiu.com": [
+      "sina.com.cn"
+    ],
+    "hubpd.com": [
+      "huanqiu.com"
     ],
     "hubspot.com": [
       "scoop.it",
       "500px.com",
       "thelancet.com"
+    ],
+    "huffingtonpost.com": [
+      "huffingtonpost.co.uk"
     ],
     "hugedata.com.cn": [
       "miit.gov.cn"
@@ -7906,14 +6270,12 @@
     "hwcdn.net": [
       "boingboing.net"
     ],
-    "hybrid.ai": [
-      "rambler.ru"
-    ],
     "iasds01.com": [
       "discovery.com"
     ],
     "ibclick.stream": [
-      "webmd.com"
+      "webmd.com",
+      "wikitravel.org"
     ],
     "ibillboard.com": [
       "t-online.de",
@@ -7929,9 +6291,6 @@
       "livescience.com",
       "skyrock.com"
     ],
-    "idealmedia.com": [
-      "thehill.com"
-    ],
     "ign.com": [
       "videojs.com"
     ],
@@ -7943,18 +6302,18 @@
       "variety.com"
     ],
     "im-apps.net": [
+      "economist.com",
       "exblog.jp",
-      "biglobe.ne.jp",
-      "goo.ne.jp"
+      "biglobe.ne.jp"
     ],
     "imgur.com": [
       "stackoverflow.com",
       "stackexchange.com"
     ],
     "impact-ad.jp": [
+      "economist.com",
       "yahoo.co.jp",
-      "hatena.ne.jp",
-      "goo.ne.jp"
+      "hatena.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
@@ -7968,6 +6327,9 @@
     "inq.com": [
       "ups.com"
     ],
+    "inquisitr.com": [
+      "flipboard.com"
+    ],
     "insightexpressai.com": [
       "unsplash.com",
       "philly.com"
@@ -7979,24 +6341,25 @@
     ],
     "instinctiveads.com": [
       "rollingstone.com",
-      "variety.com"
+      "variety.com",
+      "nist.gov"
     ],
     "intentiq.com": [
-      "thinkgeek.com",
-      "active.com"
+      "thinkgeek.com"
     ],
     "intentmedia.net": [
       "tripadvisor.com"
     ],
     "intercom.io": [
-      "themegrill.com",
-      "emarketer.com",
-      "diabetes.org"
+      "visual.ly",
+      "yumpu.com",
+      "emarketer.com"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
+      "inhabitat.com",
       "wikitravel.org"
     ],
     "investingchannel.com": [
@@ -8014,10 +6377,14 @@
       "virgilio.it"
     ],
     "iperceptions.com": [
+      "seagate.com",
+      "honeywell.com",
       "boeing.com"
     ],
+    "ipinyou.com": [
+      "suning.com"
+    ],
     "ipredictive.com": [
-      "imdb.com",
       "myspace.com",
       "dailymotion.com"
     ],
@@ -8038,7 +6405,6 @@
       "businessinsider.com"
     ],
     "jrs5.com": [
-      "nike.com",
       "coursera.org",
       "bostonglobe.com"
     ],
@@ -8049,7 +6415,11 @@
     ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com"
+      "zenfolio.com"
+    ],
+    "kakao.com": [
+      "daum.net",
+      "tistory.com"
     ],
     "kameleoon.eu": [
       "welt.de",
@@ -8072,9 +6442,9 @@
       "dzwww.com"
     ],
     "krxd.net": [
-      "cnn.com",
-      "theguardian.com",
-      "usatoday.com"
+      "slate.com",
+      "twitch.tv",
+      "nypost.com"
     ],
     "leadintel.io": [
       "nme.com"
@@ -8082,21 +6452,15 @@
     "leadlander.com": [
       "panasonic.com"
     ],
-    "legocdn.com": [
-      "lego.com"
-    ],
     "liadm.com": [
       "bloomberg.com",
       "time.com",
       "economist.com"
     ],
-    "licasd.com": [
-      "time.com"
-    ],
     "ligadx.com": [
+      "telegraph.co.uk",
       "springer.com",
-      "lemonde.fr",
-      "lefigaro.fr"
+      "lemonde.fr"
     ],
     "lightboxcdn.com": [
       "gizmodo.com",
@@ -8104,9 +6468,9 @@
       "fastcompany.com"
     ],
     "lijit.com": [
-      "sourceforge.net",
-      "wsj.com",
-      "bloomberg.com"
+      "deviantart.com",
+      "uci.edu",
+      "mirror.co.uk"
     ],
     "link-page.info": [
       "netvibes.com"
@@ -8117,23 +6481,22 @@
       "sourceforge.net"
     ],
     "linksynergy.com": [
+      "pcworld.com",
       "nike.com",
-      "alibabacloud.com",
-      "coursera.org"
+      "alibabacloud.com"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "microsoft.com",
       "msn.com",
-      "bing.com"
+      "bing.com",
+      "skype.com"
     ],
     "livechatinc.com": [
       "ning.com",
       "wpengine.com",
-      "sophos.com",
-      "nazwa.pl"
+      "sophos.com"
     ],
     "livejournal.net": [
       "livejournal.com"
@@ -8141,9 +6504,10 @@
     "liveperson.net": [
       "talktalk.co.uk",
       "earthlink.net",
-      "trendmicro.com"
+      "thetimes.co.uk"
     ],
     "loc.gov": [
+      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
@@ -8173,10 +6537,17 @@
       "t-online.de",
       "statista.com"
     ],
+    "madeleine.de": [
+      "t-online.de"
+    ],
     "mail.ru": [
       "vk.com",
       "yandex.ru",
       "icq.com"
+    ],
+    "mailchimp.com": [
+      "boingboing.net",
+      "colorlib.com"
     ],
     "marinsm.com": [
       "webs.com",
@@ -8185,7 +6556,6 @@
     ],
     "marketlinc.com": [
       "teamviewer.us",
-      "norton.com",
       "eset.com"
     ],
     "marketo.com": [
@@ -8199,19 +6569,22 @@
       "mercurynews.com"
     ],
     "mathtag.com": [
-      "sourceforge.net",
-      "nytimes.com",
-      "forbes.com"
+      "adobe.com",
+      "vimeo.com",
+      "sourceforge.net"
+    ],
+    "mct01.com": [
+      "zol.com.cn"
     ],
     "media.net": [
       "nytimes.com",
-      "forbes.com",
-      "reuters.com"
+      "dropbox.com",
+      "forbes.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
-      "uci.edu",
-      "autodesk.com"
+      "columbia.edu",
+      "uci.edu"
     ],
     "mediaforge.com": [
       "nike.com",
@@ -8219,12 +6592,13 @@
       "bostonglobe.com"
     ],
     "mediaplex.com": [
-      "t-online.de",
       "economist.com",
-      "dell.com"
+      "dell.com",
+      "shutterfly.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
+      "liberation.fr",
       "leparisien.fr"
     ],
     "mediav.com": [
@@ -8232,22 +6606,15 @@
       "ctrip.com",
       "toutiao.com"
     ],
-    "mediawallahscript.com": [
-      "sourceforge.net"
-    ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "thelancet.com",
       "cell.com"
     ],
     "metadsp.co.uk": [
-      "boingboing.net",
-      "standard.co.uk"
-    ],
-    "mfadsrvr.com": [
-      "forbes.com"
+      "nypost.com",
+      "variety.com"
     ],
     "mg2connext.com": [
       "philly.com",
@@ -8257,27 +6624,27 @@
       "liveleak.com"
     ],
     "miaozhen.com": [
+      "qq.com",
       "sina.com.cn",
-      "pconline.com.cn",
-      "qq.com"
+      "pconline.com.cn"
     ],
     "microad.jp": [
       "sakura.ne.jp",
       "hatena.ne.jp"
     ],
     "microsoft.com": [
+      "msn.com",
       "live.com",
-      "skype.com",
-      "office.com"
+      "skype.com"
     ],
     "microsoftonline.com": [
       "office.com",
       "microsoft.com"
     ],
     "mktoresp.com": [
-      "parallels.com",
       "zend.com",
-      "prweb.com"
+      "prweb.com",
+      "techtarget.com"
     ],
     "ml314.com": [
       "sourceforge.net",
@@ -8286,8 +6653,8 @@
     ],
     "mmstat.com": [
       "youku.com",
-      "sohu.com",
-      "taobao.com"
+      "taobao.com",
+      "alibaba.com"
     ],
     "monetate.net": [
       "nationalgeographic.com",
@@ -8296,7 +6663,7 @@
     "mookie1.com": [
       "t-online.de",
       "businessinsider.com",
-      "npr.org"
+      "photobucket.com"
     ],
     "mouseflow.com": [
       "nintendo.com"
@@ -8306,14 +6673,12 @@
       "heise.de"
     ],
     "mrpfd.com": [
-      "symantec.com",
       "hpe.com"
     ],
     "msgapp.com": [
       "post-gazette.com"
     ],
     "msn.com": [
-      "w3.org",
       "marketwatch.com"
     ],
     "mtvnservices.com": [
@@ -8323,6 +6688,9 @@
     "musthird.com": [
       "airbnb.com"
     ],
+    "myhard.com": [
+      "yesky.com"
+    ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
@@ -8331,16 +6699,13 @@
       "myspace.com"
     ],
     "myvisualiq.net": [
-      "soundcloud.com",
-      "paypal.com",
-      "surveymonkey.com"
+      "surveymonkey.com",
+      "spotify.com",
+      "economist.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
       "yellowpages.com"
-    ],
-    "narrative.io": [
-      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -8355,7 +6720,8 @@
       "t-online.de"
     ],
     "naver.com": [
-      "unity3d.com"
+      "unity3d.com",
+      "cafe24.com"
     ],
     "naver.jp": [
       "line.me"
@@ -8364,6 +6730,9 @@
       "cnbc.com",
       "nbcnews.com",
       "today.com"
+    ],
+    "netmng.com": [
+      "theknot.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -8377,10 +6746,13 @@
     ],
     "news.com.au": [
       "theaustralian.com.au",
-      "heraldsun.com.au"
+      "heraldsun.com.au",
+      "dailytelegraph.com.au"
     ],
     "newscdn.com.au": [
-      "heraldsun.com.au"
+      "theaustralian.com.au",
+      "heraldsun.com.au",
+      "dailytelegraph.com.au"
     ],
     "newscgp.com": [
       "wsj.com",
@@ -8402,8 +6774,7 @@
     ],
     "newyorker.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -8420,15 +6791,23 @@
       "huffingtonpost.com"
     ],
     "nuggad.net": [
-      "t-online.de"
+      "t-online.de",
+      "liberation.fr"
     ],
     "nxtck.com": [
-      "nike.com",
       "coursera.org",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "orange.fr"
     ],
     "o0bg.com": [
       "bostonglobe.com"
+    ],
+    "oath.com": [
+      "huffingtonpost.co.uk",
+      "techradar.com"
+    ],
+    "ocdn.eu": [
+      "onet.pl"
     ],
     "office.com": [
       "microsoftonline.com"
@@ -8436,14 +6815,10 @@
     "office365.com": [
       "microsoftonline.com"
     ],
-    "ojrq.net": [
-      "autodesk.com"
-    ],
     "ok.ru": [
       "ria.ru"
     ],
     "olark.com": [
-      "texas.gov",
       "webstarts.com"
     ],
     "olympicchannel.com": [
@@ -8452,13 +6827,10 @@
     "omkt.co": [
       "prweb.com"
     ],
-    "omnidsp.com": [
-      "rambler.ru"
-    ],
     "omnitagjs.com": [
-      "variety.com",
-      "standard.co.uk",
-      "home.pl"
+      "independent.co.uk",
+      "springer.com",
+      "variety.com"
     ],
     "omtrdc.net": [
       "adobe.com",
@@ -8485,11 +6857,10 @@
     "onthe.io": [
       "indiatimes.com",
       "express.co.uk",
-      "rbc.ru"
+      "wn.com"
     ],
     "ooyala.com": [
-      "accuweather.com",
-      "fedex.com"
+      "accuweather.com"
     ],
     "openhub.net": [
       "mariadb.org"
@@ -8498,9 +6869,9 @@
       "novostimira.com"
     ],
     "openx.net": [
-      "yahoo.com",
       "nytimes.com",
-      "forbes.com"
+      "dropbox.com",
+      "telegraph.co.uk"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -8513,14 +6884,10 @@
       "qianlong.com"
     ],
     "optimizely.com": [
-      "nytimes.com",
       "creativecommons.org",
-      "webs.com",
-      "couchsurfing.com",
-      "gitlab.com",
-      "imageshack.com",
-      "box.com",
-      "fox.com"
+      "live.com",
+      "ibm.com",
+      "blizzard.com"
     ],
     "ora.tv": [
       "cheezburger.com",
@@ -8548,10 +6915,13 @@
     "owox.com": [
       "boredpanda.com"
     ],
+    "paddle.com": [
+      "snapwidget.com"
+    ],
     "pardot.com": [
-      "tandfonline.com",
       "prezi.com",
-      "ap.org"
+      "ap.org",
+      "rebelmouse.com"
     ],
     "parsely.com": [
       "wsj.com",
@@ -8602,16 +6972,15 @@
       "express.co.uk"
     ],
     "po.st": [
-      "smithsonianmag.com",
       "nme.com"
     ],
     "popsugar-assets.com": [
       "popsugar.com"
     ],
     "postrelease.com": [
-      "wsj.com",
       "reuters.com",
-      "independent.co.uk"
+      "independent.co.uk",
+      "chicagotribune.com"
     ],
     "powerlinks.com": [
       "variety.com",
@@ -8619,10 +6988,8 @@
       "howtogeek.com"
     ],
     "pressboard.ca": [
-      "thestar.com"
-    ],
-    "prfct.co": [
-      "smugmug.com"
+      "thestar.com",
+      "observer.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
@@ -8649,9 +7016,12 @@
     "pub.network": [
       "coindesk.com"
     ],
+    "publishme.se": [
+      "blogg.se"
+    ],
     "pubmatic.com": [
-      "forbes.com",
-      "bloomberg.com",
+      "tinyurl.com",
+      "telegraph.co.uk",
       "usatoday.com"
     ],
     "pubmine.com": [
@@ -8661,12 +7031,7 @@
       "variety.com"
     ],
     "purch.com": [
-      "livescience.com",
-      "space.com",
-      "tomshardware.com"
-    ],
-    "purechat.com": [
-      "byu.edu"
+      "space.com"
     ],
     "pushanert.com": [
       "4shared.com"
@@ -8677,20 +7042,22 @@
     "pymx5.com": [
       "sfgate.com",
       "seattletimes.com",
-      "seattlepi.com"
+      "rd.com"
     ],
     "qq.com": [
-      "tencent.com"
+      "tencent.com",
+      "yesky.com",
+      "bshare.cn"
     ],
     "qualtrics.com": [
+      "techrepublic.com",
       "nintendo.com",
-      "cnet.com",
-      "mayoclinic.org"
+      "cnet.com"
     ],
     "quantserve.com": [
+      "vimeo.com",
       "wordpress.org",
-      "reddit.com",
-      "soundcloud.com"
+      "reddit.com"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -8709,13 +7076,18 @@
     "radiotime.com": [
       "tunein.com"
     ],
+    "rakuten.co.jp": [
+      "infoseek.co.jp"
+    ],
     "rambler.ru": [
       "livejournal.com",
       "novostimira.com",
       "ria.ru"
     ],
     "reachmax.cn": [
-      "qq.com"
+      "yesky.com",
+      "bshare.cn",
+      "sohu.com"
     ],
     "reddit.com": [
       "acm.org",
@@ -8727,35 +7099,34 @@
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
-    "republer.com": [
-      "rambler.ru"
+    "render.githubusercontent.com": [
+      "github.com"
+    ],
+    "researchintel.com": [
+      "intel.com"
     ],
     "reson8.com": [
-      "startribune.com",
-      "biography.com"
+      "startribune.com"
     ],
     "responsetap.com": [
       "manchester.ac.uk"
     ],
-    "reutersmedia.net": [
-      "reuters.com"
-    ],
     "revcontent.com": [
       "jpost.com",
-      "breitbart.com",
-      "bostonherald.com"
+      "breitbart.com"
     ],
     "revjet.com": [
       "bankrate.com"
     ],
     "rezync.com": [
       "economist.com",
+      "salon.com",
       "investopedia.com"
     ],
     "rfihub.com": [
-      "forbes.com",
-      "npr.org",
-      "economist.com"
+      "dropbox.com",
+      "tinyurl.com",
+      "npr.org"
     ],
     "rhombusads.com": [
       "adweek.com"
@@ -8773,8 +7144,8 @@
     ],
     "rkdms.com": [
       "wired.com",
-      "npr.org",
-      "cbsnews.com"
+      "cbsnews.com",
+      "gizmodo.com"
     ],
     "rlcdn.com": [
       "adobe.com",
@@ -8787,38 +7158,32 @@
     "rockyou.net": [
       "springer.com"
     ],
-    "rqtrk.eu": [
-      "npr.org"
-    ],
     "rtk.io": [
       "seattletimes.com",
       "startribune.com",
       "azcentral.com"
     ],
     "ru4.com": [
-      "bloomberg.com",
-      "npr.org"
+      "uci.edu"
     ],
     "rubiconproject.com": [
-      "nytimes.com",
-      "forbes.com",
-      "wsj.com"
-    ],
-    "rutarget.ru": [
-      "rambler.ru",
-      "ria.ru"
+      "yahoo.com",
+      "amazon.com",
+      "sourceforge.net"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "bell-labs.com",
-      "hwg.org"
+      "bell-labs.com"
+    ],
+    "s3xified.com": [
+      "coindesk.com"
     ],
     "sabavision.com": [
       "mihanblog.com"
     ],
     "salesforceliveagent.com": [
       "marriott.com",
-      "teamviewer.us",
-      "prweb.com"
+      "prweb.com",
+      "salesforce.com"
     ],
     "salesloft.com": [
       "wpengine.com",
@@ -8833,8 +7198,8 @@
       "lifehacker.com",
       "history.com"
     ],
-    "samplicio.us": [
-      "go.com"
+    "scarabresearch.com": [
+      "tate.org.uk"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -8855,16 +7220,13 @@
       "cell.com"
     ],
     "scorecardresearch.com": [
+      "linkedin.com",
       "yahoo.com",
-      "tumblr.com",
-      "flickr.com"
+      "tumblr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
       "startribune.com"
-    ],
-    "scribd.com": [
-      "macrumors.com"
     ],
     "sdp-campaign.de": [
       "t-online.de"
@@ -8882,8 +7244,7 @@
     ],
     "self.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "sendtonews.com": [
       "bostonherald.com"
@@ -8893,13 +7254,16 @@
       "space.com",
       "howtogeek.com"
     ],
+    "servedby-buysellads.com": [
+      "dribbble.com"
+    ],
     "serverbid.com": [
       "sciencedaily.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
       "businessinsider.com",
-      "npr.org"
+      "sciencemag.org"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -8913,24 +7277,23 @@
     ],
     "sharethis.com": [
       "uk.com",
-      "us.org",
-      "www.vic.gov.au"
+      "uci.edu",
+      "us.org"
     ],
     "sharethrough.com": [
-      "cnet.com",
-      "time.com",
-      "wired.com"
+      "springer.com",
+      "photobucket.com",
+      "cnbc.com"
     ],
     "shop.pe": [
-      "dyn.com"
+      "bluehost.com"
     ],
     "siftscience.com": [
+      "scribd.com",
       "kickstarter.com",
-      "flickr.com",
-      "shutterstock.com"
+      "flickr.com"
     ],
     "simpli.fi": [
-      "washingtontimes.com",
       "thinkgeek.com",
       "tampabay.com"
     ],
@@ -8938,7 +7301,8 @@
       "sina.com.cn"
     ],
     "sina.com.cn": [
-      "weibo.com"
+      "weibo.com",
+      "suning.com"
     ],
     "siteimprove.com": [
       "berkeley.edu",
@@ -8949,12 +7313,13 @@
       "in.gov"
     ],
     "sitelock.com": [
-      "joomla.org"
+      "joomla.org",
+      "netfirms.com"
     ],
     "sitescout.com": [
-      "forbes.com",
-      "tinyurl.com",
-      "time.com"
+      "barnesandnoble.com",
+      "tinypic.com",
+      "salon.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
@@ -8968,9 +7333,9 @@
       "slashdot.org"
     ],
     "smartadserver.com": [
+      "telegraph.co.uk",
       "springer.com",
-      "elpais.com",
-      "skyrock.com"
+      "elpais.com"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
@@ -8983,9 +7348,9 @@
       "smithsonianmag.com"
     ],
     "snapchat.com": [
-      "wsj.com",
       "giphy.com",
-      "walmart.com"
+      "walmart.com",
+      "wpengine.com"
     ],
     "so.com": [
       "360.cn"
@@ -9002,22 +7367,23 @@
       "howstuffworks.com"
     ],
     "sogou.com": [
-      "ifeng.com",
       "soso.com"
+    ],
+    "sohu.com": [
+      "bshare.cn"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
     "sonobi.com": [
-      "myspace.com",
-      "cnet.com",
-      "usatoday.com"
+      "usatoday.com",
+      "springer.com",
+      "deviantart.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
       "bmj.com",
-      "ea.com",
-      "mo.gov"
+      "ea.com"
     ],
     "sphereup.com": [
       "jpost.com"
@@ -9026,6 +7392,12 @@
       "hp.com",
       "slack.com",
       "sophos.com"
+    ],
+    "spineuniverse.com": [
+      "psychcentral.com"
+    ],
+    "spingo.com": [
+      "detroitnews.com"
     ],
     "sportz.io": [
       "gulfnews.com"
@@ -9038,17 +7410,15 @@
       "denverpost.com"
     ],
     "spotxchange.com": [
-      "imdb.com",
       "dailymotion.com",
-      "npr.org"
+      "express.co.uk",
+      "thenextweb.com"
     ],
     "spoutable.com": [
       "alternet.org",
       "dailydot.com"
     ],
     "springernature.com": [
-      "nature.com",
-      "springer.com",
       "biomedcentral.com"
     ],
     "springserve.com": [
@@ -9091,29 +7461,31 @@
     "stripe.com": [
       "smashballoon.com",
       "presscustomizr.com",
-      "themezee.com",
-      "documentcloud.org"
+      "themezee.com"
     ],
     "sumo.com": [
       "snopes.com",
-      "cdbaby.com",
-      "studiopress.com"
+      "studiopress.com",
+      "sitepoint.com"
     ],
     "sundaysky.com": [
       "fiverr.com",
       "jpost.com",
-      "dailydot.com"
+      "careerbuilder.com"
+    ],
+    "suning.cn": [
+      "suning.com"
     ],
     "suning.com": [
       "qq.com",
+      "sohu.com",
       "ifeng.com"
     ],
-    "supplyframe.com": [
-      "arduino.cc",
-      "ti.com"
+    "sunrtb.com": [
+      "yesky.com"
     ],
-    "survata.com": [
-      "tripadvisor.com"
+    "supplyframe.com": [
+      "arduino.cc"
     ],
     "surveymonkey.com": [
       "cambridge.org",
@@ -9122,31 +7494,27 @@
     ],
     "switchadhub.com": [
       "lycos.com",
-      "thehindu.com"
-    ],
-    "symantec.com": [
-      "norton.com"
+      "thehindu.com",
+      "coindesk.com"
     ],
     "taboola.com": [
       "weebly.com",
-      "msn.com",
-      "wsj.com"
+      "dropbox.com",
+      "msn.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
     ],
     "tailtarget.com": [
-      "uol.com.br",
-      "variety.com"
+      "uol.com.br"
     ],
     "tamgrt.com": [
-      "tripadvisor.com",
-      "hotels.com"
+      "tripadvisor.com"
     ],
     "tanx.com": [
+      "sina.com.cn",
       "sohu.com",
-      "ifeng.com",
-      "tmall.com"
+      "alibaba.com"
     ],
     "taobao.com": [
       "sina.com.cn",
@@ -9154,15 +7522,16 @@
       "tmall.com"
     ],
     "tapad.com": [
-      "tinyurl.com",
-      "wsj.com",
-      "paypal.com"
+      "hp.com",
+      "wired.com",
+      "spotify.com"
     ],
     "tawk.to": [
-      "cba.pl"
+      "cba.pl",
+      "affordable-papers.net"
     ],
-    "taylorandfrancis.com": [
-      "tandfonline.com"
+    "teads.tv": [
+      "telegraph.co.uk"
     ],
     "tealiumiq.com": [
       "ibm.com",
@@ -9174,8 +7543,7 @@
     ],
     "teenvogue.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "theadex.com": [
       "t-online.de",
@@ -9183,18 +7551,15 @@
       "sueddeutsche.de"
     ],
     "thebrighttag.com": [
-      "netflix.com",
       "playstation.com",
-      "washingtontimes.com"
+      "washingtontimes.com",
+      "mercurynews.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
     ],
     "theguardian.com": [
       "videojs.com"
-    ],
-    "thrtle.com": [
-      "sourceforge.net"
     ],
     "tianqi.com": [
       "qianlong.com"
@@ -9216,15 +7581,12 @@
     "tinypass.com": [
       "bloomberg.com",
       "businessinsider.com",
-      "techcrunch.com"
+      "independent.co.uk"
     ],
     "tiqcdn.com": [
       "wsj.com",
       "cisco.com",
       "marketwatch.com"
-    ],
-    "tm-awx.com": [
-      "mirror.co.uk"
     ],
     "tmall.com": [
       "taobao.com"
@@ -9238,7 +7600,11 @@
       "qualtrics.com"
     ],
     "tradelab.fr": [
-      "eklablog.com"
+      "eklablog.com",
+      "leparisien.fr"
+    ],
+    "traffic-media.co": [
+      "radikal.ru"
     ],
     "trafficjunky.net": [
       "pornhub.com"
@@ -9268,9 +7634,6 @@
       "prnewswire.com",
       "zimbra.com"
     ],
-    "triblive.com": [
-      "bleacherreport.com"
-    ],
     "tripadvisor.com": [
       "accorhotels.com"
     ],
@@ -9289,11 +7652,11 @@
     "trustarc.com": [
       "skynet.be"
     ],
-    "trustpilot.com": [
-      "jalbum.net"
+    "tumblr.com": [
+      "theweek.com"
     ],
     "turn.com": [
-      "forbes.com",
+      "tinyurl.com",
       "hp.com",
       "wired.com"
     ],
@@ -9305,19 +7668,15 @@
       "jimdo.com",
       "squarespace.com"
     ],
-    "twimg.com": [
-      "coe.int",
-      "dol.gov"
-    ],
     "twitter.com": [
+      "amazon.com",
       "wordpress.org",
-      "nytimes.com",
-      "dropbox.com"
+      "nytimes.com"
     ],
     "tynt.com": [
+      "salon.com",
       "investopedia.com",
-      "accuweather.com",
-      "washingtontimes.com"
+      "accuweather.com"
     ],
     "uc.se": [
       "jalbum.net"
@@ -9346,12 +7705,13 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "boingboing.net",
-      "bell-labs.com"
+      "hbr.org",
+      "boingboing.net"
     ],
     "upsellit.com": [
       "samsung.com",
-      "motorola.com"
+      "motorola.com",
+      "ccleaner.com"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
@@ -9359,11 +7719,15 @@
     "usa.gov": [
       "transportation.gov"
     ],
+    "useproof.com": [
+      "iconosquare.com"
+    ],
     "usergram.info": [
       "ocn.ne.jp"
     ],
     "uservoice.com": [
-      "scoop.it"
+      "scoop.it",
+      "theknot.com"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -9382,14 +7746,16 @@
     ],
     "vanityfair.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "veinteractive.com": [
       "prweb.com"
     ],
     "velaro.com": [
       "lg.com"
+    ],
+    "verticalhealth.net": [
+      "psychcentral.com"
     ],
     "viafoura.co": [
       "cbc.ca",
@@ -9404,7 +7770,7 @@
     ],
     "videohub.tv": [
       "wsj.com",
-      "bloomberg.com"
+      "uci.edu"
     ],
     "vidible.tv": [
       "huffingtonpost.com",
@@ -9412,9 +7778,9 @@
       "autoblog.com"
     ],
     "viglink.com": [
-      "cnet.com",
       "zdnet.com",
-      "thedailybeast.com"
+      "thedailybeast.com",
+      "softonic.com"
     ],
     "vilynx.com": [
       "cbsnews.com",
@@ -9424,8 +7790,7 @@
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "wufoo.com",
-      "oclc.org"
+      "wufoo.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
@@ -9441,28 +7806,33 @@
     "vk.com": [
       "yandex.ru",
       "rt.com",
-      "ria.ru"
+      "liveinternet.ru"
     ],
     "vogue.com": [
-      "wired.com",
-      "pitchfork.com"
+      "wired.com"
+    ],
+    "volvelle.tech": [
+      "prweb.com"
     ],
     "voxmedia.com": [
       "theverge.com",
       "vox.com",
-      "recode.net",
-      "polygon.com"
+      "recode.net"
     ],
     "w55c.net": [
-      "forbes.com",
-      "hp.com",
-      "businessinsider.com"
+      "hpe.com"
     ],
     "wal.co": [
       "walmart.com"
     ],
     "wallst.com": [
       "reuters.com"
+    ],
+    "waptime.cn": [
+      "tianqi.com"
+    ],
+    "warnerbros.com": [
+      "tmz.com"
     ],
     "wbtrk.net": [
       "bild.de",
@@ -9477,8 +7847,7 @@
       "wunderground.com"
     ],
     "webmd.com": [
-      "medscape.com",
-      "medicinenet.com"
+      "medscape.com"
     ],
     "weborama.fr": [
       "lemonde.fr",
@@ -9511,9 +7880,6 @@
     "weibo.com": [
       "sina.com.cn"
     ],
-    "welt.de": [
-      "bild.de"
-    ],
     "whistleout.com": [
       "earthlink.net"
     ],
@@ -9526,16 +7892,17 @@
       "wikisource.org"
     ],
     "wired.com": [
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
-      "globalnews.ca",
-      "vancouversun.com"
+      "globalnews.ca"
     ],
     "wishpond.com": [
+      "discovermagazine.com"
+    ],
+    "wishpond.net": [
       "discovermagazine.com"
     ],
     "wistia.com": [
@@ -9550,13 +7917,11 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "redbubble.com",
-      "upwork.com"
+      "zappos.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "wnyc.org": [
       "newyorker.com"
@@ -9593,6 +7958,13 @@
     "xad.com": [
       "vt.edu"
     ],
+    "xg4ken.com": [
+      "bluehost.com",
+      "kaspersky.com"
+    ],
+    "xinhuanet.com": [
+      "news.cn"
+    ],
     "xiti.com": [
       "lemonde.fr",
       "skyrock.com",
@@ -9603,12 +7975,16 @@
       "ocn.ne.jp"
     ],
     "xplosion.de": [
+      "t-online.de",
       "spiegel.de",
-      "sueddeutsche.de",
-      "zeit.de"
+      "sueddeutsche.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
+    ],
+    "xtgreat.com": [
+      "qq.com",
+      "sohu.com"
     ],
     "yadro.ru": [
       "vk.com",
@@ -9625,6 +8001,9 @@
       "tumblr.com",
       "flickr.com"
     ],
+    "yahoosmallbusiness.com": [
+      "yahoo.com"
+    ],
     "yandex.ru": [
       "opera.com",
       "livejournal.com",
@@ -9633,21 +8012,20 @@
     "yastatic.net": [
       "liveinternet.ru",
       "sputniknews.com",
-      "ria.ru"
+      "qip.ru"
     ],
     "yieldlab.net": [
       "t-online.de",
-      "springer.com",
-      "spiegel.de"
+      "telegraph.co.uk",
+      "springer.com"
     ],
     "yieldoptimizer.com": [
-      "philly.com",
-      "groupon.com"
+      "fourseasons.com"
     ],
     "yimg.com": [
+      "yahoo.com",
       "flickr.com",
-      "nytimes.com",
-      "dropbox.com"
+      "nytimes.com"
     ],
     "yldbt.com": [
       "biography.com",
@@ -9663,11 +8041,12 @@
       "google.com",
       "mozilla.org",
       "nih.gov",
-      "honeywell.com"
+      "unt.edu"
     ],
     "youvisit.com": [
       "osu.edu",
-      "fsu.edu"
+      "fsu.edu",
+      "unh.edu"
     ],
     "ypcdn.com": [
       "yellowpages.com"
@@ -9679,17 +8058,21 @@
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com"
+      "thehindu.com",
+      "infoplease.com"
     ],
     "zemanta.com": [
       "variety.com",
       "lemonde.fr",
-      "standard.co.uk"
+      "farfetch.com"
     ],
     "zergnet.com": [
       "imdb.com",
       "marketwatch.com",
       "weather.com"
+    ],
+    "zhaopin.cn": [
+      "zhaopin.com"
     ],
     "zidtech.com": [
       "coindesk.com"
@@ -9709,5 +8092,5 @@
       "parallels.com"
     ]
   },
-  "version": "2018.9.26"
+  "version": "2018.9.27"
 }

--- a/results.json
+++ b/results.json
@@ -3,13 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535131518617,
-      "userAction": ""
-    },
-    "112-tzm-766.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535149513388,
+      "nextUpdateTime": 1535262627774,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -24,111 +18,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "126.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "127.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "15gifts.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535203312039,
+      "nextUpdateTime": 1535626983992,
       "userAction": ""
     },
-    "1dmp.io": {
+    "20794186p.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535587166558,
       "userAction": ""
     },
-    "1rx.io": {
+    "20798148p.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "23video.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "247-inc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535265170878,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535391580217,
+      "nextUpdateTime": 1535624128010,
       "userAction": ""
     },
-    "2mdnsys.com": {
+    "2ecd5.v.fwmrm.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535452599779,
       "userAction": ""
     },
     "2o7.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "33across.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360buyimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "360yield.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "3gl.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -141,223 +69,121 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535288564686,
+      "nextUpdateTime": 1535535546152,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535556755499,
+      "nextUpdateTime": 1535662314785,
+      "userAction": ""
+    },
+    "4303900.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535206086724,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535616677370,
+      "nextUpdateTime": 1535538081882,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535547398351,
+      "nextUpdateTime": 1535266457214,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535592234323,
-      "userAction": ""
-    },
-    "4924464.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535440457062,
+      "nextUpdateTime": 1535396666801,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535276170445,
-      "userAction": ""
-    },
-    "4dsply.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "50bang.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535448735698,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535593380762,
+      "nextUpdateTime": 1535243002291,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535321145910,
-      "userAction": ""
-    },
-    "5779616.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535482911467,
-      "userAction": ""
-    },
-    "58.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "58cdn.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "5p4rk13.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "6126321.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535371657297,
+      "nextUpdateTime": 1535337090048,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535167279610,
-      "userAction": ""
-    },
-    "6sc.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "7eer.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "7grid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535580006291,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535524131585,
+      "nextUpdateTime": 1535489115471,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535340362267,
-      "userAction": ""
-    },
-    "8329645.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535353449192,
-      "userAction": ""
-    },
-    "8758559.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535615993684,
+      "nextUpdateTime": 1535568595011,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535133497126,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535312919301,
       "userAction": ""
     },
-    "a.quora.com": {
+    "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535405357388,
+      "nextUpdateTime": 1535475207820,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535490342215,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535301965338,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535378457839,
+      "nextUpdateTime": 1535357074390,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535161779696,
+      "nextUpdateTime": 1535655182527,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535211637737,
+      "nextUpdateTime": 1535519468673,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535563194232,
-      "userAction": ""
-    },
-    "aamcftag.aamsitecertifier.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535518074755,
-      "userAction": ""
-    },
-    "aamsitecertifier.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535611575907,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535119827399,
-      "userAction": ""
-    },
-    "aaxads.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "abmr.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "accessatlanta.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535446366018,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -366,22 +192,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accuweather.com": {
+    "accounts.us1.gigya.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535504617595,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535429731669,
-      "userAction": ""
-    },
-    "acint.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535253661031,
       "userAction": ""
     },
     "acpm.fr": {
@@ -390,123 +210,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "acquia.com": {
+    "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "actionnetwork.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1534640190001,
+      "nextUpdateTime": 1535369444025,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535338170348,
+      "nextUpdateTime": 1535691309435,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535559735121,
-      "userAction": ""
-    },
-    "acuityplatform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "acxiomapac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-hatena.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad-stir.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535376624050,
       "userAction": ""
     },
-    "ad-survey.com": {
+    "ad-score.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ad.adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535280536254,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535264413152,
-      "userAction": ""
-    },
-    "ad.yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535443152680,
-      "userAction": ""
-    },
-    "adapf.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adaraanalytics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adc-srv.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adclear.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535211259067,
       "userAction": ""
     },
     "addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "addtoany.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adentifi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -516,57 +252,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adfox.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adfront.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adhigh.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adidas.fi": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adingo.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adition.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adjust-net.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adlmerge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -576,58 +264,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admaster.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "admiral.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535437438641,
-      "userAction": ""
-    },
-    "admission.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "admixer.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adobe.com": {
+    "ado.pro-market.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adotmob.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adriver.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535620955615,
       "userAction": ""
     },
     "adroll.com": {
@@ -636,58 +282,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.adfox.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535192940943,
-      "userAction": ""
-    },
-    "ads.pro-market.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535166695414,
-      "userAction": ""
-    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535492314435,
+      "nextUpdateTime": 1535272034892,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535135614621,
+      "nextUpdateTime": 1535595817030,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535549461468,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535505404872,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535393595473,
-      "userAction": ""
-    },
-    "adscale.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535510061258,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585040406,
+      "nextUpdateTime": 1535227640334,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535485571758,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535513512165,
       "userAction": ""
     },
     "adsnative.com": {
@@ -696,19 +324,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsniper.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -720,153 +336,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtags.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adtdp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "advertur.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adwstats.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx.com.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adx1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "adzerk.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aetnd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "afilio.com.br": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "agkn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aid-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aidata.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aili.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aimfr.solution.weborama.fr": {
+    "aimfar.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535494521452,
-      "userAction": ""
-    },
-    "ajx130.online": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "akamaihd.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "akamaized.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "albacross.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alibaba.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alicdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "alipay.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aliyun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535390413184,
       "userAction": ""
     },
     "allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "am15.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -876,148 +360,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "amazon.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "amazon.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "amazoncustomerservice.d2.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "amazonwebservices.d2.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535475655145,
-      "userAction": ""
-    },
-    "amazonwebservicesinc.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535384144806,
-      "userAction": ""
-    },
-    "ameba.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535542954455,
+      "nextUpdateTime": 1535485288372,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535381037838,
+      "nextUpdateTime": 1535342343438,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535613174595,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535464239398,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535108485791,
-      "userAction": ""
-    },
-    "and.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "answcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "answerscloud.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "antdsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aol.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aol.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535353985951,
       "userAction": ""
     },
     "ap.lijit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535275471737,
-      "userAction": ""
-    },
-    "ap.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "apester.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535360650206,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535336991540,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535501934181,
       "userAction": ""
     },
-    "api-cache.adsnative.com": {
+    "api-iam.intercom.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535408184819,
+      "userAction": ""
+    },
+    "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535575652992,
+      "nextUpdateTime": 1535222960634,
       "userAction": ""
     },
-    "api.circularhub.com": {
+    "api.bounceexchange.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535169145890,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535623743904,
       "userAction": ""
     },
-    "api.company-target.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535317179596,
-      "userAction": ""
-    },
-    "api.ooyala.com": {
+    "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535236794710,
+      "userAction": ""
+    },
+    "api.nanigans.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535594380737,
+      "userAction": ""
+    },
+    "api.pymx5.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535395219456,
       "userAction": ""
     },
     "apis.google.com": {
@@ -1026,40 +444,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "apn.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535218695801,
-      "userAction": ""
-    },
-    "appdynamics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "apple.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "aqtracker.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "arcgis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535592146802,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -1068,82 +456,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "areyouahuman.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "arrivalist.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535501468829,
-      "userAction": ""
-    },
-    "as.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535229691374,
-      "userAction": ""
-    },
-    "asos-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "assets.adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535391921965,
-      "userAction": ""
-    },
-    "assets.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535530764372,
-      "userAction": ""
-    },
-    "atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atemda.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "atgsvcs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ati-host.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "att.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535694314872,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -1152,166 +468,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.tags.newscgp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535164070585,
-      "userAction": ""
-    },
-    "audtd.com": {
+    "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "auth.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "autoimg.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "autopilothq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535494074509,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535355659377,
-      "userAction": ""
-    },
-    "b.nativendo.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535538712482,
+      "nextUpdateTime": 1535247779526,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535483331527,
-      "userAction": ""
-    },
-    "b1img.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535226328665,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535505370686,
-      "userAction": ""
-    },
-    "b92.yahoo.co.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535148881205,
-      "userAction": ""
-    },
-    "baidu.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bam-x.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535202486243,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535529473453,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535597253083,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535541829645,
-      "userAction": ""
-    },
-    "bazaarvoice.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbb.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbbpromos.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbc.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bbelements.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535542051945,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535487258088,
-      "userAction": ""
-    },
-    "beacon.sojern.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535529821305,
-      "userAction": ""
-    },
-    "beatport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "beemray.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "benchtag2.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "betweendigital.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535252312595,
       "userAction": ""
     },
     "bfmio.com": {
@@ -1320,40 +516,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bfmtv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535526427623,
-      "userAction": ""
-    },
-    "bid.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535484981338,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535382038883,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535558241739,
+      "nextUpdateTime": 1535480847940,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535327480100,
-      "userAction": ""
-    },
-    "biddingx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535647133688,
       "userAction": ""
     },
     "bidr.io": {
@@ -1368,93 +546,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bigmining.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bigmir.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bing.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bitbucket.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizibly.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizographics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bizrate.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "blogos.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bloomberg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluecava.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluemix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bluetoad.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bnidx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1476,34 +576,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boston.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "botradar.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "boudja.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535062904378,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "brandcdn.com": {
+    "boxinc.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535480752964,
       "userAction": ""
     },
     "brides.com": {
@@ -1512,112 +594,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "brightcove.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "brightcove.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "britishairways.d3.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535552042196,
-      "userAction": ""
-    },
     "bs.serving-sys.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535430149297,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535587303603,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535546439609,
+      "nextUpdateTime": 1535544471047,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535375679856,
-      "userAction": ""
-    },
-    "btttag.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "bumlam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "c-ctrip.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535509302674,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535505105536,
+      "nextUpdateTime": 1535439684416,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535571444799,
+      "nextUpdateTime": 1535372974143,
       "userAction": ""
     },
-    "c.deployads.com": {
+    "c.liadm.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535584627640,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535375054801,
       "userAction": ""
     },
-    "c.jsrdn.com": {
+    "c.statcounter.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535253163372,
-      "userAction": ""
-    },
-    "c.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535419121418,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535565223252,
+      "nextUpdateTime": 1535689108903,
       "userAction": ""
     },
-    "c212.net": {
+    "cache.vindicosuite.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "c3tag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cadreon.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535487196231,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -1626,40 +654,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "candlewoodsuites.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535596662850,
+      "nextUpdateTime": 1535672073907,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535590260745,
-      "userAction": ""
-    },
-    "capturehighered.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "carambo.la": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535523620270,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -1668,94 +672,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cbsi.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cbsistatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ccgateway.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-apple.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535214837676,
-      "userAction": ""
-    },
-    "cdn-hotels.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cdn-net.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535654255150,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535608709373,
-      "userAction": ""
-    },
-    "cdn.blueconic.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535256296804,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535312966669,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535493360512,
-      "userAction": ""
-    },
-    "cdn.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535490700346,
-      "userAction": ""
-    },
-    "cdn.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535411948604,
-      "userAction": ""
-    },
-    "cdn.engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535446078859,
-      "userAction": ""
-    },
-    "cdn.justuno.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535382379876,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535255974831,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535601702055,
+      "nextUpdateTime": 1535345088017,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -1764,82 +702,28 @@
       "nextUpdateTime": 1529084908284,
       "userAction": ""
     },
-    "cdn.onthe.io": {
+    "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535353300697,
-      "userAction": ""
-    },
-    "cdn.pardot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535617791411,
-      "userAction": ""
-    },
-    "cdn.static.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535400873241,
+      "nextUpdateTime": 1535594352004,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535121167406,
+      "nextUpdateTime": 1535235445711,
       "userAction": ""
     },
-    "cdn.tinypass.com": {
+    "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535467316593,
+      "nextUpdateTime": 1535266344256,
       "userAction": ""
     },
-    "cdn.viglink.com": {
+    "cdns.gigya.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535566437816,
-      "userAction": ""
-    },
-    "cdn.yldbt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535334881641,
-      "userAction": ""
-    },
-    "cdn1-res.sundaysky.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535143354964,
-      "userAction": ""
-    },
-    "cdn2.lockerdome.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535529533114,
-      "userAction": ""
-    },
-    "cdnwidget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cern.ch": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "changeagain.me": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "charitynavigator.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535423728304,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -1851,79 +735,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535134554501,
-      "userAction": ""
-    },
-    "chei.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chicagotribune.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinajob.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinaso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "chinavivaki.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "choozle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "civicscience.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ckies.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clickability.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clicktale.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "clicktripz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535530563408,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -1938,58 +750,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "clmbtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cloudflare.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cm.e.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535362642071,
-      "userAction": ""
-    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535429314447,
-      "userAction": ""
-    },
-    "cm.l.qq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535280560755,
-      "userAction": ""
-    },
-    "cms.tanx.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535240105058,
-      "userAction": ""
-    },
-    "cnet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535375206049,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535142903454,
-      "userAction": ""
-    },
-    "cnn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535223704946,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -1998,52 +768,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cnzz.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "coherentpath.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cohesionapps.com": {
+    "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collector-963.tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535346254938,
-      "userAction": ""
-    },
-    "collegenet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "comm100.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535358602103,
       "userAction": ""
     },
     "company-target.com": {
@@ -2052,16 +780,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "complex.com": {
+    "condenast.demdex.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "conative.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535574500673,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -2070,34 +792,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "conductrics.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "configusa.veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535543444411,
-      "userAction": ""
-    },
-    "connatix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535174547715,
-      "userAction": ""
-    },
-    "connexity.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535483865039,
       "userAction": ""
     },
     "consensu.org": {
@@ -2106,28 +804,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consent.cmp.oath.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535501732621,
-      "userAction": ""
-    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumable.com": {
+    "consumer.krxd.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535261715060,
       "userAction": ""
     },
-    "contentabc.com": {
+    "contextual.media.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535389202601,
       "userAction": ""
     },
     "contextweb.com": {
@@ -2136,93 +828,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "conv-blizzard-emea.cd.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535326160739,
-      "userAction": ""
-    },
-    "conv-blizzard-na.cd.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535228455740,
-      "userAction": ""
-    },
-    "convertful.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "convertro.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "convio.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cornell.edu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535193184634,
-      "userAction": ""
-    },
-    "cox.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "coxbusiness.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cpex.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535323524063,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cquotient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cr-nielsen.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creativecdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "creativecommons.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2232,70 +846,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "croissed.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "crowneplaza.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "crsspxl.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cssrvsync.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535231023580,
       "userAction": ""
     },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535218329476,
-      "userAction": ""
-    },
-    "ct.pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535231836071,
-      "userAction": ""
-    },
-    "ctv.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "curse.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "custhelp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cx.atdmt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535375224707,
+      "nextUpdateTime": 1535694255065,
       "userAction": ""
     },
     "cxense.com": {
@@ -2304,127 +864,55 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "d.adroll.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535215730697,
+      "userAction": ""
+    },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535510911863,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535553722917,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535402065299,
-      "userAction": ""
-    },
-    "d1af033869koo7.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d1rv23qj5kas56.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "d2-apps.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535606895685,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535313149602,
-      "userAction": ""
-    },
-    "d41.co": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535382596864,
       "userAction": ""
     },
-    "da-ads.com": {
+    "data.ad-score.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535303819645,
       "userAction": ""
     },
-    "dailymail.co.uk": {
+    "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dailymotion.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535521287337,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535127779521,
-      "userAction": ""
-    },
-    "datamind.ru": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535572992646,
       "userAction": ""
     },
-    "datasteam.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daum.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daumcdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "daumdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dc-storm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "de.ioam.de": {
+    "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535553465126,
+      "nextUpdateTime": 1535519088936,
       "userAction": ""
     },
-    "deep.bi": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "delivery.h.switchadhub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535249908051,
-      "userAction": ""
-    },
-    "dell.com": {
+    "deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2436,81 +924,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "departapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deployads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deqwas.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "developermedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "developers.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dhs.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "di-dtaectolog-us-prod-1.appspot.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dianomi.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dictionary.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "digikulture-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535473213147,
-      "userAction": ""
-    },
-    "digitaladsystems.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2520,28 +936,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "disney.com": {
+    "dis.us.criteo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535661792347,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535514492739,
+      "nextUpdateTime": 1535232050057,
       "userAction": ""
     },
-    "disqus.com": {
+    "districtm-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "distiltag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535645818795,
       "userAction": ""
     },
     "districtm.io": {
@@ -2550,45 +960,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "djv99sxoqpv11.cloudfront.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535278571573,
-      "userAction": ""
-    },
-    "dmxleo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dnnapi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535483132878,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dol.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "domdex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2598,46 +978,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dotsub.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "doublemax.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "doublepimpssl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "doubleverify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535220813510,
-      "userAction": ""
-    },
-    "dpmsrv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535303632169,
       "userAction": ""
     },
     "drive.google.com": {
@@ -2646,16 +996,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dx.steelhousemedia.com": {
+    "dsum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535284046783,
-      "userAction": ""
-    },
-    "dynad.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535203788849,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -2664,34 +1008,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dynatrace-managed.com": {
+    "eb2.3lift.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "dyntrk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535462065407,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -2700,52 +1020,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ebdr3.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebis.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ecdn.firstimpression.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535480744702,
-      "userAction": ""
-    },
-    "econda-monitor.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ecustomeropinions.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "edge-cdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535109055535,
-      "userAction": ""
-    },
-    "edmunds.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535583449091,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -2760,118 +1038,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "elsevier.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "elsevierhealth.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emlgrid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "emxdgt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "engage.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535417679010,
-      "userAction": ""
-    },
-    "envato.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "equalstyle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eset.marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535324409999,
-      "userAction": ""
-    },
     "eset.tt.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535172647379,
-      "userAction": ""
-    },
-    "espn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "estara.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "estat.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "etracker.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "etsystudio.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535394964179,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535233686356,
-      "userAction": ""
-    },
-    "evenhotels.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "eventsabout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535477714020,
       "userAction": ""
     },
     "everesttech.net": {
@@ -2880,64 +1062,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "everyaction.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535412667318,
-      "userAction": ""
-    },
-    "evise.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "evolok.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "evyy.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ew3.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ewscripps.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535440360689,
-      "userAction": ""
-    },
-    "exactag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "excite.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "exe.bid": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535379656026,
       "userAction": ""
     },
     "exelator.com": {
@@ -2946,22 +1074,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "exosrv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "expedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535550982016,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535345851450,
       "userAction": ""
     },
     "eyeota.net": {
@@ -2970,70 +1086,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eyereturn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ezoic.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535067712368,
-      "userAction": ""
-    },
-    "facetz.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fairfax.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fastcompany.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535532544281,
+      "nextUpdateTime": 1535450343934,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535476086076,
-      "userAction": ""
-    },
-    "fdlstatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "feathr.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535309167566,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -3048,166 +1122,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ffx.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fidelity-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "filepicker.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "firstimpression.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flashtalking.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flickr.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flipboard.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "flyercity.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fo-api.omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535110977981,
-      "userAction": ""
-    },
-    "fontawesome.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foresee.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "forms.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535114875943,
-      "userAction": ""
-    },
-    "formstack.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fout.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "fox.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxbusiness.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxnet.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535397455637,
-      "userAction": ""
-    },
-    "foxnews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxsports.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "foxycart.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "freeskreen.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535263330795,
-      "userAction": ""
-    },
-    "freshdesk.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "friendbuy.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "funcaptcha.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "funnyordie.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535465485854,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -3222,106 +1146,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.cn.miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535463525932,
-      "userAction": ""
-    },
     "g2.gumgum.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535240351512,
-      "userAction": ""
-    },
-    "g2crowd.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535666835971,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535282616525,
+      "nextUpdateTime": 1535209533543,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535324356929,
-      "userAction": ""
-    },
-    "gamer-network.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535336446858,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535406151780,
+      "nextUpdateTime": 1535593979644,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535595384247,
-      "userAction": ""
-    },
-    "gateway.answerscloud.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535529600416,
-      "userAction": ""
-    },
-    "gemius.pl": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gentags.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535617465597,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535474265266,
+      "userAction": ""
+    },
+    "geosync.solution.weborama.fr": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535470476213,
-      "userAction": ""
-    },
-    "getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getdrip.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getpocket.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "getsmartcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gfycat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535392194713,
       "userAction": ""
     },
     "gigya.com": {
@@ -3330,33 +1194,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "giphy.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "github.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "globalwebindex.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gmossp-sp.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3372,18 +1212,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "goo.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "google.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "google.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -3393,7 +1221,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535299738930,
+      "nextUpdateTime": 1535456837113,
       "userAction": ""
     },
     "gq.com": {
@@ -3405,19 +1233,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535232994108,
-      "userAction": ""
-    },
-    "gridsumdissector.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "groupondata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535352505666,
       "userAction": ""
     },
     "groups.google.com": {
@@ -3426,33 +1242,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gsimedia.net": {
+    "gslbeacon.lijit.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535629742696,
       "userAction": ""
     },
-    "gssprt.jp": {
+    "gum.criteo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "gtags.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535428819281,
       "userAction": ""
     },
     "gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "guoshipartners.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3462,298 +1266,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hatena.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hatena.ne.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hb-api.omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535149948702,
-      "userAction": ""
-    },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535528458660,
+      "nextUpdateTime": 1535503241069,
       "userAction": ""
     },
-    "healte.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hearstnp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "help.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hiexpress.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "highwire.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hitslink.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hive.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hlserve.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hm.baidu.com": {
+    "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535592367417,
-      "userAction": ""
-    },
-    "holidayinn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "holidayinnresorts.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "horyzon-media.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hotelindigo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hotelsapi.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "htmedia.in": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huffingtonpost.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huffingtonpost.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "huihui.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hwcdn.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hypemarks.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "i.gridsumdissector.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535258286357,
+      "nextUpdateTime": 1535673061315,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535361476630,
+      "userAction": ""
+    },
+    "ib.3lift.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560008032,
-      "userAction": ""
-    },
-    "i.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "i1img.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ib-ibi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535582031482,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535558901666,
-      "userAction": ""
-    },
-    "ibclick.stream": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535168630812,
-      "userAction": ""
-    },
-    "ibillboard.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ibt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535668050896,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535611501989,
-      "userAction": ""
-    },
-    "id5-sync.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535224773713,
-      "userAction": ""
-    },
-    "idealmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ign.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "igodigital.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iheart.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "im-apps.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imagetopng.club": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imedia.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "img.ak.impact-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535376841775,
-      "userAction": ""
-    },
-    "img.purch.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imgfarm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "imgur.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "impact-ad.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535519131089,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -3762,52 +1308,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "infinity-tracking.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "infinityid.condenastdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535609251930,
-      "userAction": ""
-    },
-    "infolinks.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "innovid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "inq.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "inquisitr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "inside-graph.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535350768670,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535259006632,
+      "nextUpdateTime": 1535272317482,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -3816,34 +1326,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "instagram.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535313547846,
-      "userAction": ""
-    },
-    "instinctiveads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "intentiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "intentmedia.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535572303283,
       "userAction": ""
     },
     "intercom.io": {
@@ -3852,112 +1338,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "intergient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "internetbrands.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535212585331,
-      "userAction": ""
-    },
-    "investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "investis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "invoc.us": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ioam.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iperceptions.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ipinyou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ipredictive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "irs01.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "izooto.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535505082401,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535555974254,
+      "userAction": ""
+    },
+    "js.adsrvr.org": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535302445154,
-      "userAction": ""
-    },
-    "janrainsso.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jd.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jquery.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jrs5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535656782989,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -3969,42 +1365,6 @@
     "jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "justpremium.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "justuno.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jword.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "jyxo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kakao.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kameleoon.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4050,28 +1410,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "kinja.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "kiwiirc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "l.ooyala.com": {
+    "l.sharethis.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535413172230,
       "userAction": ""
     },
     "labs.google.com": {
@@ -4080,61 +1428,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ladsp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "leadintel.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "leaf.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "legocdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lejwaengv.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "liadm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "libero.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licasd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "licdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ligadx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -4152,43 +1446,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lincoln.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "link-page.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "linkedin.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "linksynergy.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "list-manage.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "listrakbi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "live.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -4200,166 +1458,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "livedoor.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "livejournal.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "liveperson.net": {
+    "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535393415816,
       "userAction": ""
     },
-    "lkqd.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "load.instinctiveads.com": {
+    "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535156309565,
-      "userAction": ""
-    },
-    "load.sumo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535193129482,
+      "nextUpdateTime": 1535386732667,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535330758728,
+      "nextUpdateTime": 1535399584027,
       "userAction": ""
     },
-    "loc.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lockerdome.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535602667578,
-      "userAction": ""
-    },
-    "log.mmstat.com": {
+    "login-ds.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535614693593,
-      "userAction": ""
-    },
-    "logc187.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535533148953,
+      "nextUpdateTime": 1535451066232,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535423452721,
-      "userAction": ""
-    },
-    "logly.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535219009893,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535260246626,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535663645260,
       "userAction": ""
     },
-    "logs1136.xiti.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535620450441,
-      "userAction": ""
-    },
-    "lptag.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535381494449,
-      "userAction": ""
-    },
-    "lqm.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lucklayed.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lwcal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lytics.io": {
+    "m.addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "m.reachmax.cn": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535177699423,
-      "userAction": ""
-    },
-    "m6r.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "madeleine.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mail.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mailchimp.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mantisadnetwork.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535302271160,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -4380,40 +1518,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketo.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "match.adsrvr.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535382731107,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535521811421,
+      "userAction": ""
+    },
+    "match.deepintent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535638997127,
       "userAction": ""
     },
     "match.prod.bidr.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535338080427,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535567304417,
       "userAction": ""
     },
-    "matheranalytics.com": {
+    "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535438152314,
       "userAction": ""
     },
     "mathtag.com": {
@@ -4422,10 +1548,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "me-ssl.effectivemeasure.net": {
+    "mc.webvisor.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535545627821,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535584747297,
+      "userAction": ""
+    },
+    "mc.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535439720084,
       "userAction": ""
     },
     "media.net": {
@@ -4443,127 +1575,13 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535562992042,
-      "userAction": ""
-    },
-    "mediaforge.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medialand.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediaplex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediav.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediawallahscript.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medscape.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "medtargetsystem.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mendeley.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "messenger.live.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "metadsp.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mg2connext.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mgid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "miamiherald.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microad.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microsoft.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "microsoftonline.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535348403984,
       "userAction": ""
     },
     "mid.rkdms.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535261768429,
-      "userAction": ""
-    },
-    "mirtesen.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535694375796,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -4575,91 +1593,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535088403217,
-      "userAction": ""
-    },
-    "mlb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mlive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mmstat.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mmtro.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "molefefiseranis.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monetate.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "monster.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mookie1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mouseflow.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mpnrs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mrpfd.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "msgapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "msn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mssl.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535132799668,
+      "nextUpdateTime": 1535592189311,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -4674,18 +1608,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mthsense.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtrx.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535349304856,
-      "userAction": ""
-    },
     "mts0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -4698,31 +1620,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mtty.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mtvnservices.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "multiview.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "musthird.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "muumuu-domain.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -4742,44 +1640,8 @@
     },
     "mx.technolutions.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535512750016,
-      "userAction": ""
-    },
-    "mybuys.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myhard.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mynativeplatform.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myregistry.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myspacecdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "myvisualiq.net": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535659044372,
       "userAction": ""
     },
     "nanigans.com": {
@@ -4788,118 +1650,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "narrative.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nasdaq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nationalgeographic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "native.ai": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535458022322,
-      "userAction": ""
-    },
-    "nativendo.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "naver.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "naver.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nbcnews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nbcu.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535351358779,
-      "userAction": ""
-    },
-    "nbcuni.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "netdna-ssl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "netmng.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newatlas.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "neweggimages.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535243950608,
       "userAction": ""
     },
     "newscgp.com": {
@@ -4911,31 +1665,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535270929625,
-      "userAction": ""
-    },
-    "newsinc.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsmemory.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsvine.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newsweekgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535200399853,
       "userAction": ""
     },
     "newyorker.com": {
@@ -4944,40 +1674,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ngpvan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nih.gov": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nineto5mac-d.openx.net": {
+    "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535458910130,
+      "nextUpdateTime": 1535196785688,
       "userAction": ""
     },
-    "nokia.com": {
+    "nexus-websocket-b.intercom.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "norton.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535415967207,
       "userAction": ""
     },
     "nr-data.net": {
@@ -4986,130 +1692,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nsaudience.pl": {
+    "oclc.112.2o7.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nscontext.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nuggad.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nxtck.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nymag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "nzaza.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "o0bg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oasc10.247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535205066735,
-      "userAction": ""
-    },
-    "oath.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ocdn.eu": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oclc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ofapes.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "office.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "office365.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ojrq.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ok.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "olark.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "olympicchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omkt.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omnidsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "omnitagjs.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535395333287,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -5118,51 +1704,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "onclickmega.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onecount.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onet.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onetag.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535417103733,
-      "userAction": ""
-    },
     "onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onevision.com.tw": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "online-metrix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "onsugar.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5172,99 +1716,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "openhub.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "openstat.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "openx.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "opf.ooyala.com": {
+    "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "opinionstage.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optaim.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimix.asia": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535531761134,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "optimove.events": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ora.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oracleimg.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "orangeads.fr": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "oreilly.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "otm-r.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "otto.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5274,52 +1740,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ovh.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "owneriq.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "owox.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "p.adsymptotic.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535365238469,
-      "userAction": ""
-    },
-    "p.cpx.to": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535168480502,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535536846901,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535348749572,
+      "nextUpdateTime": 1535477613091,
+      "userAction": ""
+    },
+    "p.rfihub.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535594442097,
+      "userAction": ""
+    },
+    "p.skimresources.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535255133764,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535338824891,
-      "userAction": ""
-    },
-    "paddle.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535516317349,
       "userAction": ""
     },
     "pardot.com": {
@@ -5334,93 +1782,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "paypal.com": {
+    "pbbl.co": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "paypalobjects.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "payroll.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pba.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535543859020,
-      "userAction": ""
-    },
-    "pbskids.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pcmag.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pdmp.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "performgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "perimeterx.net": {
+    "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pewresearch.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "phonograph2.voxmedia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535325549253,
+      "nextUpdateTime": 1535318942650,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535354151599,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535527261052,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pinterest.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5433,85 +1815,79 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535263794027,
       "userAction": ""
     },
-    "pixanalytics.com": {
+    "pixel-geo.prfct.co": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535428050071,
+      "userAction": ""
+    },
+    "pixel.advertising.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535195199383,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535444780876,
+      "nextUpdateTime": 1535285373385,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535260055836,
+      "userAction": ""
+    },
+    "pixel.mathtag.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535344368148,
+      "nextUpdateTime": 1535451828821,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535558880509,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535543163260,
       "userAction": ""
     },
-    "pixel.s3xified.com": {
+    "pixel.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535454023503,
+      "nextUpdateTime": 1535312448131,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535559337523,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535416158831,
       "userAction": ""
     },
-    "pixel.zprk.io": {
+    "pixel.tapad.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535144814767,
+      "nextUpdateTime": 1535565660114,
       "userAction": ""
     },
-    "piximedia.com": {
+    "pixeltrack.eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pixnet.cc": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "placed.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535454303618,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535124167487,
+      "nextUpdateTime": 1535551623961,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535551158517,
       "userAction": ""
     },
     "play.google.com": {
@@ -5520,40 +1896,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535505151187,
-      "userAction": ""
-    },
-    "players.brightcove.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535344024587,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535388410492,
-      "userAction": ""
-    },
-    "playwire.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "plista.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535402866178,
       "userAction": ""
     },
     "plus.google.com": {
@@ -5565,37 +1917,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "polymorphicads.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "popin.cc": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "popsugar-assets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535294459416,
+      "nextUpdateTime": 1535475065526,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469659560,
+      "nextUpdateTime": 1535695656230,
       "userAction": ""
     },
     "postrelease.com": {
@@ -5604,21 +1932,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "powerlinks.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pressboard.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "prfct.co": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5628,64 +1944,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "prod-mng-proxy-connext.azurewebsites.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535243906722,
-      "userAction": ""
-    },
-    "proparm.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "provenpixel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "providesupport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "proximus.demdex.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535564390419,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535335077582,
       "userAction": ""
     },
-    "proximustv.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pscp.tv": {
+    "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535557003492,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535611640025,
-      "userAction": ""
-    },
-    "publishme.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535530459475,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -5694,141 +1968,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubmine.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pulpix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "purch.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "purechat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "px.adhigh.net": {
+    "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535176013543,
+      "nextUpdateTime": 1535391786951,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535634385364,
+      "userAction": ""
+    },
+    "px.dynamicyield.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535131329876,
+      "nextUpdateTime": 1535477757297,
       "userAction": ""
     },
-    "pxf.io": {
+    "px0.pbbl.co": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxtres.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxuno.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pxzwei.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535602689619,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535033233942,
+      "nextUpdateTime": 1535603192843,
       "userAction": ""
     },
-    "qantas.demdex.net": {
+    "q.quora.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535490587938,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535465840376,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535345306051,
-      "userAction": ""
-    },
-    "qnsr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qsstats.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qtmojo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "qualtrics.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantcast.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535217833076,
+      "nextUpdateTime": 1535324744755,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quantummetric.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quickbooks.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "quickbooksonline.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -5838,28 +2022,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "r.skimresources.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535565958781,
+      "userAction": ""
+    },
     "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535217930912,
-      "userAction": ""
-    },
-    "rackcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "radiotime.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rakuten.co.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535642093402,
       "userAction": ""
     },
     "rambler.ru": {
@@ -5868,135 +2040,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rbnt.org": {
+    "rand.d1.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rcsmetrics.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reachmax.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535707841720,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535304923654,
+      "nextUpdateTime": 1535417435881,
       "userAction": ""
     },
-    "reddit.com": {
+    "registercom.sc.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535639045889,
       "userAction": ""
     },
-    "redlink.com": {
+    "registercom.tt.omtrdc.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reference.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "regmedia.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "relap.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "republer.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "researchintel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reson8.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "responsetap.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "reutersmedia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "revjet.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rezync.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535700009586,
       "userAction": ""
     },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ria.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "richmetrics.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "richrelevance.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rightnowtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6012,52 +2082,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rnengage.com": {
+    "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535459268205,
       "userAction": ""
     },
-    "rockyou.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "roomkey.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "roymorgan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtax.criteo.com": {
+    "rs.gwallet.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535222519189,
+      "nextUpdateTime": 1535550689197,
       "userAction": ""
     },
-    "rtb.com.ru": {
+    "rtb.districtm.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rtk.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ru4.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535581477119,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -6068,20 +2108,8 @@
     },
     "rudy.adsnative.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535347337543,
-      "userAction": ""
-    },
-    "rundsp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "rutarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535306716979,
       "userAction": ""
     },
     "s-static.ak.facebook.com": {
@@ -6090,178 +2118,106 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "s-vop.sundaysky.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535565498310,
+      "userAction": ""
+    },
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535352076386,
+      "nextUpdateTime": 1535550767486,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535561577916,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535303185049,
       "userAction": ""
     },
-    "s.clickability.com": {
+    "s.cpx.to": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535224844708,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535203984775,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535201225344,
+      "nextUpdateTime": 1535631922807,
+      "userAction": ""
+    },
+    "s.jsrdn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535584011160,
+      "userAction": ""
+    },
+    "s.po.st": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535623990141,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535214890098,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535318932345,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535434341417,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535433040753,
       "userAction": ""
     },
     "s.yimg.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535216141835,
+      "nextUpdateTime": 1535497825993,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535580705625,
+      "nextUpdateTime": 1535629850574,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535131999264,
+      "nextUpdateTime": 1535349679166,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535493968964,
-      "userAction": ""
-    },
-    "s3-us-west-2.amazonaws.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "s3xified.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535575186441,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477270241,
-      "userAction": ""
-    },
-    "sabavision.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "salesforceliveagent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "salesloft.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "salesmanago.pl": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "samba.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535543506276,
       "userAction": ""
     },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535121885101,
+      "nextUpdateTime": 1535220699469,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535435991656,
-      "userAction": ""
-    },
-    "sbal4kp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scarabresearch.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535336371028,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535441459044,
-      "userAction": ""
-    },
-    "scholarlyiq.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciencedirect.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciencedirectassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sciverse.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scoop.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "scopus.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535559224450,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -6270,52 +2226,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "scribblelive.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535244758147,
-      "userAction": ""
-    },
-    "scripps.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535227106148,
-      "userAction": ""
-    },
-    "script.ioam.de": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sddan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "se.monetate.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535391241554,
-      "userAction": ""
-    },
-    "seadform.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535313735845,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535453750224,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535628154957,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -6324,135 +2244,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "searchmarketing.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535243571282,
+      "nextUpdateTime": 1535474812376,
+      "userAction": ""
+    },
+    "secfld.vmmpxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535444155546,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535119927597,
-      "userAction": ""
-    },
-    "secure-cf-c.ooyala.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "secure-dcr.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535335494368,
+      "nextUpdateTime": 1535642753805,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535584481337,
+      "nextUpdateTime": 1535276310459,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535177741800,
+      "nextUpdateTime": 1535363543163,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535107082511,
+      "nextUpdateTime": 1535565120595,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535292364343,
+      "nextUpdateTime": 1535443585948,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535562920063,
+      "nextUpdateTime": 1535404481201,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535398828987,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535212835954,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535351110245,
+      "nextUpdateTime": 1535409011676,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535579341049,
-      "userAction": ""
-    },
-    "secure.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535254601040,
-      "userAction": ""
-    },
-    "securedvisit.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535315990216,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535591583698,
+      "nextUpdateTime": 1535378697325,
       "userAction": ""
     },
-    "seekingalpha.com": {
+    "segapi.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535505097650,
       "userAction": ""
     },
-    "sekindo.com": {
+    "segments.company-target.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535695255538,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "semasio.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6462,33 +2340,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servedby-buysellads.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "serverbid.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shareaholic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6504,81 +2358,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sheego.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "shop.pe": {
+    "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1534791910138,
-      "userAction": ""
-    },
-    "shopify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "simplereach.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "simpli.fi": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sina.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sina.com.cn": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sinoptik.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitehelix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535645884557,
       "userAction": ""
     },
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "siteimproveanalytics.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitelabweb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sitelock.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6594,159 +2382,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sjs.bizographics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535196852776,
-      "userAction": ""
-    },
     "skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sky.com": {
+    "smartlock.google.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "slashdotmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartadserver.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smartclip.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smashing-delivery.herokuapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smi2.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smithsonian.museum": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "smyte.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535365253512,
       "userAction": ""
     },
     "snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "snapwidget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "snplow.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "so.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "socdm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sociomantic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "soflopxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "softonic-analytics.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sogou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sohu.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sojern.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sokrati.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solarwinds.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535180937040,
-      "userAction": ""
-    },
-    "soliditet.se": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "solocpm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6756,99 +2406,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sonyentertainmentnetwork.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sourceforge.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sp.analytics.yahoo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535161310463,
-      "userAction": ""
-    },
-    "sp.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spectate.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sphereup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spiceworks.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spineuniverse.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spingo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spot.im": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spotify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spots.im": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535640486680,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -6858,94 +2430,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "springernature.com": {
+    "srv-2018-08-24-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535421211051,
       "userAction": ""
     },
-    "springserve.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sprinklr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "srv-2018-08-23-09.config.parsely.com": {
+    "srv-2018-08-24-09.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535292359742,
+      "nextUpdateTime": 1535480074393,
       "userAction": ""
     },
-    "srv-2018-08-23-10.config.parsely.com": {
+    "srv-2018-08-24-10.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535475527218,
+      "nextUpdateTime": 1535695203010,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535550468582,
-      "userAction": ""
-    },
-    "srx.com.sg": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ss3.zedo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535129275153,
+      "nextUpdateTime": 1535594397444,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535229607025,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535476159880,
       "userAction": ""
     },
-    "ssp.adriver.ru": {
+    "ssum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535203697827,
+      "nextUpdateTime": 1535566753682,
       "userAction": ""
     },
-    "st.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535164370467,
-      "userAction": ""
-    },
-    "stackadapt.com": {
+    "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "staples-sparx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "staples-static.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "starfieldtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535525489997,
       "userAction": ""
     },
     "statcounter.com": {
@@ -6960,40 +2484,22 @@
       "nextUpdateTime": 1529315030088,
       "userAction": ""
     },
-    "static.apester.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535270017993,
-      "userAction": ""
-    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535289627794,
-      "userAction": ""
-    },
-    "static.getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535459656103,
-      "userAction": ""
-    },
-    "static.mediarithmics.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535318289140,
+      "nextUpdateTime": 1535296389449,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535229325922,
+      "nextUpdateTime": 1535384977874,
       "userAction": ""
     },
-    "staticimgfarm.com": {
+    "static.quantcast.mgr.consensu.org": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535579789908,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -7004,74 +2510,14 @@
     },
     "stats.g.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535508331167,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535305848007,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535190455456,
-      "userAction": ""
-    },
-    "staybridge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "steelhousemedia.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "steepto.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stg-sp.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stg8.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "stickyadstv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "storage.googleapis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "storygize.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "streem.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "streetscout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535595376018,
       "userAction": ""
     },
     "stripe.com": {
@@ -7083,7 +2529,13 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535231190644,
+      "nextUpdateTime": 1535537728387,
+      "userAction": ""
+    },
+    "sundaysky-partners.tremorhub.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535518349440,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -7092,94 +2544,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "suning.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sunrtb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "supplyframe.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "survata.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421948525,
-      "userAction": ""
-    },
-    "surveymonkey.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535345993866,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535311993890,
+      "nextUpdateTime": 1535219408003,
       "userAction": ""
     },
-    "switchadhub.com": {
+    "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535630811315,
       "userAction": ""
     },
-    "symantec.com": {
+    "sync.adkernel.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535488277961,
+      "userAction": ""
+    },
+    "sync.bfmio.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535485112515,
+      "userAction": ""
+    },
+    "sync.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535636613941,
+      "userAction": ""
+    },
+    "sync.mathtag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535208558420,
+      "userAction": ""
+    },
+    "sync.multiview.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "synacor.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sync.1rx.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535436844877,
-      "userAction": ""
-    },
-    "sync.audtd.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535423682583,
-      "userAction": ""
-    },
-    "sync.datamind.ru": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535591448993,
-      "userAction": ""
-    },
-    "sync.republer.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535227536756,
+      "nextUpdateTime": 1535457905320,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535404928871,
+      "nextUpdateTime": 1535247764908,
+      "userAction": ""
+    },
+    "sync.teads.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535553055729,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -7188,105 +2610,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "t.go.sohu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535161788370,
-      "userAction": ""
-    },
     "taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tacdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tag-st.contextweb.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535575760736,
-      "userAction": ""
-    },
-    "tag.1rx.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535224096496,
-      "userAction": ""
-    },
-    "tag.audience.acpm.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535587928642,
-      "userAction": ""
-    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535172809545,
-      "userAction": ""
-    },
-    "tag.marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535169314524,
-      "userAction": ""
-    },
-    "tag.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535482405835,
-      "userAction": ""
-    },
-    "tag.sp.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535108288134,
-      "userAction": ""
-    },
-    "tag4arm.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tagdelivery.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tailtarget.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535682805604,
       "userAction": ""
     },
     "talkgadget.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tamgrt.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tanx.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "taobao.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7296,22 +2634,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "targetimg1.com": {
+    "tapestry.tapad.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tawk.to": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tcell.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535412121553,
       "userAction": ""
     },
     "teads.tv": {
@@ -7332,45 +2658,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "techweb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "telegraph.co.uk": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "telekom.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tenmax.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "theadex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "theatlas.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7380,64 +2670,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "theglobeandmail.ca": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "theguardian.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thesaurus.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "thomsonreuters.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535536640170,
-      "userAction": ""
-    },
-    "tidaltv.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tidelinedata.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535397495968,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535335023989,
-      "userAction": ""
-    },
-    "timewarnercable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535457769814,
       "userAction": ""
     },
     "tinypass.com": {
@@ -7446,34 +2688,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tiqcdn.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tl813.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535210811276,
-      "userAction": ""
-    },
-    "tm-awx.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tmall.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535559796030,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -7482,94 +2700,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "token.rubiconproject.com": {
+    "top100.rambler.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535573160300,
-      "userAction": ""
-    },
-    "toutapp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535674487346,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535515643596,
-      "userAction": ""
-    },
-    "tracc.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535666639786,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535424312057,
-      "userAction": ""
-    },
-    "track.hubspot.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535264130780,
-      "userAction": ""
-    },
-    "trackad.cz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trackalyzer.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tracking.g2crowd.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535237778325,
-      "userAction": ""
-    },
-    "tradedoubler.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tradelab.fr": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficgate.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficjam.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trafficjunky.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535318646462,
       "userAction": ""
     },
     "translate.google.com": {
@@ -7578,22 +2724,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "travelzoo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trb.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "treasuredata.com": {
+    "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535582467003,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -7608,99 +2742,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trends.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535603923908,
-      "userAction": ""
-    },
-    "tribalfusion.com": {
+    "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tribl.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535233893141,
-      "userAction": ""
-    },
-    "tripadvisor.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tronc.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trumba.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "truoptik.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustev.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trustpilot.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trvl-px.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tumblr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535228762576,
       "userAction": ""
     },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tutorialize.me": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tvsquared.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "twimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7710,184 +2760,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tynt.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ubi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uciservice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uconnect.tealiumiq.com": {
+    "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535393886670,
+      "nextUpdateTime": 1535428488428,
       "userAction": ""
     },
-    "ucoz.net": {
+    "us-u.openx.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535274956469,
       "userAction": ""
     },
-    "udmserve.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535539694388,
-      "userAction": ""
-    },
-    "udnfunlife.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uefa.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ufpcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ugdturner.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unagi-eu.amazon.com": {
+    "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535196808939,
+      "nextUpdateTime": 1535305181818,
       "userAction": ""
     },
-    "undertone.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unicc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "unity.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "universal.iperceptions.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535325388047,
-      "userAction": ""
-    },
-    "unrulymedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "upravel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ups.xplosion.de": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535407396093,
-      "userAction": ""
-    },
-    "upsellit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uptolike.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "urbandictionary.store": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "usa.gov": {
+    "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "useproof.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "usergram.info": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "userreport.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ustream.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "utarget.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "utarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "uuidksinc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "v12group.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535662229786,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -7896,87 +2790,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "velaro.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "velemh.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vendorlist.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535354855735,
-      "userAction": ""
-    },
-    "verticalhealth.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "veruta.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viafoura.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viafoura.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "video.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "videoamp.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "videohub.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vidible.tv": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "viglink.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vilynx.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -7992,45 +2808,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "virgilio.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "visitor-service.tealiumiq.com": {
+    "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535281447453,
+      "nextUpdateTime": 1535397114831,
       "userAction": ""
     },
-    "visualstudio.com": {
+    "vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vizury.com": {
+    "vmss.boldchat.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "vk.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535214742233,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535291406968,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "volvelle.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -8040,97 +2838,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vtracy.de": {
+    "w.soundcloud.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535399516836,
       "userAction": ""
     },
-    "w55c.net": {
+    "wam-yahoo.solution.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535574783124,
+      "userAction": ""
+    },
+    "wamfactory.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wallst.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "waptime.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "warnerbros.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wbtrk.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wcfbc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "weather.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535422378909,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535205349790,
-      "userAction": ""
-    },
-    "webmd.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535334744593,
       "userAction": ""
     },
     "weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webpush.jp": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "websimages.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webtrekk.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -8142,39 +2874,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "weibo.com": {
+    "webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "welt.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "whistleout.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "widget.intercom.io": {
+    "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535613320681,
-      "userAction": ""
-    },
-    "wikia-services.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wikimedia.org": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -8184,52 +2892,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wise.space": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wishpond.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wishpond.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wistia.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wistia.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wix.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wkxppshj-qx.global.ssl.fastly.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1534814085104,
       "userAction": ""
     },
     "wmagazine.com": {
@@ -8238,88 +2904,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wnyc.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "woobi.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "woopic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wordpress.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wrating.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535133343141,
-      "userAction": ""
-    },
-    "wsj.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wsj.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wurfl.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535342355123,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535160363763,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535686767683,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535121108712,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535568564540,
       "userAction": ""
     },
     "www.bing.com": {
@@ -8330,44 +2930,44 @@
     },
     "www.bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535515298218,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535355718102,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535253088334,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535421728359,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535377541215,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535669005641,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535332528512,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535515969140,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535386038890,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535373992834,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535531778087,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535478659047,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535470694034,
       "userAction": ""
     },
     "www.google.com": {
@@ -8378,145 +2978,97 @@
     },
     "www.gq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535109212248,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535251051351,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535565021346,
+      "userAction": ""
+    },
+    "www.linkedin.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535353938304,
+      "nextUpdateTime": 1535661590077,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535324760182,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535397837841,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535412184727,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535219280175,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535371018711,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535212377389,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535524961484,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535362442612,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535401655245,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535656763846,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535364193938,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535626436765,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535307422760,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535561837419,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535212366928,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535297112694,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535257180613,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535361254835,
+      "userAction": ""
+    },
+    "www.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535629604233,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535432091170,
-      "userAction": ""
-    },
-    "wwwimages.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wywyuserservice.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535279920046,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535372826747,
-      "userAction": ""
-    },
-    "xad.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xg4ken.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xinhuanet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535458765015,
       "userAction": ""
     },
     "xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xlisting.jp": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xplosion.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xs4all.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xsdownload.adobe.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "xxxlutz.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -8527,12 +3079,6 @@
       "userAction": ""
     },
     "yadro.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -8550,67 +3096,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yandex.ua": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yastatic.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535288290126,
-      "userAction": ""
-    },
-    "yieldify.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yieldoptimizer.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yldbt.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ymetrica1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535543854128,
-      "userAction": ""
-    },
-    "yoox.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yotpo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "youtube-nocookie.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
@@ -8622,109 +3108,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "youvisit.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ypcdn.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "yudu.co.nz": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535312844355,
+      "nextUpdateTime": 1535637470267,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535168425931,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535478471197,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535346541264,
-      "userAction": ""
-    },
-    "zedo.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535189816756,
       "userAction": ""
     },
     "zemanta.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zendesk.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zergnet.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zhaopin.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zhiziyun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ziffdavis.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zoho.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zohopublic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zoomph.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -8768,7 +3170,13 @@
     "2o7.net": [
       "mysql.com",
       "cdc.gov",
-      "theatlantic.com"
+      "theatlantic.com",
+      "prnewswire.com",
+      "fastcompany.com",
+      "earthlink.net",
+      "qz.com",
+      "philips.com",
+      "oclc.org"
     ],
     "33across.com": [
       "accuweather.com"
@@ -8786,12 +3194,15 @@
     ],
     "3gl.net": [
       "istockphoto.com",
-      "gettyimages.com"
+      "gettyimages.com",
+      "economist.com"
     ],
     "3lift.com": [
       "nature.com",
       "springer.com",
-      "theverge.com"
+      "theverge.com",
+      "usatoday.com",
+      "newatlas.com"
     ],
     "4dsply.com": [
       "wnd.com"
@@ -8849,7 +3260,8 @@
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr"
+      "liberation.fr",
+      "leparisien.fr"
     ],
     "acquia.com": [
       "panasonic.com",
@@ -8867,6 +3279,12 @@
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
+    ],
+    "ad-plus.cn": [
+      "sohu.com"
+    ],
+    "ad-score.com": [
+      "wnd.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
@@ -8892,12 +3310,15 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com"
+      "washingtonexaminer.com",
+      "tinypic.com"
     ],
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
-      "yahoo.com"
+      "yahoo.com",
+      "who.int",
+      "gulfnews.com"
     ],
     "addtoany.com": [
       "irs.gov"
@@ -8909,7 +3330,9 @@
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com"
+      "springer.com",
+      "shutterstock.com",
+      "helsinki.fi"
     ],
     "adfox.ru": [
       "livejournal.com",
@@ -8933,7 +3356,8 @@
     "adition.com": [
       "bloomberg.com",
       "dailymotion.com",
-      "spiegel.de"
+      "spiegel.de",
+      "t-online.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -8942,7 +3366,8 @@
     "adkernel.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com"
+      "space.com",
+      "dailydot.com"
     ],
     "adlmerge.com": [
       "tomsk.ru"
@@ -8961,22 +3386,25 @@
     "adnxs.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "bostonherald.com"
     ],
     "adobe.com": [
       "wikipedia.org",
-      "apache.org",
       "behance.net",
-      "msnbc.com"
+      "history.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
       "bbb.org",
-      "bizjournals.com"
+      "bizjournals.com",
+      "worldbank.org"
     ],
     "adotmob.com": [
       "standard.co.uk",
-      "upwork.com"
+      "upwork.com",
+      "nypost.com"
     ],
     "adriver.ru": [
       "ria.ru",
@@ -8986,7 +3414,9 @@
     "adroll.com": [
       "stumbleupon.com",
       "nature.com",
-      "nginx.org"
+      "nginx.org",
+      "cloudflare.com",
+      "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
@@ -8996,7 +3426,8 @@
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "informationweek.com"
+      "informationweek.com",
+      "bostonherald.com"
     ],
     "adsniper.ru": [
       "rambler.ru"
@@ -9004,7 +3435,9 @@
     "adsrvr.org": [
       "adobe.com",
       "yahoo.com",
-      "googletagmanager.com"
+      "googletagmanager.com",
+      "sourceforge.net",
+      "hgtv.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -9014,7 +3447,9 @@
     "adsymptotic.com": [
       "tinyurl.com",
       "etsy.com",
-      "tripadvisor.com"
+      "tripadvisor.com",
+      "economist.com",
+      "realtor.com"
     ],
     "adtags.pro": [
       "tomsk.ru"
@@ -9025,7 +3460,9 @@
     "advertising.com": [
       "amazon.com",
       "sourceforge.net",
-      "dropbox.com"
+      "dropbox.com",
+      "wsj.com",
+      "walgreens.com"
     ],
     "advertur.ru": [
       "radikal.ru"
@@ -9054,7 +3491,8 @@
     "agkn.com": [
       "amazon.com",
       "t-online.de",
-      "bloomberg.com"
+      "bloomberg.com",
+      "cnet.com"
     ],
     "aid-ad.jp": [
       "shinobi.jp"
@@ -9073,7 +3511,8 @@
     "akamaihd.net": [
       "voanews.com",
       "repubblica.it",
-      "iyfubh.com"
+      "iyfubh.com",
+      "forbes.com"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -9093,6 +3532,7 @@
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
+      "sohu.com",
       "aliexpress.com"
     ],
     "alipay.com": [
@@ -9105,15 +3545,21 @@
     "allure.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "am15.net": [
       "radikal.ru"
     ],
+    "amap.com": [
+      "zhaopin.com"
+    ],
     "amazon-adsystem.com": [
       "amazon.com",
       "nytimes.com",
-      "reddit.com"
+      "reddit.com",
+      "cnn.com",
+      "bostonherald.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -9123,8 +3569,7 @@
       "imdb.com",
       "amazon.co.uk",
       "amazon.de",
-      "amazon.co.jp",
-      "amazon.es"
+      "amazon.co.jp"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -9138,7 +3583,8 @@
     "answerscloud.com": [
       "worldbank.org",
       "acs.org",
-      "fbi.gov"
+      "fbi.gov",
+      "navy.mil"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -9149,7 +3595,8 @@
     "aol.com": [
       "engadget.com",
       "indiatimes.com",
-      "autoblog.com"
+      "autoblog.com",
+      "techcrunch.com"
     ],
     "ap.org": [
       "post-gazette.com"
@@ -9165,7 +3612,9 @@
     "app.link": [
       "foursquare.com",
       "history.com",
-      "nbc.com"
+      "nbc.com",
+      "airbnb.com",
+      "strava.com"
     ],
     "appdynamics.com": [
       "nfl.com"
@@ -9173,7 +3622,8 @@
     "apple.com": [
       "digitaltrends.com",
       "icloud.com",
-      "softpedia.com"
+      "softpedia.com",
+      "thinkgeek.com"
     ],
     "aqtracker.com": [
       "nikkei.com"
@@ -9184,7 +3634,8 @@
     "architecturaldigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
@@ -9241,10 +3692,14 @@
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com"
+      "ifeng.com",
+      "sohu.com"
     ],
     "bam-x.com": [
       "gq.com"
+    ],
+    "baur.de": [
+      "t-online.de"
     ],
     "bazaarvoice.com": [
       "target.com",
@@ -9286,7 +3741,9 @@
     "bfmio.com": [
       "symantec.com",
       "tinypic.com",
-      "venturebeat.com"
+      "venturebeat.com",
+      "livescience.com",
+      "dailydot.com"
     ],
     "bfmtv.com": [
       "liberation.fr",
@@ -9298,12 +3755,16 @@
     "bidr.io": [
       "adobe.com",
       "dailymotion.com",
-      "hootsuite.com"
+      "hootsuite.com",
+      "hp.com",
+      "box.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
-      "amazon.com"
+      "amazon.com",
+      "forbes.com",
+      "newatlas.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -9316,7 +3777,9 @@
       "vimeo.com",
       "cnn.com",
       "weebly.com",
-      "msn.com"
+      "msn.com",
+      "microsoft.com",
+      "pingdom.com"
     ],
     "bitbucket.org": [
       "atlassian.com"
@@ -9324,7 +3787,9 @@
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com"
+      "zendesk.com",
+      "ibm.com",
+      "gitlab.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
@@ -9332,12 +3797,14 @@
     "bizographics.com": [
       "zend.com",
       "nginx.com",
-      "oreilly.com"
+      "oreilly.com",
+      "jimdo.com"
     ],
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -9352,7 +3819,8 @@
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
-      "sfgate.com"
+      "sfgate.com",
+      "chron.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -9364,21 +3832,23 @@
       "jigsy.com",
       "bravenet.com"
     ],
-    "bobo.com": [
-      "163.com"
-    ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org"
+      "cancer.org",
+      "networksolutions.com"
     ],
     "bonappetit.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "boston.com": [
       "bostonglobe.com"
+    ],
+    "bostonglobemedia.com": [
+      "boston.com"
     ],
     "botradar.tech": [
       "radikal.ru"
@@ -9389,7 +3859,9 @@
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com"
+      "wired.com",
+      "usatoday.com",
+      "pitchfork.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
@@ -9397,14 +3869,15 @@
     "brides.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "brightcove.com": [
       "scholastic.com",
       "si.com",
       "federalreserve.gov",
-      "informationweek.com",
-      "straitstimes.com"
+      "theaustralian.com.au",
+      "informationweek.com"
     ],
     "brightcove.net": [
       "lefigaro.fr",
@@ -9414,7 +3887,9 @@
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
-      "zendesk.com"
+      "zendesk.com",
+      "livescience.com",
+      "dailydot.com"
     ],
     "btttag.com": [
       "samsung.com",
@@ -9454,12 +3929,15 @@
     "casalemedia.com": [
       "amazon.com",
       "dropbox.com",
-      "myspace.com"
+      "myspace.com",
+      "washingtonpost.com",
+      "gizmodo.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
-      "gamespot.com"
+      "gamespot.com",
+      "cnet.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -9522,10 +4000,6 @@
     "ckies.net": [
       "abril.com.br"
     ],
-    "cleveland.com": [
-      "nola.com",
-      "al.com"
-    ],
     "clickability.com": [
       "prnewswire.com",
       "philly.com",
@@ -9547,7 +4021,11 @@
       "uci.edu",
       "nbcnews.com",
       "sciencemag.org",
+      "nginx.com",
       "allaboutcookies.org"
+    ],
+    "cmgdigital.com": [
+      "ajc.com"
     ],
     "cnet.com": [
       "zdnet.com"
@@ -9558,7 +4036,8 @@
     "cntraveler.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "cnzz.com": [
       "zol.com.cn"
@@ -9589,7 +4068,9 @@
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com"
+      "redhat.com",
+      "hp.com",
+      "box.com"
     ],
     "complex.com": [
       "knowyourmeme.com",
@@ -9602,7 +4083,9 @@
     "condenastdigital.com": [
       "wired.com",
       "arstechnica.com",
-      "nj.com"
+      "nj.com",
+      "newyorker.com",
+      "pitchfork.com"
     ],
     "conductrics.com": [
       "nginx.com"
@@ -9617,10 +4100,15 @@
     "consensu.org": [
       "rollingstone.com",
       "variety.com",
-      "adweek.com"
+      "adweek.com",
+      "independent.co.uk",
+      "nme.com"
     ],
     "consumable.com": [
       "xfinity.com"
+    ],
+    "content.ad": [
+      "tinypic.com"
     ],
     "contentabc.com": [
       "pornhub.com"
@@ -9628,7 +4116,9 @@
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "forbes.com",
+      "coindesk.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -9656,7 +4146,9 @@
     "cpx.to": [
       "express.co.uk",
       "digitaltrends.com",
-      "techradar.com"
+      "techradar.com",
+      "independent.co.uk",
+      "apartmenttherapy.com"
     ],
     "cquotient.com": [
       "gopro.com"
@@ -9674,7 +4166,9 @@
     "criteo.com": [
       "tinyurl.com",
       "washingtonpost.com",
-      "dailymail.co.uk"
+      "dailymail.co.uk",
+      "dropbox.com",
+      "sedo.com"
     ],
     "croissed.info": [
       "4shared.com"
@@ -9686,9 +4180,6 @@
       "sourceforge.net",
       "slashdot.org",
       "bartleby.com"
-    ],
-    "crwdcntrl.net": [
-      "bloomberg.com"
     ],
     "cssrvsync.com": [
       "springer.com",
@@ -9706,7 +4197,9 @@
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
-      "gizmodo.com"
+      "gizmodo.com",
+      "wsj.com",
+      "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -9758,13 +4251,18 @@
     "deep.bi": [
       "hrw.org"
     ],
+    "deepintent.com": [
+      "infoplease.com"
+    ],
     "dell.com": [
       "rsa.com"
     ],
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "amazon.com"
+      "amazon.com",
+      "soundcloud.com",
+      "skynet.be"
     ],
     "departapp.com": [
       "liveuamap.com"
@@ -9809,7 +4307,9 @@
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk"
+      "express.co.uk",
+      "gizmodo.com",
+      "bostonherald.com"
     ],
     "disney.com": [
       "starwars.com"
@@ -9821,12 +4321,14 @@
       "rollingstone.com"
     ],
     "distiltag.com": [
-      "reuters.com"
+      "reuters.com",
+      "merriam-webster.com"
     ],
     "districtm.io": [
       "barnesandnoble.com",
       "urbandictionary.com",
-      "axs.com"
+      "axs.com",
+      "newatlas.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
       "4shared.com"
@@ -9844,12 +4346,15 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com"
+      "tinypic.com",
+      "slashdot.org"
     ],
     "dotomi.com": [
       "tinyurl.com",
       "samsung.com",
-      "webmd.com"
+      "webmd.com",
+      "forbes.com",
+      "walgreens.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -9857,7 +4362,9 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com"
+      "linkedin.com",
+      "sourceforge.net",
+      "virginia.gov"
     ],
     "doublemax.net": [
       "udn.com"
@@ -9868,6 +4375,9 @@
     "doubleverify.com": [
       "military.com",
       "allafrica.com"
+    ],
+    "dowjones.io": [
+      "marketwatch.com"
     ],
     "dpmsrv.com": [
       "boston.com",
@@ -9880,7 +4390,8 @@
     "dynamicyield.com": [
       "t-online.de",
       "cnbc.com",
-      "nbcnews.com"
+      "nbcnews.com",
+      "washingtonexaminer.com"
     ],
     "dynatrace-managed.com": [
       "delta.com"
@@ -9929,12 +4440,15 @@
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com"
+      "gulfnews.com",
+      "goal.com"
     ],
     "eloqua.com": [
       "intel.com",
       "cisco.com",
-      "prnewswire.com"
+      "prnewswire.com",
+      "redhat.com",
+      "eset.com"
     ],
     "elsevier.com": [
       "sciencedirect.com",
@@ -9961,7 +4475,8 @@
     "epicurious.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -9992,7 +4507,9 @@
     "everesttech.net": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "usatoday.com",
+      "newatlas.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
@@ -10023,7 +4540,9 @@
     "exelator.com": [
       "soundcloud.com",
       "forbes.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "talktalk.co.uk",
+      "gizmodo.com"
     ],
     "exosrv.com": [
       "pornhub.com"
@@ -10034,14 +4553,17 @@
     "eyeota.net": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "heraldsun.com.au"
     ],
     "eyereturn.com": [
       "thestar.com",
       "queensu.ca"
     ],
     "eyeviewads.com": [
-      "staples.com"
+      "staples.com",
+      "nypost.com",
+      "walgreens.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -10050,7 +4572,9 @@
     "facebook.com": [
       "instagram.com",
       "wordpress.org",
-      "adobe.com"
+      "adobe.com",
+      "nytimes.com",
+      "lexisnexis.com"
     ],
     "facetz.net": [
       "novostimira.com",
@@ -10108,7 +4632,8 @@
     "flyertown.ca": [
       "canada.com",
       "globalnews.ca",
-      "nationalpost.com"
+      "nationalpost.com",
+      "vancouversun.com"
     ],
     "fontawesome.com": [
       "socarrao.com.br",
@@ -10120,7 +4645,8 @@
     "foresee.com": [
       "epa.gov",
       "si.edu",
-      "theglobeandmail.com"
+      "theglobeandmail.com",
+      "sec.gov"
     ],
     "formstack.com": [
       "in.gov"
@@ -10157,6 +4683,9 @@
     "friendbuy.com": [
       "lulu.com"
     ],
+    "fuel451.com": [
+      "prezi.com"
+    ],
     "funcaptcha.com": [
       "axs.com"
     ],
@@ -10167,7 +4696,9 @@
     "fwmrm.net": [
       "yahoo.com",
       "mlb.com",
-      "xfinity.com"
+      "xfinity.com",
+      "discovery.com",
+      "hgtv.com"
     ],
     "g2crowd.com": [
       "prezi.com",
@@ -10210,7 +4741,9 @@
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au"
+      "abc.net.au",
+      "sfgate.com",
+      "hgtv.com"
     ],
     "giphy.com": [
       "urbandictionary.com",
@@ -10223,7 +4756,8 @@
     "glamour.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
@@ -10243,7 +4777,8 @@
     "golfdigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
@@ -10255,14 +4790,16 @@
       "youtube.com",
       "linkedin.com",
       "google.de",
+      "sourceforge.net",
       "scmp.com",
       "chromium.org",
-      "google.be"
+      "designboom.com"
     ],
     "gq.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "gridsumdissector.com": [
       "qq.com",
@@ -10271,9 +4808,6 @@
     ],
     "groupondata.com": [
       "groupon.com"
-    ],
-    "grubstreet.com": [
-      "nymag.com"
     ],
     "gsimedia.net": [
       "acehardware.com"
@@ -10289,7 +4823,8 @@
     "gumgum.com": [
       "liveuamap.com",
       "colourlovers.com",
-      "infoplease.com"
+      "infoplease.com",
+      "coindesk.com"
     ],
     "guoshipartners.com": [
       "udn.com"
@@ -10297,7 +4832,9 @@
     "gwallet.com": [
       "adobe.com",
       "ox.ac.uk",
-      "ihg.com"
+      "ihg.com",
+      "economist.com",
+      "business2community.com"
     ],
     "gwmtracking.com": [
       "proofpoint.com"
@@ -10363,7 +4900,8 @@
     "hubspot.com": [
       "wpengine.com",
       "shopify.com",
-      "technologyreview.com"
+      "technologyreview.com",
+      "scoop.it"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
@@ -10405,7 +4943,8 @@
     "ibillboard.com": [
       "springer.com",
       "home.pl",
-      "idnes.cz"
+      "idnes.cz",
+      "t-online.de"
     ],
     "ibt.com": [
       "newsweek.com",
@@ -10414,7 +4953,8 @@
     "id5-sync.com": [
       "bloomberg.com",
       "venturebeat.com",
-      "dailymotion.com"
+      "dailymotion.com",
+      "livescience.com"
     ],
     "idealmedia.com": [
       "alternet.org",
@@ -10434,7 +4974,8 @@
     "im-apps.net": [
       "exblog.jp",
       "rakuten.co.jp",
-      "biglobe.ne.jp"
+      "biglobe.ne.jp",
+      "economist.com"
     ],
     "imagetopng.club": [
       "4shared.com"
@@ -10453,12 +4994,15 @@
     "impact-ad.jp": [
       "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "economist.com"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com"
+      "bbc.com",
+      "wsj.com",
+      "gizmodo.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
@@ -10484,7 +5028,8 @@
     "insightexpressai.com": [
       "unsplash.com",
       "standard.co.uk",
-      "motorola.com"
+      "motorola.com",
+      "gopro.com"
     ],
     "instagram.com": [
       "cam.ac.uk",
@@ -10495,11 +5040,13 @@
     "instinctiveads.com": [
       "variety.com",
       "dp.ua",
-      "blackberry.com"
+      "blackberry.com",
+      "rollingstone.com"
     ],
     "intentiq.com": [
       "sourceforge.net",
-      "symantec.com"
+      "symantec.com",
+      "slashdot.org"
     ],
     "intentmedia.net": [
       "hotels.com",
@@ -10509,7 +5056,8 @@
     "intercom.io": [
       "themeforest.net",
       "ft.com",
-      "elegantthemes.com"
+      "elegantthemes.com",
+      "iconfinder.com"
     ],
     "intergient.com": [
       "infoplease.com"
@@ -10554,7 +5102,8 @@
       "indianexpress.com"
     ],
     "janrainsso.com": [
-      "vancouversun.com"
+      "vancouversun.com",
+      "nationalpost.com"
     ],
     "jd.com": [
       "163.com",
@@ -10575,7 +5124,8 @@
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com"
+      "dallasnews.com",
+      "vancouversun.com"
     ],
     "justpremium.com": [
       "tvtropes.org"
@@ -10602,7 +5152,9 @@
     "keywee.co": [
       "latimes.com",
       "nationalgeographic.com",
-      "chicagotribune.com"
+      "chicagotribune.com",
+      "nytimes.com",
+      "zappos.com"
     ],
     "kinja.com": [
       "gizmodo.com",
@@ -10612,10 +5164,15 @@
     "kiwiirc.com": [
       "enlightenment.org"
     ],
+    "knet.cn": [
+      "dzwww.com"
+    ],
     "krxd.net": [
       "inhabitat.com",
       "bgr.com",
-      "jalopnik.com"
+      "jalopnik.com",
+      "cnn.com",
+      "gizmodo.com"
     ],
     "ladsp.com": [
       "exblog.jp",
@@ -10638,7 +5195,9 @@
     "liadm.com": [
       "webmd.com",
       "nj.com",
-      "patch.com"
+      "patch.com",
+      "economist.com",
+      "washingtonexaminer.com"
     ],
     "libero.it": [
       "virgilio.it"
@@ -10657,12 +5216,16 @@
     "lightboxcdn.com": [
       "zdnet.com",
       "fastcompany.com",
-      "adweek.com"
+      "adweek.com",
+      "mashable.com",
+      "dailycaller.com"
     ],
     "lijit.com": [
       "sourceforge.net",
       "bloomberg.com",
-      "deviantart.com"
+      "deviantart.com",
+      "mirror.co.uk",
+      "infoplease.com"
     ],
     "lincoln.com": [
       "ford.com"
@@ -10674,7 +5237,9 @@
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "msn.com",
+      "lexisnexis.com"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
@@ -10691,7 +5256,7 @@
       "paypal.com",
       "skype.com",
       "msn.com",
-      "microsoft.com",
+      "bing.com",
       "office.com"
     ],
     "livechatinc.com": [
@@ -10709,7 +5274,8 @@
     "liveperson.net": [
       "apache.org",
       "prnewswire.com",
-      "ibm.com"
+      "ibm.com",
+      "talktalk.co.uk"
     ],
     "lkqd.net": [
       "allafrica.com"
@@ -10743,7 +5309,8 @@
     "lytics.io": [
       "adweek.com",
       "digitaltrends.com",
-      "fool.com"
+      "fool.com",
+      "economist.com"
     ],
     "m6r.eu": [
       "t-online.de",
@@ -10755,12 +5322,14 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com"
+      "google.com",
+      "yandex.ru"
     ],
     "mailchimp.com": [
       "colorlib.com",
       "fas.org",
-      "tias.com"
+      "tias.com",
+      "nap.edu"
     ],
     "mantisadnetwork.com": [
       "tvtropes.org"
@@ -10768,17 +5337,20 @@
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "hootsuite.com"
+      "hootsuite.com",
+      "smugmug.com"
     ],
     "marketlinc.com": [
       "kaspersky.com",
       "norton.com",
-      "eset.com"
+      "eset.com",
+      "teamviewer.us"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
       "dyn.com",
+      "searchengineland.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
@@ -10789,17 +5361,22 @@
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "forbes.com",
+      "dailydot.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
-      "forbes.com"
+      "forbes.com",
+      "reuters.com",
+      "cracked.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
       "uci.edu",
-      "autodesk.com"
+      "autodesk.com",
+      "box.com"
     ],
     "mediaforge.com": [
       "nike.com",
@@ -10842,7 +5419,8 @@
     ],
     "metadsp.co.uk": [
       "nypost.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "variety.com"
     ],
     "mg2connext.com": [
       "mercurynews.com",
@@ -10871,11 +5449,9 @@
       "live.com",
       "skype.com",
       "or.kr",
-      "msn.com",
       "office.com",
       "xbox.com",
-      "complex.com",
-      "encyclopedia.com"
+      "complex.com"
     ],
     "microsoftonline.com": [
       "microsoft.com",
@@ -10887,12 +5463,16 @@
     "mktoresp.com": [
       "parallels.com",
       "prnewswire.com",
-      "zend.com"
+      "zend.com",
+      "oreilly.com",
+      "pingdom.com"
     ],
     "ml314.com": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "wsj.com",
+      "dailydot.com"
     ],
     "mlb.com": [
       "nhl.com"
@@ -10903,7 +5483,8 @@
     "mmstat.com": [
       "alibaba.com",
       "youku.com",
-      "taobao.com"
+      "taobao.com",
+      "sohu.com"
     ],
     "mmtro.com": [
       "upwork.com"
@@ -10922,7 +5503,8 @@
     "mookie1.com": [
       "t-online.de",
       "nbcnews.com",
-      "theglobeandmail.com"
+      "theglobeandmail.com",
+      "thetimes.co.uk"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -10957,7 +5539,8 @@
       "cc.com"
     ],
     "multiview.com": [
-      "symantec.com"
+      "symantec.com",
+      "nutrition.org"
     ],
     "musthird.com": [
       "airbnb.com"
@@ -10984,12 +5567,14 @@
     "myvisualiq.net": [
       "soundcloud.com",
       "surveymonkey.com",
-      "spotify.com"
+      "spotify.com",
+      "paypal.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
       "overstock.com",
-      "squareup.com"
+      "squareup.com",
+      "zappos.com"
     ],
     "narrative.io": [
       "sourceforge.net"
@@ -11012,7 +5597,8 @@
     ],
     "naver.com": [
       "unity3d.com",
-      "cafe24.com"
+      "cafe24.com",
+      "yonhapnews.co.kr"
     ],
     "naver.jp": [
       "line.me",
@@ -11025,7 +5611,8 @@
     "nbcuni.com": [
       "cnbc.com",
       "msnbc.com",
-      "nbc.com"
+      "nbc.com",
+      "nbcnews.com"
     ],
     "netdna-ssl.com": [
       "alternet.org"
@@ -11058,7 +5645,9 @@
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
-      "thesun.co.uk"
+      "thesun.co.uk",
+      "wsj.com",
+      "heraldsun.com.au"
     ],
     "newsinc.com": [
       "latimes.com",
@@ -11079,7 +5668,8 @@
     "newyorker.com": [
       "wired.com",
       "vanityfair.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -11091,9 +5681,6 @@
       "medlineplus.gov",
       "clinicaltrials.gov"
     ],
-    "nj.com": [
-      "bleacherreport.com"
-    ],
     "nokia.com": [
       "bell-labs.com"
     ],
@@ -11103,7 +5690,9 @@
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com"
+      "oracle.com",
+      "washingtonpost.com",
+      "helsinki.fi"
     ],
     "nsaudience.pl": [
       "interia.pl"
@@ -11174,12 +5763,15 @@
     "omnitagjs.com": [
       "springer.com",
       "standard.co.uk",
-      "home.pl"
+      "home.pl",
+      "variety.com"
     ],
     "omtrdc.net": [
       "adobe.com",
       "amazon.com",
-      "telegraph.co.uk"
+      "telegraph.co.uk",
+      "intel.com",
+      "eset.com"
     ],
     "onclickmega.com": [
       "brothersoft.com"
@@ -11193,7 +5785,9 @@
     "onetrust.com": [
       "themeisle.com",
       "bitbucket.org",
-      "namecheap.com"
+      "namecheap.com",
+      "cnn.com",
+      "active.com"
     ],
     "onevision.com.tw": [
       "udn.com"
@@ -11207,7 +5801,8 @@
     "onthe.io": [
       "indiatimes.com",
       "wn.com",
-      "express.co.uk"
+      "express.co.uk",
+      "rbc.ru"
     ],
     "ooyala.com": [
       "accuweather.com",
@@ -11224,7 +5819,9 @@
     "openx.net": [
       "yahoo.com",
       "amazon.com",
-      "nytimes.com"
+      "nytimes.com",
+      "forbes.com",
+      "active.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -11244,9 +5841,11 @@
       "live.com",
       "ibm.com",
       "hp.com",
+      "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
+      "foxnews.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
@@ -11256,26 +5855,26 @@
       "prweb.com",
       "dictionary.com",
       "bitbucket.org",
+      "gotomeeting.com",
       "accorhotels.com",
       "uber.com",
       "xbox.com",
+      "history.com",
       "bestbuy.com",
       "jamanetwork.com",
       "imageshack.com",
       "atlassian.com",
       "dallasnews.com",
       "metmuseum.org",
-      "intuit.com",
       "blizzard.com",
-      "office.com",
-      "squareup.com",
+      "intuit.com",
       "starbucks.com",
+      "squareup.com",
       "ajc.com",
       "justgiving.com",
       "dreamhost.com",
       "edx.org",
       "bartleby.com",
-      "malwarebytes.com",
       "theknot.com",
       "zenfolio.com",
       "fourseasons.com",
@@ -11311,7 +5910,9 @@
     "outbrain.com": [
       "nature.com",
       "scribd.com",
-      "foxnews.com"
+      "foxnews.com",
+      "cnn.com",
+      "pitchfork.com"
     ],
     "ovh.com": [
       "ovh.co.uk"
@@ -11330,12 +5931,15 @@
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org"
+      "ap.org",
+      "propublica.org"
     ],
     "parsely.com": [
       "time.com",
       "wired.com",
-      "wikia.com"
+      "wikia.com",
+      "wsj.com",
+      "dezeen.com"
     ],
     "paypal.com": [
       "paypal.me"
@@ -11347,6 +5951,9 @@
     ],
     "payroll.com": [
       "intuit.com"
+    ],
+    "pbbl.co": [
+      "zappos.com"
     ],
     "pbskids.org": [
       "pbs.org"
@@ -11369,18 +5976,23 @@
     "pewresearch.org": [
       "pewinternet.org"
     ],
+    "photobucket.com": [
+      "tinypic.com"
+    ],
     "pingan.com": [
       "autohome.com.cn"
     ],
     "pinterest.com": [
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "nytimes.com"
+      "nytimes.com",
+      "etsy.com"
     ],
     "pitchfork.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "epicurious.com"
     ],
     "pixanalytics.com": [
       "pixnet.net"
@@ -11407,7 +6019,8 @@
     "po.st": [
       "smithsonianmag.com",
       "wnd.com",
-      "business2community.com"
+      "business2community.com",
+      "nme.com"
     ],
     "polymorphicads.jp": [
       "shinobi.jp"
@@ -11421,24 +6034,29 @@
     "postrelease.com": [
       "reuters.com",
       "independent.co.uk",
-      "chicagotribune.com"
+      "chicagotribune.com",
+      "wsj.com",
+      "bostonherald.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
       "livescience.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "variety.com"
     ],
     "pressboard.ca": [
       "observer.com"
     ],
     "prfct.co": [
       "smugmug.com",
-      "marthastewart.com"
+      "marthastewart.com",
+      "business2community.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
       "symantec.com",
-      "slashdot.org"
+      "slashdot.org",
+      "business2community.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
@@ -11472,7 +6090,9 @@
     "pubmatic.com": [
       "dropbox.com",
       "tinyurl.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "usatoday.com",
+      "walgreens.com"
     ],
     "pubmine.com": [
       "foreignpolicy.com",
@@ -11505,7 +6125,8 @@
     "pymx5.com": [
       "seattletimes.com",
       "seattlepi.com",
-      "sfgate.com"
+      "sfgate.com",
+      "cracked.com"
     ],
     "qnsr.com": [
       "serverwatch.com"
@@ -11513,7 +6134,8 @@
     "qq.com": [
       "sina.com.cn",
       "ctrip.com",
-      "weather.com.cn"
+      "weather.com.cn",
+      "tencent.com"
     ],
     "qsstats.com": [
       "serverwatch.com",
@@ -11531,7 +6153,9 @@
     "quantserve.com": [
       "wordpress.org",
       "vimeo.com",
-      "reddit.com"
+      "reddit.com",
+      "soundcloud.com",
+      "gizmodo.com"
     ],
     "quantummetric.com": [
       "macys.com"
@@ -11545,10 +6169,13 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com"
+      "ning.com",
+      "nypost.com",
+      "eset.com"
     ],
     "rackcdn.com": [
-      "frontiersin.org"
+      "frontiersin.org",
+      "post-gazette.com"
     ],
     "radiotime.com": [
       "tunein.com"
@@ -11560,7 +6187,8 @@
       "livejournal.com",
       "washingtonpost.com",
       "novostimira.com",
-      "ria.ru"
+      "ria.ru",
+      "kharkov.ua"
     ],
     "rbnt.org": [
       "radikal.ru"
@@ -11624,7 +6252,9 @@
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
-      "npr.org"
+      "npr.org",
+      "forbes.com",
+      "gopro.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -11644,12 +6274,16 @@
     "rkdms.com": [
       "time.com",
       "wired.com",
-      "cbsnews.com"
+      "cbsnews.com",
+      "zdnet.com",
+      "gizmodo.com"
     ],
     "rlcdn.com": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "reddit.com",
+      "box.com"
     ],
     "rnengage.com": [
       "oracle.com",
@@ -11671,7 +6305,6 @@
     ],
     "rtk.io": [
       "post-gazette.com",
-      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
@@ -11681,7 +6314,9 @@
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "nytimes.com",
+      "pitchfork.com"
     ],
     "rundsp.com": [
       "hpe.com",
@@ -11721,6 +6356,9 @@
       "gizmodo.com",
       "lifehacker.com"
     ],
+    "samplicio.us": [
+      "reddit.com"
+    ],
     "sbal4kp.com": [
       "dropbox.com"
     ],
@@ -11753,7 +6391,9 @@
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
-      "tumblr.com"
+      "tumblr.com",
+      "nytimes.com",
+      "gizmodo.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
@@ -11762,6 +6402,9 @@
     ],
     "sddan.com": [
       "upwork.com"
+    ],
+    "sdp-campaign.de": [
+      "t-online.de"
     ],
     "seadform.net": [
       "bloomberg.com"
@@ -11782,12 +6425,14 @@
     "selectablemedia.com": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com"
     ],
     "self.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "semasio.net": [
       "bloomberg.com"
@@ -11799,7 +6444,8 @@
     "servebom.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com"
+      "space.com",
+      "dailydot.com"
     ],
     "servedby-buysellads.com": [
       "dribbble.com"
@@ -11810,7 +6456,9 @@
     "serving-sys.com": [
       "dropbox.com",
       "t-online.de",
-      "nbcnews.com"
+      "nbcnews.com",
+      "businessinsider.com",
+      "hgtv.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -11823,12 +6471,15 @@
     "sharethis.com": [
       "www.uk.com",
       "whatsapp.com",
-      "lycos.com"
+      "lycos.com",
+      "bloomberg.com",
+      "bl.uk"
     ],
     "sharethrough.com": [
       "yahoo.com",
       "cnn.com",
-      "time.com"
+      "time.com",
+      "walgreens.com"
     ],
     "sheego.de": [
       "t-online.de"
@@ -11868,7 +6519,11 @@
     "siteimprove.com": [
       "usda.gov",
       "verisign.com",
-      "udel.edu"
+      "udel.edu",
+      "berkeley.edu",
+      "jhu.edu",
+      "case.edu",
+      "oclc.org"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
@@ -11884,12 +6539,16 @@
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "seattletimes.com"
+      "seattletimes.com",
+      "slashdot.org",
+      "networksolutions.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com"
+      "gizmodo.com",
+      "arstechnica.com",
+      "coindesk.com"
     ],
     "sky.com": [
       "skygroup.sky",
@@ -11926,7 +6585,9 @@
     "snapchat.com": [
       "jimdo.com",
       "overstock.com",
-      "complex.com"
+      "complex.com",
+      "wsj.com",
+      "zappos.com"
     ],
     "snapwidget.com": [
       "udel.edu"
@@ -11977,7 +6638,9 @@
     "sonobi.com": [
       "photobucket.com",
       "deviantart.com",
-      "springer.com"
+      "springer.com",
+      "myspace.com",
+      "detroitnews.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -11986,7 +6649,8 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "irishtimes.com"
+      "irishtimes.com",
+      "mo.gov"
     ],
     "sourceforge.net": [
       "libpng.org"
@@ -12003,7 +6667,8 @@
     "spiceworks.com": [
       "cloudflare.com",
       "symantec.com",
-      "sophos.com"
+      "sophos.com",
+      "hp.com"
     ],
     "spineuniverse.com": [
       "psychcentral.com"
@@ -12027,7 +6692,9 @@
     "spotxchange.com": [
       "amazon.com",
       "dropbox.com",
-      "dailymotion.com"
+      "dailymotion.com",
+      "thenextweb.com",
+      "bostonherald.com"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -12066,7 +6733,8 @@
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org"
+      "man7.org",
+      "zerohedge.com"
     ],
     "staticimgfarm.com": [
       "excite.com"
@@ -12118,12 +6786,14 @@
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com"
+      "studiopress.com",
+      "makezine.com"
     ],
     "sundaysky.com": [
       "overstock.com",
       "alternet.org",
-      "infoplease.com"
+      "infoplease.com",
+      "careerbuilder.com"
     ],
     "suning.com": [
       "qq.com",
@@ -12159,7 +6829,9 @@
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
-      "t-online.de"
+      "t-online.de",
+      "msn.com",
+      "edmunds.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -12180,7 +6852,8 @@
     "tanx.com": [
       "sina.com.cn",
       "alibaba.com",
-      "ifeng.com"
+      "ifeng.com",
+      "sohu.com"
     ],
     "taobao.com": [
       "sina.com.cn",
@@ -12191,7 +6864,9 @@
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
-      "soundcloud.com"
+      "soundcloud.com",
+      "paypal.com",
+      "bostonherald.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -12203,17 +6878,22 @@
       "sophos.com"
     ],
     "teads.tv": [
-      "alternet.org"
+      "alternet.org",
+      "networksolutions.com"
     ],
     "tealiumiq.com": [
       "ibm.com",
       "cbsnews.com",
-      "evernote.com"
+      "evernote.com",
+      "cnet.com",
+      "usmagazine.com"
     ],
     "technolutions.net": [
       "illinois.edu",
       "upenn.edu",
-      "uci.edu"
+      "uci.edu",
+      "udel.edu",
+      "case.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -12221,7 +6901,8 @@
     "teenvogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "telegraph.co.uk": [
       "wordpress.com"
@@ -12243,7 +6924,8 @@
     "thebrighttag.com": [
       "netflix.com",
       "wufoo.com",
-      "playstation.com"
+      "playstation.com",
+      "zappos.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -12268,7 +6950,8 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com"
+      "ew.com",
+      "time.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -12276,14 +6959,17 @@
     "tinypass.com": [
       "businessinsider.com",
       "techcrunch.com",
-      "kickstarter.com"
+      "kickstarter.com",
+      "cnbc.com",
+      "gizmodo.com"
     ],
     "tiqcdn.com": [
       "cisco.com",
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
-      "hpe.com"
+      "hpe.com",
+      "francetvinfo.fr"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -12298,7 +6984,9 @@
     "tns-counter.ru": [
       "livejournal.com",
       "vk.com",
-      "yandex.ru"
+      "yandex.ru",
+      "mail.ru",
+      "radikal.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
@@ -12349,12 +7037,14 @@
     "tremorhub.com": [
       "usatoday.com",
       "azcentral.com",
-      "freep.com"
+      "freep.com",
+      "detroitnews.com"
     ],
     "tribalfusion.com": [
       "dailymotion.com",
       "pastebin.com",
-      "liveleak.com"
+      "liveleak.com",
+      "marriott.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -12399,7 +7089,9 @@
     "turn.com": [
       "bloomberg.com",
       "wired.com",
-      "webmd.com"
+      "webmd.com",
+      "hp.com",
+      "pitchfork.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
@@ -12407,7 +7099,8 @@
     "tvsquared.com": [
       "telegraph.co.uk",
       "jimdo.com",
-      "squarespace.com"
+      "squarespace.com",
+      "economist.com"
     ],
     "twimg.com": [
       "coe.int",
@@ -12418,8 +7111,10 @@
       "wordpress.org",
       "yahoo.com",
       "chicagotribune.com",
+      "nytimes.com",
       "cnn.com",
-      "cnet.com"
+      "cnet.com",
+      "rfi.fr"
     ],
     "tynt.com": [
       "accuweather.com",
@@ -12467,7 +7162,8 @@
     "unrulymedia.com": [
       "nypost.com",
       "earthlink.net",
-      "boingboing.net"
+      "boingboing.net",
+      "networkadvertising.org"
     ],
     "upravel.com": [
       "rambler.ru",
@@ -12498,6 +7194,10 @@
     "userreport.com": [
       "scotsman.com"
     ],
+    "uservoice.com": [
+      "scoop.it",
+      "theknot.com"
+    ],
     "ustream.tv": [
       "ibm.com"
     ],
@@ -12519,7 +7219,8 @@
     "vanityfair.com": [
       "wired.com",
       "newyorker.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "veinteractive.com": [
       "prweb.com",
@@ -12551,17 +7252,21 @@
       "hpe.com"
     ],
     "videohub.tv": [
-      "liveuamap.com"
+      "liveuamap.com",
+      "wsj.com",
+      "bloomberg.com"
     ],
     "vidible.tv": [
       "aol.com",
       "nydailynews.com",
-      "autoblog.com"
+      "autoblog.com",
+      "huffingtonpost.com"
     ],
     "viglink.com": [
       "zdnet.com",
       "softonic.com",
-      "techrepublic.com"
+      "techrepublic.com",
+      "cnet.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
@@ -12574,12 +7279,15 @@
       "livestream.com",
       "wufoo.com",
       "heroku.com",
+      "emarketer.com",
       "designboom.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
       "fortune.com",
-      "people.com"
+      "people.com",
+      "time.com",
+      "zappos.com"
     ],
     "virgilio.it": [
       "libero.it"
@@ -12593,12 +7301,17 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru"
+      "ria.ru",
+      "yandex.ru"
+    ],
+    "vmmpxl.com": [
+      "networksolutions.com"
     ],
     "vogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "volvelle.tech": [
       "prweb.com",
@@ -12614,13 +7327,14 @@
     "vtracy.de": [
       "bloomberg.com"
     ],
-    "vulture.com": [
-      "nymag.com"
-    ],
     "w55c.net": [
       "hpe.com",
       "ebay.com",
-      "sourceforge.net"
+      "sourceforge.net",
+      "pbs.org"
+    ],
+    "wal.co": [
+      "walmart.com"
     ],
     "wallst.com": [
       "reuters.com"
@@ -12649,7 +7363,8 @@
     "weborama.fr": [
       "lemonde.fr",
       "rbc.ru",
-      "lexpress.fr"
+      "lexpress.fr",
+      "leparisien.fr"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -12673,7 +7388,11 @@
     "webtrendslive.com": [
       "nature.com",
       "abc.net.au",
-      "oup.com"
+      "oup.com",
+      "dhl.com"
+    ],
+    "webvisor.org": [
+      "kharkov.ua"
     ],
     "weibo.com": [
       "sina.com.cn"
@@ -12697,7 +7416,8 @@
     "wired.com": [
       "newyorker.com",
       "vanityfair.com",
-      "vogue.com"
+      "vogue.com",
+      "pitchfork.com"
     ],
     "wise.space": [
       "purevolume.com"
@@ -12707,7 +7427,7 @@
       "suntimes.com",
       "canada.com",
       "globalnews.ca",
-      "vancouversun.com"
+      "bostonherald.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
@@ -12718,7 +7438,8 @@
     "wistia.com": [
       "zendesk.com",
       "typeform.com",
-      "photoshelter.com"
+      "photoshelter.com",
+      "buffer.com"
     ],
     "wistia.net": [
       "nielsen.com"
@@ -12734,7 +7455,8 @@
     "wmagazine.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com"
+      "vanityfair.com",
+      "pitchfork.com"
     ],
     "wnyc.org": [
       "newyorker.com",
@@ -12755,11 +7477,11 @@
       "prnewswire.com",
       "cbslocal.com",
       "fortune.com",
-      "nypost.com",
       "akismet.com",
+      "nypost.com",
       "news.com.au",
-      "metro.co.uk",
-      "variety.com"
+      "variety.com",
+      "metro.co.uk"
     ],
     "wrating.com": [
       "163.com",
@@ -12802,7 +7524,9 @@
     "xiti.com": [
       "lemonde.fr",
       "unblog.fr",
-      "uefa.com"
+      "uefa.com",
+      "skyrock.com",
+      "leparisien.fr"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
@@ -12823,27 +7547,31 @@
     "yadro.ru": [
       "vk.com",
       "novostimira.com",
-      "mail.ru"
+      "mail.ru",
+      "rt.com",
+      "radikal.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
-      "rakuten.co.jp"
+      "rakuten.co.jp",
+      "economist.com"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
-      "flickr.com"
-    ],
-    "yahoosmallbusiness.com": [
-      "yahoo.com"
+      "flickr.com",
+      "sourceforge.net",
+      "eset.com"
     ],
     "yandex.ru": [
       "livejournal.com",
       "opera.com",
       "stanford.edu",
       "ning.com",
-      "fourseasons.com"
+      "rt.com",
+      "radikal.ru",
+      "kharkov.ua"
     ],
     "yandex.ua": [
       "kharkov.ua",
@@ -12860,7 +7588,8 @@
     "yieldlab.net": [
       "spiegel.de",
       "heise.de",
-      "faz.net"
+      "faz.net",
+      "t-online.de"
     ],
     "yieldoptimizer.com": [
       "ihg.com",
@@ -12871,13 +7600,13 @@
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
-      "dropbox.com",
       "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
-      "newyorker.com"
+      "newyorker.com",
+      "pcworld.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -12903,7 +7632,7 @@
       "nih.gov",
       "telegraph.co.uk",
       "caltech.edu",
-      "acm.org",
+      "ahajournals.org",
       "honeywell.com"
     ],
     "youvisit.com": [
@@ -12920,7 +7649,8 @@
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com"
+      "ign.com",
+      "everydayhealth.com"
     ],
     "zedo.com": [
       "tinypic.com",
@@ -12930,7 +7660,9 @@
     "zemanta.com": [
       "independent.co.uk",
       "thehill.com",
-      "farfetch.com"
+      "farfetch.com",
+      "paypal.com",
+      "infoplease.com"
     ],
     "zendesk.com": [
       "jugem.jp",
@@ -12941,7 +7673,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "wunderground.com"
+      "marketwatch.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -12973,5 +7705,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.23"
+  "version": "2018.8.24"
 }

--- a/results.json
+++ b/results.json
@@ -3,7 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535262627774,
+      "nextUpdateTime": 1535598197544,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,31 +27,31 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535626983992,
-      "userAction": ""
-    },
-    "20794186p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535587166558,
+      "nextUpdateTime": 1535671078852,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535265170878,
+      "nextUpdateTime": 1535760970927,
+      "userAction": ""
+    },
+    "2771890.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535477982326,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535624128010,
+      "nextUpdateTime": 1535520902504,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535452599779,
+      "nextUpdateTime": 1535508988871,
       "userAction": ""
     },
     "2o7.net": {
@@ -69,121 +69,157 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535535546152,
+      "nextUpdateTime": 1535388856176,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535662314785,
+      "nextUpdateTime": 1535492182388,
       "userAction": ""
     },
     "4303900.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535206086724,
+      "nextUpdateTime": 1535709815906,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535538081882,
+      "nextUpdateTime": 1535690936934,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535266457214,
+      "nextUpdateTime": 1535282712221,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535396666801,
+      "nextUpdateTime": 1535642991767,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535448735698,
+      "nextUpdateTime": 1535526803320,
+      "userAction": ""
+    },
+    "516-dgm-318.mktoresp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535662787551,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535243002291,
+      "nextUpdateTime": 1535488582093,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535337090048,
+      "nextUpdateTime": 1535328095043,
+      "userAction": ""
+    },
+    "5779616.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535323766046,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535580006291,
+      "nextUpdateTime": 1535614886406,
+      "userAction": ""
+    },
+    "6954342.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535360379630,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535489115471,
+      "nextUpdateTime": 1535440566618,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535568595011,
+      "nextUpdateTime": 1535299551431,
+      "userAction": ""
+    },
+    "8758559.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535315581112,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535312919301,
+      "nextUpdateTime": 1535376693594,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535475207820,
+      "nextUpdateTime": 1535719315712,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535301965338,
+      "nextUpdateTime": 1535589740320,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535357074390,
+      "nextUpdateTime": 1535470877593,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535655182527,
+      "nextUpdateTime": 1535702667567,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535519468673,
+      "nextUpdateTime": 1535724954686,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535611575907,
+      "nextUpdateTime": 1535483154043,
+      "userAction": ""
+    },
+    "aa.agkn.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535780115828,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535446366018,
+      "nextUpdateTime": 1535779559578,
+      "userAction": ""
+    },
+    "aax.amazon-adsystem.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535412607145,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -195,13 +231,13 @@
     "accounts.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535504617595,
+      "nextUpdateTime": 1535434218229,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535253661031,
+      "nextUpdateTime": 1535660982750,
       "userAction": ""
     },
     "acpm.fr": {
@@ -213,19 +249,19 @@
     "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535369444025,
+      "nextUpdateTime": 1535490888501,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535691309435,
+      "nextUpdateTime": 1535404713512,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535376624050,
+      "nextUpdateTime": 1535641831031,
       "userAction": ""
     },
     "ad-score.com": {
@@ -236,8 +272,14 @@
     },
     "ad.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535211259067,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535379331728,
+      "userAction": ""
+    },
+    "ad.yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535307543537,
       "userAction": ""
     },
     "addthis.com": {
@@ -273,7 +315,7 @@
     "ado.pro-market.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535620955615,
+      "nextUpdateTime": 1535527859438,
       "userAction": ""
     },
     "adroll.com": {
@@ -285,37 +327,43 @@
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535272034892,
+      "nextUpdateTime": 1535445477120,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535595817030,
+      "nextUpdateTime": 1535585934820,
+      "userAction": ""
+    },
+    "ads.scorecardresearch.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535744320295,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535505404872,
+      "nextUpdateTime": 1535694008167,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510061258,
+      "nextUpdateTime": 1535577473176,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535227640334,
+      "nextUpdateTime": 1535711402958,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535513512165,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535726386777,
       "userAction": ""
     },
     "adsnative.com": {
@@ -342,10 +390,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "agkn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "aimfar.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535390413184,
+      "nextUpdateTime": 1535609624527,
       "userAction": ""
     },
     "allure.com": {
@@ -369,73 +423,103 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535485288372,
+      "nextUpdateTime": 1535691963120,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535342343438,
+      "nextUpdateTime": 1535516989467,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535464239398,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535284316576,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535353985951,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535285639223,
+      "userAction": ""
+    },
+    "analytics.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535540660259,
+      "userAction": ""
+    },
+    "answerscloud.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535360650206,
+      "nextUpdateTime": 1535751809759,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535501934181,
+      "nextUpdateTime": 1535472792249,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535408184819,
+      "nextUpdateTime": 1535501927149,
+      "userAction": ""
+    },
+    "api-public.addthis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535762945972,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535222960634,
+      "nextUpdateTime": 1535704572492,
+      "userAction": ""
+    },
+    "api.adsnative.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535558537040,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535623743904,
+      "nextUpdateTime": 1535711849116,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535236794710,
+      "nextUpdateTime": 1535630848647,
       "userAction": ""
     },
     "api.nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535594380737,
+      "nextUpdateTime": 1535780608617,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535395219456,
+      "nextUpdateTime": 1535442958777,
+      "userAction": ""
+    },
+    "api.viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535461454234,
       "userAction": ""
     },
     "apis.google.com": {
@@ -447,7 +531,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535592146802,
+      "nextUpdateTime": 1535346277488,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -459,7 +543,7 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694314872,
+      "nextUpdateTime": 1535661299224,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -468,46 +552,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "au.audience.newscgp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535726850586,
+      "userAction": ""
+    },
     "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535494074509,
+      "nextUpdateTime": 1535553365774,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535247779526,
+      "nextUpdateTime": 1535469524850,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535226328665,
+      "nextUpdateTime": 1535654763789,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535202486243,
+      "nextUpdateTime": 1535637344742,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535597253083,
+      "nextUpdateTime": 1535524792139,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535542051945,
+      "nextUpdateTime": 1535726960200,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535252312595,
+      "nextUpdateTime": 1535432389781,
       "userAction": ""
     },
     "bfmio.com": {
@@ -519,25 +609,19 @@
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535382038883,
+      "nextUpdateTime": 1535784224054,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535480847940,
+      "nextUpdateTime": 1535573293865,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535647133688,
-      "userAction": ""
-    },
-    "bidr.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535551251160,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -585,7 +669,7 @@
     "boxinc.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535480752964,
+      "nextUpdateTime": 1535478347303,
       "userAction": ""
     },
     "brides.com": {
@@ -597,55 +681,61 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535587303603,
+      "nextUpdateTime": 1535315840766,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535544471047,
+      "nextUpdateTime": 1535306900694,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535509302674,
+      "nextUpdateTime": 1535302383139,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535439684416,
+      "nextUpdateTime": 1535392133905,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535372974143,
+      "nextUpdateTime": 1535503302723,
+      "userAction": ""
+    },
+    "c.deployads.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535412362928,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535375054801,
+      "nextUpdateTime": 1535584173633,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535419121418,
+      "nextUpdateTime": 1535597776860,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535689108903,
+      "nextUpdateTime": 1535690141366,
       "userAction": ""
     },
     "cache.vindicosuite.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535487196231,
+      "nextUpdateTime": 1535279594967,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -657,13 +747,13 @@
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535672073907,
+      "nextUpdateTime": 1535327513388,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535523620270,
+      "nextUpdateTime": 1535568142694,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -675,25 +765,37 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535654255150,
+      "nextUpdateTime": 1535517244578,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535312966669,
+      "nextUpdateTime": 1535517807139,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535255974831,
+      "nextUpdateTime": 1535755634406,
+      "userAction": ""
+    },
+    "cdn.inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535779331445,
+      "userAction": ""
+    },
+    "cdn.justuno.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535713763814,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535345088017,
+      "nextUpdateTime": 1535528231483,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -705,25 +807,31 @@
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535594352004,
+      "nextUpdateTime": 1535560444094,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535235445711,
+      "nextUpdateTime": 1535368051541,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535266344256,
+      "nextUpdateTime": 1535608113749,
+      "userAction": ""
+    },
+    "cdn1-res.sundaysky.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535644505799,
       "userAction": ""
     },
     "cdns.gigya.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535423728304,
+      "nextUpdateTime": 1535455708662,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -735,7 +843,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535530563408,
+      "nextUpdateTime": 1535567467824,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -753,13 +861,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535375206049,
+      "nextUpdateTime": 1535483839903,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535223704946,
+      "nextUpdateTime": 1535365976800,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -771,7 +879,7 @@
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535358602103,
+      "nextUpdateTime": 1535444044156,
       "userAction": ""
     },
     "company-target.com": {
@@ -783,7 +891,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535574500673,
+      "nextUpdateTime": 1535682892731,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -795,7 +903,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535483865039,
+      "nextUpdateTime": 1535296279568,
       "userAction": ""
     },
     "consensu.org": {
@@ -813,13 +921,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535261715060,
+      "nextUpdateTime": 1535506369860,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535389202601,
+      "nextUpdateTime": 1535701071745,
       "userAction": ""
     },
     "contextweb.com": {
@@ -831,7 +939,7 @@
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535323524063,
+      "nextUpdateTime": 1535424975290,
       "userAction": ""
     },
     "cpx.to": {
@@ -849,13 +957,13 @@
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535231023580,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694255065,
+      "nextUpdateTime": 1535762279418,
       "userAction": ""
     },
     "cxense.com": {
@@ -867,49 +975,73 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535215730697,
+      "nextUpdateTime": 1535342840522,
+      "userAction": ""
+    },
+    "d.agkn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535565611927,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535553722917,
+      "nextUpdateTime": 1535713060726,
+      "userAction": ""
+    },
+    "d.df-srv.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535364087304,
+      "userAction": ""
+    },
+    "d.la1-c2-dfw.salesforceliveagent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535674921575,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606895685,
+      "nextUpdateTime": 1535487468755,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535382596864,
+      "nextUpdateTime": 1535606881689,
       "userAction": ""
     },
     "data.ad-score.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535303819645,
+      "nextUpdateTime": 1535303631043,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535521287337,
+      "nextUpdateTime": 1535379877739,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535572992646,
+      "nextUpdateTime": 1535357000518,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535519088936,
+      "nextUpdateTime": 1535668414319,
+      "userAction": ""
+    },
+    "de.ioam.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535731438109,
       "userAction": ""
     },
     "deepintent.com": {
@@ -924,9 +1056,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "deployads.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "developers.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "df-srv.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -939,19 +1083,19 @@
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535661792347,
+      "nextUpdateTime": 1535432116374,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535232050057,
+      "nextUpdateTime": 1535319875858,
       "userAction": ""
     },
     "districtm-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535645818795,
+      "nextUpdateTime": 1535721504755,
       "userAction": ""
     },
     "districtm.io": {
@@ -963,7 +1107,7 @@
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483132878,
+      "nextUpdateTime": 1535293970894,
       "userAction": ""
     },
     "docs.google.com": {
@@ -987,7 +1131,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535303632169,
+      "nextUpdateTime": 1535778123280,
       "userAction": ""
     },
     "drive.google.com": {
@@ -998,8 +1142,20 @@
     },
     "dsum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535203788849,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535544929225,
+      "userAction": ""
+    },
+    "dsum.casalemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535728636063,
+      "userAction": ""
+    },
+    "dxpmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1011,7 +1167,7 @@
     "eb2.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535462065407,
+      "nextUpdateTime": 1535569655087,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1023,7 +1179,7 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535583449091,
+      "nextUpdateTime": 1535525806664,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1047,13 +1203,19 @@
     "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535394964179,
+      "nextUpdateTime": 1535726564765,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477714020,
+      "nextUpdateTime": 1535399555453,
+      "userAction": ""
+    },
+    "events.mediarithmics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535428968914,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1065,7 +1227,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535379656026,
+      "nextUpdateTime": 1535403017484,
       "userAction": ""
     },
     "exelator.com": {
@@ -1077,7 +1239,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535345851450,
+      "nextUpdateTime": 1535646811319,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1088,7 +1250,7 @@
     },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1101,13 +1263,13 @@
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535450343934,
+      "nextUpdateTime": 1535725073044,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535309167566,
+      "nextUpdateTime": 1535696802415,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1128,10 +1290,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "foxnet.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535786271610,
+      "userAction": ""
+    },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465485854,
+      "nextUpdateTime": 1535281885570,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1149,43 +1317,55 @@
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535666835971,
+      "nextUpdateTime": 1535692750885,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535209533543,
+      "nextUpdateTime": 1535691303682,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535336446858,
+      "nextUpdateTime": 1535691097103,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535593979644,
+      "nextUpdateTime": 1535545531677,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535617465597,
+      "nextUpdateTime": 1535587812182,
+      "userAction": ""
+    },
+    "gannett.hb.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535649331173,
+      "userAction": ""
+    },
+    "gateway.answerscloud.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535491753062,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535474265266,
+      "nextUpdateTime": 1535307250586,
       "userAction": ""
     },
     "geosync.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535392194713,
+      "nextUpdateTime": 1535284522122,
       "userAction": ""
     },
     "gigya.com": {
@@ -1221,7 +1401,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535456837113,
+      "nextUpdateTime": 1535317462506,
       "userAction": ""
     },
     "gq.com": {
@@ -1233,7 +1413,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535352505666,
+      "nextUpdateTime": 1535648552872,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1242,16 +1422,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "gscounters.us1.gigya.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535453629901,
+      "userAction": ""
+    },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535629742696,
+      "nextUpdateTime": 1535367472545,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535428819281,
+      "nextUpdateTime": 1535629285942,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1269,37 +1455,49 @@
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503241069,
+      "nextUpdateTime": 1535465563548,
+      "userAction": ""
+    },
+    "hpr.outbrain.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535418833610,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535673061315,
+      "nextUpdateTime": 1535364247788,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535361476630,
+      "nextUpdateTime": 1535423720799,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535582031482,
+      "nextUpdateTime": 1535418433351,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535791087893,
+      "userAction": ""
+    },
+    "ic.tynt.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535668050896,
+      "nextUpdateTime": 1535533568374,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535519131089,
+      "nextUpdateTime": 1535505218565,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1311,13 +1509,19 @@
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535350768670,
+      "nextUpdateTime": 1535334042860,
+      "userAction": ""
+    },
+    "inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535272317482,
+      "nextUpdateTime": 1535515823670,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -1329,7 +1533,7 @@
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535572303283,
+      "nextUpdateTime": 1535619321717,
       "userAction": ""
     },
     "intercom.io": {
@@ -1341,19 +1545,31 @@
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535505082401,
+      "nextUpdateTime": 1535538084696,
+      "userAction": ""
+    },
+    "ioam.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "iperceptions.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ips-invite.iperceptions.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535461878087,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535555974254,
-      "userAction": ""
-    },
-    "js.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535656782989,
+      "nextUpdateTime": 1535692870860,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1363,6 +1579,12 @@
       "userAction": ""
     },
     "jsrdn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1416,12 +1638,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "l.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535413172230,
-      "userAction": ""
-    },
     "labs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1452,52 +1668,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "live.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535393415816,
+      "nextUpdateTime": 1535681411551,
       "userAction": ""
     },
     "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535386732667,
+      "nextUpdateTime": 1535321905319,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399584027,
+      "nextUpdateTime": 1535566793461,
+      "userAction": ""
+    },
+    "log.outbrain.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535418449649,
       "userAction": ""
     },
     "login-ds.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535451066232,
+      "nextUpdateTime": 1535561002865,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535219009893,
+      "nextUpdateTime": 1535755600759,
+      "userAction": ""
+    },
+    "login.live.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535388260240,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535663645260,
+      "nextUpdateTime": 1535584230515,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535302271160,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535708708425,
+      "userAction": ""
+    },
+    "map.dxpmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535628695462,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1521,25 +1767,19 @@
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535521811421,
+      "nextUpdateTime": 1535652945157,
       "userAction": ""
     },
     "match.deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535638997127,
-      "userAction": ""
-    },
-    "match.prod.bidr.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535567304417,
+      "nextUpdateTime": 1535460992471,
       "userAction": ""
     },
     "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535438152314,
+      "nextUpdateTime": 1535663791310,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1551,13 +1791,13 @@
     "mc.webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535584747297,
+      "nextUpdateTime": 1535286232291,
       "userAction": ""
     },
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535439720084,
+      "nextUpdateTime": 1535536846686,
       "userAction": ""
     },
     "media.net": {
@@ -1575,13 +1815,25 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535348403984,
+      "nextUpdateTime": 1535302299674,
+      "userAction": ""
+    },
+    "mediarithmics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "messenger.live.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535694375796,
+      "nextUpdateTime": 1535606263682,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1593,7 +1845,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535592189311,
+      "nextUpdateTime": 1535387249359,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1638,12 +1890,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mx.technolutions.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535659044372,
-      "userAction": ""
-    },
     "nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1653,7 +1899,7 @@
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535243950608,
+      "nextUpdateTime": 1535381874834,
       "userAction": ""
     },
     "newscgp.com": {
@@ -1665,7 +1911,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535200399853,
+      "nextUpdateTime": 1535311629687,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1677,13 +1923,13 @@
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535196785688,
+      "nextUpdateTime": 1535376489955,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535415967207,
+      "nextUpdateTime": 1535418451285,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1695,7 +1941,7 @@
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535395333287,
+      "nextUpdateTime": 1535785645386,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -1725,7 +1971,7 @@
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535531761134,
+      "nextUpdateTime": 1535785571775,
       "userAction": ""
     },
     "optimizely.com": {
@@ -1740,34 +1986,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "owneriq.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535536846901,
+      "nextUpdateTime": 1535329796782,
+      "userAction": ""
+    },
+    "p.cpx.to": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535520890292,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477613091,
+      "nextUpdateTime": 1535389036499,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535594442097,
+      "nextUpdateTime": 1535511748310,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535255133764,
+      "nextUpdateTime": 1535711083150,
+      "userAction": ""
+    },
+    "p.yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535505388228,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535516317349,
+      "nextUpdateTime": 1535641328780,
       "userAction": ""
     },
     "pardot.com": {
@@ -1782,22 +2046,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pbbl.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535318942650,
+      "nextUpdateTime": 1535336231323,
+      "userAction": ""
+    },
+    "pd.sharethis.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535496198612,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535527261052,
+      "nextUpdateTime": 1535546381760,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -1815,79 +2079,79 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535263794027,
+      "nextUpdateTime": 1535775677065,
       "userAction": ""
     },
     "pixel-geo.prfct.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535428050071,
+      "nextUpdateTime": 1535759777976,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535195199383,
+      "nextUpdateTime": 1535462179315,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535285373385,
+      "nextUpdateTime": 1535427198698,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535260055836,
+      "nextUpdateTime": 1535373297517,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535451828821,
+      "nextUpdateTime": 1535355242307,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535543163260,
+      "nextUpdateTime": 1535647714316,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535312448131,
+      "nextUpdateTime": 1535525085673,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535416158831,
+      "nextUpdateTime": 1535665286918,
       "userAction": ""
     },
     "pixel.tapad.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535565660114,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535312220420,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535454303618,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535543028633,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535551623961,
+      "nextUpdateTime": 1535298519588,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535551158517,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "play.google.com": {
@@ -1899,13 +2163,13 @@
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535344024587,
+      "nextUpdateTime": 1535737640371,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535402866178,
+      "nextUpdateTime": 1535668829519,
       "userAction": ""
     },
     "plus.google.com": {
@@ -1917,19 +2181,25 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535475065526,
+      "nextUpdateTime": 1535606931325,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695656230,
+      "nextUpdateTime": 1535421638602,
       "userAction": ""
     },
     "postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pr-bh.ybp.yahoo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535293929134,
       "userAction": ""
     },
     "prfct.co": {
@@ -1944,22 +2214,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "profile.justuno.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535623328400,
+      "userAction": ""
+    },
     "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535335077582,
+      "nextUpdateTime": 1535551954716,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535557003492,
+      "nextUpdateTime": 1535593545310,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535530459475,
+      "nextUpdateTime": 1535583692664,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -1971,43 +2247,49 @@
     "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535391786951,
+      "nextUpdateTime": 1535370162061,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535634385364,
+      "nextUpdateTime": 1535542087750,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477757297,
+      "nextUpdateTime": 1535646457589,
       "userAction": ""
     },
-    "px0.pbbl.co": {
+    "px.owneriq.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535602689619,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535403538242,
+      "userAction": ""
+    },
+    "px.steelhousemedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535353388308,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535603192843,
+      "nextUpdateTime": 1535419488708,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535465840376,
+      "nextUpdateTime": 1535369878735,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535324744755,
+      "nextUpdateTime": 1535360796345,
       "userAction": ""
     },
     "quantserve.com": {
@@ -2025,13 +2307,7 @@
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535565958781,
-      "userAction": ""
-    },
-    "r.turn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535642093402,
+      "nextUpdateTime": 1535352011476,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2043,25 +2319,31 @@
     "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535707841720,
+      "nextUpdateTime": 1535286295528,
+      "userAction": ""
+    },
+    "rcom.dynamicyield.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535306518026,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535417435881,
+      "nextUpdateTime": 1535694908698,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535639045889,
+      "nextUpdateTime": 1535378845796,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535700009586,
+      "nextUpdateTime": 1535430722611,
       "userAction": ""
     },
     "rfihub.com": {
@@ -2085,19 +2367,19 @@
     "rp.gwallet.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535459268205,
+      "nextUpdateTime": 1535722022072,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535550689197,
+      "nextUpdateTime": 1535789545771,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535581477119,
+      "nextUpdateTime": 1535426725737,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -2106,118 +2388,118 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rudy.adsnative.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535306716979,
-      "userAction": ""
-    },
     "s-static.ak.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "s-vop.sundaysky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535565498310,
-      "userAction": ""
-    },
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535550767486,
+      "nextUpdateTime": 1535544352908,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535303185049,
+      "nextUpdateTime": 1535604512693,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535203984775,
+      "nextUpdateTime": 1535629576922,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535631922807,
+      "nextUpdateTime": 1535598595757,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584011160,
+      "nextUpdateTime": 1535337571271,
       "userAction": ""
     },
     "s.po.st": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535623990141,
+      "nextUpdateTime": 1535309914794,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535318932345,
+      "nextUpdateTime": 1535468509231,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535433040753,
+      "nextUpdateTime": 1535566474727,
       "userAction": ""
     },
     "s.yimg.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535497825993,
+      "nextUpdateTime": 1535661147872,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535629850574,
+      "nextUpdateTime": 1535527772076,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535349679166,
+      "nextUpdateTime": 1535375732663,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535575186441,
+      "nextUpdateTime": 1535418939591,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535543506276,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535312742531,
+      "userAction": ""
+    },
+    "salesforceliveagent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535220699469,
+      "nextUpdateTime": 1535671086115,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535336371028,
+      "nextUpdateTime": 1535415217899,
+      "userAction": ""
+    },
+    "sbnationbidder-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535520014307,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535559224450,
+      "nextUpdateTime": 1535492741324,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2229,13 +2511,19 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535313735845,
+      "nextUpdateTime": 1535722846588,
+      "userAction": ""
+    },
+    "script.ioam.de": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535628154957,
+      "nextUpdateTime": 1535778464447,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2247,85 +2535,85 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535474812376,
+      "nextUpdateTime": 1535511738519,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535444155546,
+      "nextUpdateTime": 1535642980054,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535642753805,
+      "nextUpdateTime": 1535738150884,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535276310459,
+      "nextUpdateTime": 1535510232378,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535363543163,
+      "nextUpdateTime": 1535389044916,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535565120595,
+      "nextUpdateTime": 1535444722549,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535443585948,
+      "nextUpdateTime": 1535337220991,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535404481201,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535346501751,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535212835954,
+      "nextUpdateTime": 1535490196521,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535409011676,
+      "nextUpdateTime": 1535340041154,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315990216,
+      "nextUpdateTime": 1535662738397,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535378697325,
+      "nextUpdateTime": 1535494946898,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535505097650,
+      "nextUpdateTime": 1535708162903,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695255538,
+      "nextUpdateTime": 1535436904126,
       "userAction": ""
     },
     "self.com": {
@@ -2361,7 +2649,7 @@
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535645884557,
+      "nextUpdateTime": 1535443540105,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -2391,7 +2679,7 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535365253512,
+      "nextUpdateTime": 1535591895325,
       "userAction": ""
     },
     "snapchat.com": {
@@ -2415,7 +2703,7 @@
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535640486680,
+      "nextUpdateTime": 1535500469983,
       "userAction": ""
     },
     "spotxchange.com": {
@@ -2430,46 +2718,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-24-09.config.parsely.com": {
+    "srv-2018-08-25-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535421211051,
+      "nextUpdateTime": 1535320516701,
       "userAction": ""
     },
-    "srv-2018-08-24-09.pixel.parsely.com": {
+    "srv-2018-08-25-09.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535480074393,
+      "nextUpdateTime": 1535492273466,
       "userAction": ""
     },
-    "srv-2018-08-24-10.config.parsely.com": {
+    "srv-2018-08-25-10.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695203010,
+      "nextUpdateTime": 1535675261339,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535594397444,
+      "nextUpdateTime": 1535327444761,
+      "userAction": ""
+    },
+    "ssl.siteimprove.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535590743011,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535476159880,
+      "nextUpdateTime": 1535583569862,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535566753682,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535766135977,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535525489997,
+      "nextUpdateTime": 1535591035984,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2487,19 +2781,19 @@
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535296389449,
+      "nextUpdateTime": 1535419436462,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535384977874,
+      "nextUpdateTime": 1535526724439,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535579789908,
+      "nextUpdateTime": 1535354675061,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2510,14 +2804,20 @@
     },
     "stats.g.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535305848007,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535449503047,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535595376018,
+      "nextUpdateTime": 1535353496047,
+      "userAction": ""
+    },
+    "steelhousemedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "stripe.com": {
@@ -2529,13 +2829,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535537728387,
-      "userAction": ""
-    },
-    "sundaysky-partners.tremorhub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535518349440,
+      "nextUpdateTime": 1535385706713,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2547,61 +2841,67 @@
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535345993866,
+      "nextUpdateTime": 1535466735514,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535219408003,
+      "nextUpdateTime": 1535402210709,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535630811315,
+      "nextUpdateTime": 1535601519697,
+      "userAction": ""
+    },
+    "sync.adaptv.advertising.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535354555122,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535488277961,
+      "nextUpdateTime": 1535721836756,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535485112515,
+      "nextUpdateTime": 1535707308539,
       "userAction": ""
     },
     "sync.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535636613941,
+      "nextUpdateTime": 1535279621142,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535208558420,
+      "nextUpdateTime": 1535481640591,
       "userAction": ""
     },
     "sync.multiview.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535457905320,
+      "nextUpdateTime": 1535782023227,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535247764908,
+      "nextUpdateTime": 1535286963228,
       "userAction": ""
     },
     "sync.teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535553055729,
+      "nextUpdateTime": 1535597792238,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2619,7 +2919,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535682805604,
+      "nextUpdateTime": 1535325417249,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -2628,16 +2928,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tap-secure.rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535448475939,
+      "userAction": ""
+    },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tapestry.tapad.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535412121553,
       "userAction": ""
     },
     "teads.tv": {
@@ -2652,13 +2952,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "technolutions.net": {
+    "teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "teenvogue.com": {
+    "theadex.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2673,13 +2973,13 @@
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535397495968,
+      "nextUpdateTime": 1535452783142,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535457769814,
+      "nextUpdateTime": 1535746635108,
       "userAction": ""
     },
     "tinypass.com": {
@@ -2691,7 +2991,7 @@
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535559796030,
+      "nextUpdateTime": 1535550935721,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -2703,19 +3003,19 @@
     "top100.rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535674487346,
+      "nextUpdateTime": 1535684529979,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535666639786,
+      "nextUpdateTime": 1535544639408,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535318646462,
+      "nextUpdateTime": 1535567234151,
       "userAction": ""
     },
     "translate.google.com": {
@@ -2727,7 +3027,7 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535582467003,
+      "nextUpdateTime": 1535732628184,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -2745,7 +3045,7 @@
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535228762576,
+      "nextUpdateTime": 1535545230967,
       "userAction": ""
     },
     "turn.com": {
@@ -2760,28 +3060,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tynt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535428488428,
+      "nextUpdateTime": 1535784547100,
+      "userAction": ""
+    },
+    "ups.xplosion.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535314703086,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535274956469,
+      "nextUpdateTime": 1535688937954,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535305181818,
+      "nextUpdateTime": 1535597114866,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535662229786,
+      "nextUpdateTime": 1535432676742,
+      "userAction": ""
+    },
+    "va.v.liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535729794135,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -2793,6 +3111,12 @@
     "video.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2811,7 +3135,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535397114831,
+      "nextUpdateTime": 1535434926452,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -2823,13 +3147,19 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535291406968,
+      "nextUpdateTime": 1535472656099,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vop.sundaysky.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535338852200,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -2841,25 +3171,25 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535399516836,
+      "nextUpdateTime": 1535690600138,
       "userAction": ""
     },
     "wam-yahoo.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535574783124,
+      "nextUpdateTime": 1535775196955,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535422378909,
+      "nextUpdateTime": 1535325407427,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535334744593,
+      "nextUpdateTime": 1535709876484,
       "userAction": ""
     },
     "weborama.fr": {
@@ -2883,7 +3213,7 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535679663540,
       "userAction": ""
     },
     "wired.com": {
@@ -2907,19 +3237,25 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535342355123,
+      "nextUpdateTime": 1535335492897,
+      "userAction": ""
+    },
+    "ww.steelhousemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535556921277,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535686767683,
+      "nextUpdateTime": 1535475009981,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535568564540,
+      "nextUpdateTime": 1535491915288,
       "userAction": ""
     },
     "www.bing.com": {
@@ -2931,43 +3267,43 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535355718102,
+      "nextUpdateTime": 1535370836192,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535421728359,
+      "nextUpdateTime": 1535367117721,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535669005641,
+      "nextUpdateTime": 1535557439829,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535515969140,
+      "nextUpdateTime": 1535356981005,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535386038890,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535531778087,
+      "nextUpdateTime": 1535304134792,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535470694034,
+      "nextUpdateTime": 1535654060736,
       "userAction": ""
     },
     "www.google.com": {
@@ -2979,94 +3315,112 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535251051351,
+      "nextUpdateTime": 1535557201033,
+      "userAction": ""
+    },
+    "www.justuno.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535439526561,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535565021346,
+      "nextUpdateTime": 1535774798008,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535661590077,
+      "nextUpdateTime": 1535438867974,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535397837841,
+      "nextUpdateTime": 1535786649584,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535219280175,
+      "nextUpdateTime": 1535513903637,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535212377389,
+      "nextUpdateTime": 1535483680212,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535362442612,
+      "nextUpdateTime": 1535581539395,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535656763846,
+      "nextUpdateTime": 1535452630744,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535626436765,
+      "nextUpdateTime": 1535391747796,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535561837419,
+      "nextUpdateTime": 1535721812757,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535297112694,
+      "nextUpdateTime": 1535369389550,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535361254835,
+      "nextUpdateTime": 1535752078138,
       "userAction": ""
     },
     "www.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535629604233,
+      "nextUpdateTime": 1535659930279,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535279920046,
+      "nextUpdateTime": 1535279092662,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535458765015,
+      "nextUpdateTime": 1535589911304,
       "userAction": ""
     },
     "xiti.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xpl.theadex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535345322663,
+      "userAction": ""
+    },
+    "xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3096,6 +3450,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yimg.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3111,19 +3471,19 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535637470267,
+      "nextUpdateTime": 1535353268865,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535478471197,
+      "nextUpdateTime": 1535603698010,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535189816756,
+      "nextUpdateTime": 1535719784949,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3175,7 +3535,6 @@
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
-      "philips.com",
       "oclc.org"
     ],
     "33across.com": [
@@ -3195,14 +3554,14 @@
     "3gl.net": [
       "istockphoto.com",
       "gettyimages.com",
-      "economist.com"
+      "thedailybeast.com"
     ],
     "3lift.com": [
       "nature.com",
       "springer.com",
       "theverge.com",
-      "usatoday.com",
-      "newatlas.com"
+      "wunderground.com",
+      "focus.de"
     ],
     "4dsply.com": [
       "wnd.com"
@@ -3280,9 +3639,6 @@
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-plus.cn": [
-      "sohu.com"
-    ],
     "ad-score.com": [
       "wnd.com"
     ],
@@ -3310,8 +3666,7 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com",
-      "tinypic.com"
+      "washingtonexaminer.com"
     ],
     "addthis.com": [
       "nasa.gov",
@@ -3374,8 +3729,7 @@
     ],
     "admaster.com.cn": [
       "autohome.com.cn",
-      "bshare.cn",
-      "youku.com"
+      "bshare.cn"
     ],
     "admission.net": [
       "edmunds.com"
@@ -3388,7 +3742,7 @@
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "bostonherald.com"
+      "rfi.fr"
     ],
     "adobe.com": [
       "wikipedia.org",
@@ -3403,8 +3757,7 @@
     ],
     "adotmob.com": [
       "standard.co.uk",
-      "upwork.com",
-      "nypost.com"
+      "upwork.com"
     ],
     "adriver.ru": [
       "ria.ru",
@@ -3448,7 +3801,7 @@
       "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "economist.com",
+      "foursquare.com",
       "realtor.com"
     ],
     "adtags.pro": [
@@ -3492,7 +3845,8 @@
       "amazon.com",
       "t-online.de",
       "bloomberg.com",
-      "cnet.com"
+      "cnet.com",
+      "gizmodo.com"
     ],
     "aid-ad.jp": [
       "shinobi.jp"
@@ -3512,7 +3866,8 @@
       "voanews.com",
       "repubblica.it",
       "iyfubh.com",
-      "forbes.com"
+      "forbes.com",
+      "francetvinfo.fr"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -3532,8 +3887,8 @@
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
-      "sohu.com",
-      "aliexpress.com"
+      "tmall.com",
+      "1688.com"
     ],
     "alipay.com": [
       "alibaba.com",
@@ -3584,7 +3939,8 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "navy.mil"
+      "nasa.gov",
+      "walgreens.com"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -3595,8 +3951,7 @@
     "aol.com": [
       "engadget.com",
       "indiatimes.com",
-      "autoblog.com",
-      "techcrunch.com"
+      "autoblog.com"
     ],
     "ap.org": [
       "post-gazette.com"
@@ -3613,7 +3968,6 @@
       "foursquare.com",
       "history.com",
       "nbc.com",
-      "airbnb.com",
       "strava.com"
     ],
     "appdynamics.com": [
@@ -3693,7 +4047,7 @@
       "sina.com.cn",
       "163.com",
       "ifeng.com",
-      "sohu.com"
+      "51.la"
     ],
     "bam-x.com": [
       "gq.com"
@@ -3756,15 +4110,14 @@
       "adobe.com",
       "dailymotion.com",
       "hootsuite.com",
-      "hp.com",
-      "box.com"
+      "hp.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
       "amazon.com",
       "forbes.com",
-      "newatlas.com"
+      "bostonherald.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -3778,7 +4131,6 @@
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "microsoft.com",
       "pingdom.com"
     ],
     "bitbucket.org": [
@@ -3788,11 +4140,12 @@
       "eventbrite.com",
       "cloudflare.com",
       "zendesk.com",
-      "ibm.com",
+      "shutterstock.com",
       "gitlab.com"
     ],
     "bizibly.com": [
-      "eventbrite.com"
+      "eventbrite.com",
+      "cloudflare.com"
     ],
     "bizographics.com": [
       "zend.com",
@@ -3845,7 +4198,8 @@
       "pitchfork.com"
     ],
     "boston.com": [
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "bleacherreport.com"
     ],
     "bostonglobemedia.com": [
       "boston.com"
@@ -3882,13 +4236,14 @@
     "brightcove.net": [
       "lefigaro.fr",
       "politico.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "techtarget.com"
     ],
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
       "zendesk.com",
-      "livescience.com",
+      "uci.edu",
       "dailydot.com"
     ],
     "btttag.com": [
@@ -3931,7 +4286,7 @@
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
-      "gizmodo.com"
+      "pitchfork.com"
     ],
     "cbsi.com": [
       "zdnet.com",
@@ -4007,8 +4362,7 @@
     ],
     "clicktale.net": [
       "xbox.com",
-      "office.com",
-      "microsoft.com"
+      "office.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
@@ -4101,14 +4455,11 @@
       "rollingstone.com",
       "variety.com",
       "adweek.com",
-      "independent.co.uk",
+      "buzzfeed.com",
       "nme.com"
     ],
     "consumable.com": [
       "xfinity.com"
-    ],
-    "content.ad": [
-      "tinypic.com"
     ],
     "contentabc.com": [
       "pornhub.com"
@@ -4118,7 +4469,7 @@
       "myspace.com",
       "bloomberg.com",
       "forbes.com",
-      "coindesk.com"
+      "walgreens.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -4148,7 +4499,7 @@
       "digitaltrends.com",
       "techradar.com",
       "independent.co.uk",
-      "apartmenttherapy.com"
+      "rfi.fr"
     ],
     "cquotient.com": [
       "gopro.com"
@@ -4270,7 +4621,8 @@
     "deployads.com": [
       "tinyurl.com",
       "lycos.com",
-      "sciencedaily.com"
+      "sciencedaily.com",
+      "zerohedge.com"
     ],
     "deqwas.net": [
       "rakuten.co.jp"
@@ -4280,6 +4632,9 @@
     ],
     "dezeenjobs.com": [
       "dezeen.com"
+    ],
+    "df-srv.de": [
+      "focus.de"
     ],
     "dhs.gov": [
       "fema.gov"
@@ -4308,7 +4663,6 @@
       "britannica.com",
       "lifehacker.com",
       "express.co.uk",
-      "gizmodo.com",
       "bostonherald.com"
     ],
     "disney.com": [
@@ -4328,6 +4682,7 @@
       "barnesandnoble.com",
       "urbandictionary.com",
       "axs.com",
+      "timeanddate.com",
       "newatlas.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
@@ -4346,8 +4701,7 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com",
-      "slashdot.org"
+      "tinypic.com"
     ],
     "dotomi.com": [
       "tinyurl.com",
@@ -4364,7 +4718,7 @@
       "twitter.com",
       "linkedin.com",
       "sourceforge.net",
-      "virginia.gov"
+      "focus.de"
     ],
     "doublemax.net": [
       "udn.com"
@@ -4382,7 +4736,11 @@
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com"
+      "techtarget.com",
+      "adweek.com"
+    ],
+    "dxpmedia.com": [
+      "autohome.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4478,6 +4836,9 @@
       "vanityfair.com",
       "pitchfork.com"
     ],
+    "epital.gdn": [
+      "4shared.com"
+    ],
     "equalstyle.com": [
       "hubpages.com"
     ],
@@ -4490,7 +4851,11 @@
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "lefigaro.fr"
+      "lefigaro.fr",
+      "sfgate.com"
+    ],
+    "etahub.com": [
+      "pornhub.com"
     ],
     "etracker.de": [
       "sedo.com"
@@ -4508,7 +4873,7 @@
       "adobe.com",
       "yahoo.com",
       "sourceforge.net",
-      "usatoday.com",
+      "tinyurl.com",
       "newatlas.com"
     ],
     "everyaction.com": [
@@ -4541,7 +4906,7 @@
       "soundcloud.com",
       "forbes.com",
       "bloomberg.com",
-      "talktalk.co.uk",
+      "businessinsider.com",
       "gizmodo.com"
     ],
     "exosrv.com": [
@@ -4554,6 +4919,7 @@
       "sourceforge.net",
       "forbes.com",
       "bloomberg.com",
+      "gizmodo.com",
       "heraldsun.com.au"
     ],
     "eyereturn.com": [
@@ -4562,7 +4928,6 @@
     ],
     "eyeviewads.com": [
       "staples.com",
-      "nypost.com",
       "walgreens.com"
     ],
     "ezoic.net": [
@@ -4574,7 +4939,7 @@
       "wordpress.org",
       "adobe.com",
       "nytimes.com",
-      "lexisnexis.com"
+      "focus.de"
     ],
     "facetz.net": [
       "novostimira.com",
@@ -4791,9 +5156,10 @@
       "linkedin.com",
       "google.de",
       "sourceforge.net",
+      "google.ca",
       "scmp.com",
       "chromium.org",
-      "designboom.com"
+      "focus.de"
     ],
     "gq.com": [
       "wired.com",
@@ -4833,7 +5199,6 @@
       "adobe.com",
       "ox.ac.uk",
       "ihg.com",
-      "economist.com",
       "business2community.com"
     ],
     "gwmtracking.com": [
@@ -4943,8 +5308,7 @@
     "ibillboard.com": [
       "springer.com",
       "home.pl",
-      "idnes.cz",
-      "t-online.de"
+      "idnes.cz"
     ],
     "ibt.com": [
       "newsweek.com",
@@ -4974,8 +5338,7 @@
     "im-apps.net": [
       "exblog.jp",
       "rakuten.co.jp",
-      "biglobe.ne.jp",
-      "economist.com"
+      "biglobe.ne.jp"
     ],
     "imagetopng.club": [
       "4shared.com"
@@ -4994,8 +5357,7 @@
     "impact-ad.jp": [
       "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp",
-      "economist.com"
+      "goo.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
@@ -5020,7 +5382,8 @@
       "ups.com"
     ],
     "inquisitr.com": [
-      "www.poznan.pl"
+      "www.poznan.pl",
+      "flipboard.com"
     ],
     "inside-graph.com": [
       "staples.com"
@@ -5045,8 +5408,7 @@
     ],
     "intentiq.com": [
       "sourceforge.net",
-      "symantec.com",
-      "slashdot.org"
+      "symantec.com"
     ],
     "intentmedia.net": [
       "hotels.com",
@@ -5057,6 +5419,7 @@
       "themeforest.net",
       "ft.com",
       "elegantthemes.com",
+      "bigcartel.com",
       "iconfinder.com"
     ],
     "intergient.com": [
@@ -5078,7 +5441,8 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com"
+      "xing.com",
+      "focus.de"
     ],
     "iolam.it": [
       "virgilio.it"
@@ -5086,7 +5450,8 @@
     "iperceptions.com": [
       "ford.com",
       "seagate.com",
-      "honeywell.com"
+      "honeywell.com",
+      "boeing.com"
     ],
     "ipinyou.com": [
       "autohome.com.cn"
@@ -5102,8 +5467,7 @@
       "indianexpress.com"
     ],
     "janrainsso.com": [
-      "vancouversun.com",
-      "nationalpost.com"
+      "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
@@ -5133,7 +5497,8 @@
     "justuno.com": [
       "gartner.com",
       "searchengineland.com",
-      "zenfolio.com"
+      "zenfolio.com",
+      "gopro.com"
     ],
     "jword.jp": [
       "excite.co.jp"
@@ -5164,9 +5529,6 @@
     "kiwiirc.com": [
       "enlightenment.org"
     ],
-    "knet.cn": [
-      "dzwww.com"
-    ],
     "krxd.net": [
       "inhabitat.com",
       "bgr.com",
@@ -5196,7 +5558,7 @@
       "webmd.com",
       "nj.com",
       "patch.com",
-      "economist.com",
+      "bloomberg.com",
       "washingtonexaminer.com"
     ],
     "libero.it": [
@@ -5217,14 +5579,14 @@
       "zdnet.com",
       "fastcompany.com",
       "adweek.com",
-      "mashable.com",
+      "gizmodo.com",
       "dailycaller.com"
     ],
     "lijit.com": [
       "sourceforge.net",
       "bloomberg.com",
       "deviantart.com",
-      "mirror.co.uk",
+      "uci.edu",
       "infoplease.com"
     ],
     "lincoln.com": [
@@ -5257,7 +5619,8 @@
       "skype.com",
       "msn.com",
       "bing.com",
-      "office.com"
+      "office.com",
+      "microsoft.com"
     ],
     "livechatinc.com": [
       "ning.com",
@@ -5275,7 +5638,8 @@
       "apache.org",
       "prnewswire.com",
       "ibm.com",
-      "talktalk.co.uk"
+      "talktalk.co.uk",
+      "lexisnexis.com"
     ],
     "lkqd.net": [
       "allafrica.com"
@@ -5322,14 +5686,12 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com",
-      "yandex.ru"
+      "google.com"
     ],
     "mailchimp.com": [
       "colorlib.com",
       "fas.org",
-      "tias.com",
-      "nap.edu"
+      "tias.com"
     ],
     "mantisadnetwork.com": [
       "tvtropes.org"
@@ -5351,6 +5713,7 @@
       "panasonic.com",
       "dyn.com",
       "searchengineland.com",
+      "hootsuite.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
@@ -5363,7 +5726,7 @@
       "vimeo.com",
       "sourceforge.net",
       "forbes.com",
-      "dailydot.com"
+      "pitchfork.com"
     ],
     "media.net": [
       "nytimes.com",
@@ -5394,7 +5757,8 @@
     "mediarithmics.com": [
       "orange.fr",
       "lynda.com",
-      "liberation.fr"
+      "liberation.fr",
+      "leparisien.fr"
     ],
     "mediav.com": [
       "ctrip.com",
@@ -5419,8 +5783,7 @@
     ],
     "metadsp.co.uk": [
       "nypost.com",
-      "standard.co.uk",
-      "variety.com"
+      "standard.co.uk"
     ],
     "mg2connext.com": [
       "mercurynews.com",
@@ -5449,6 +5812,7 @@
       "live.com",
       "skype.com",
       "or.kr",
+      "msn.com",
       "office.com",
       "xbox.com",
       "complex.com"
@@ -5464,7 +5828,7 @@
       "parallels.com",
       "prnewswire.com",
       "zend.com",
-      "oreilly.com",
+      "nginx.com",
       "pingdom.com"
     ],
     "ml314.com": [
@@ -5472,7 +5836,7 @@
       "forbes.com",
       "bloomberg.com",
       "wsj.com",
-      "dailydot.com"
+      "zerohedge.com"
     ],
     "mlb.com": [
       "nhl.com"
@@ -5484,7 +5848,7 @@
       "alibaba.com",
       "youku.com",
       "taobao.com",
-      "sohu.com"
+      "aliexpress.com"
     ],
     "mmtro.com": [
       "upwork.com"
@@ -5577,7 +5941,8 @@
       "zappos.com"
     ],
     "narrative.io": [
-      "sourceforge.net"
+      "sourceforge.net",
+      "gizmodo.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -5691,7 +6056,7 @@
       "sourceforge.net",
       "wsj.com",
       "oracle.com",
-      "washingtonpost.com",
+      "huffingtonpost.com",
       "helsinki.fi"
     ],
     "nsaudience.pl": [
@@ -5764,13 +6129,13 @@
       "springer.com",
       "standard.co.uk",
       "home.pl",
-      "variety.com"
+      "skyrock.com"
     ],
     "omtrdc.net": [
       "adobe.com",
       "amazon.com",
       "telegraph.co.uk",
-      "intel.com",
+      "marriott.com",
       "eset.com"
     ],
     "onclickmega.com": [
@@ -5846,6 +6211,7 @@
       "springer.com",
       "cbsnews.com",
       "foxnews.com",
+      "constantcontact.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
@@ -5862,6 +6228,7 @@
       "history.com",
       "bestbuy.com",
       "jamanetwork.com",
+      "www.nhs.uk",
       "imageshack.com",
       "atlassian.com",
       "dallasnews.com",
@@ -5912,7 +6279,7 @@
       "scribd.com",
       "foxnews.com",
       "cnn.com",
-      "pitchfork.com"
+      "focus.de"
     ],
     "ovh.com": [
       "ovh.co.uk"
@@ -5920,7 +6287,8 @@
     "owneriq.net": [
       "lycos.com",
       "lg.com",
-      "washingtontimes.com"
+      "washingtontimes.com",
+      "pitchfork.com"
     ],
     "owox.com": [
       "simplesite.com"
@@ -5951,9 +6319,6 @@
     ],
     "payroll.com": [
       "intuit.com"
-    ],
-    "pbbl.co": [
-      "zappos.com"
     ],
     "pbskids.org": [
       "pbs.org"
@@ -6041,8 +6406,7 @@
     "powerlinks.com": [
       "lemonde.fr",
       "livescience.com",
-      "standard.co.uk",
-      "variety.com"
+      "standard.co.uk"
     ],
     "pressboard.ca": [
       "observer.com"
@@ -6174,8 +6538,7 @@
       "eset.com"
     ],
     "rackcdn.com": [
-      "frontiersin.org",
-      "post-gazette.com"
+      "frontiersin.org"
     ],
     "radiotime.com": [
       "tunein.com"
@@ -6204,6 +6567,9 @@
     "reddit.com": [
       "acm.org",
       "perl.com"
+    ],
+    "redditmedia.com": [
+      "reddit.com"
     ],
     "redlink.com": [
       "jamanetwork.com",
@@ -6247,14 +6613,18 @@
       "bankrate.com"
     ],
     "rezync.com": [
-      "economist.com"
+      "economist.com",
+      "salon.com"
     ],
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
       "npr.org",
-      "forbes.com",
+      "foursquare.com",
       "gopro.com"
+    ],
+    "rhombusads.com": [
+      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6275,7 +6645,7 @@
       "time.com",
       "wired.com",
       "cbsnews.com",
-      "zdnet.com",
+      "npr.org",
       "gizmodo.com"
     ],
     "rlcdn.com": [
@@ -6305,11 +6675,13 @@
     ],
     "rtk.io": [
       "post-gazette.com",
+      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
-      "bloomberg.com"
+      "bloomberg.com",
+      "uci.edu"
     ],
     "rubiconproject.com": [
       "yahoo.com",
@@ -6323,7 +6695,8 @@
       "alternet.org"
     ],
     "rutarget.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "ria.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "codepen.io",
@@ -6337,11 +6710,15 @@
     "sabavision.com": [
       "mihanblog.com"
     ],
+    "salecycle.com": [
+      "talktalk.co.uk"
+    ],
     "salesforceliveagent.com": [
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
-      "salesforce.com"
+      "salesforce.com",
+      "eset.com"
     ],
     "salesloft.com": [
       "techtarget.com",
@@ -6355,9 +6732,6 @@
       "imdb.com",
       "gizmodo.com",
       "lifehacker.com"
-    ],
-    "samplicio.us": [
-      "reddit.com"
     ],
     "sbal4kp.com": [
       "dropbox.com"
@@ -6457,7 +6831,7 @@
       "dropbox.com",
       "t-online.de",
       "nbcnews.com",
-      "businessinsider.com",
+      "npr.org",
       "hgtv.com"
     ],
     "sessioncam.com": [
@@ -6472,13 +6846,14 @@
       "www.uk.com",
       "whatsapp.com",
       "lycos.com",
-      "bloomberg.com",
-      "bl.uk"
+      "uci.edu",
+      "dailycaller.com"
     ],
     "sharethrough.com": [
       "yahoo.com",
       "cnn.com",
       "time.com",
+      "cnet.com",
       "walgreens.com"
     ],
     "sheego.de": [
@@ -6492,6 +6867,9 @@
     "shopify.com": [
       "codepen.io",
       "raspberrypi.org"
+    ],
+    "sibautomation.com": [
+      "themeisle.com"
     ],
     "simplereach.com": [
       "theatlantic.com"
@@ -6522,6 +6900,7 @@
       "udel.edu",
       "berkeley.edu",
       "jhu.edu",
+      "helsinki.fi",
       "case.edu",
       "oclc.org"
     ],
@@ -6540,7 +6919,7 @@
       "barnesandnoble.com",
       "tinypic.com",
       "seattletimes.com",
-      "slashdot.org",
+      "sciencedaily.com",
       "networksolutions.com"
     ],
     "skimresources.com": [
@@ -6560,7 +6939,8 @@
     "smartadserver.com": [
       "springer.com",
       "skyrock.com",
-      "sapo.pt"
+      "sapo.pt",
+      "elpais.com"
     ],
     "smartclip.net": [
       "infoplease.com"
@@ -6639,7 +7019,7 @@
       "photobucket.com",
       "deviantart.com",
       "springer.com",
-      "myspace.com",
+      "forbes.com",
       "detroitnews.com"
     ],
     "sonyentertainmentnetwork.com": [
@@ -6649,7 +7029,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "irishtimes.com",
+      "independent.ie",
       "mo.gov"
     ],
     "sourceforge.net": [
@@ -6745,7 +7125,8 @@
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "istockphoto.com"
+      "istockphoto.com",
+      "careerbuilder.com"
     ],
     "steepto.com": [
       "liveleak.com"
@@ -6793,7 +7174,7 @@
       "overstock.com",
       "alternet.org",
       "infoplease.com",
-      "careerbuilder.com"
+      "dailydot.com"
     ],
     "suning.com": [
       "qq.com",
@@ -6804,7 +7185,8 @@
       "yesky.com"
     ],
     "supplyframe.com": [
-      "ti.com"
+      "ti.com",
+      "arduino.cc"
     ],
     "survata.com": [
       "tripadvisor.com"
@@ -6812,7 +7194,8 @@
     "surveymonkey.com": [
       "cambridge.org",
       "investopedia.com",
-      "foreignpolicy.com"
+      "foreignpolicy.com",
+      "iop.org"
     ],
     "switchadhub.com": [
       "lycos.com",
@@ -6843,7 +7226,8 @@
       "overstock.com"
     ],
     "tailtarget.com": [
-      "uol.com.br"
+      "uol.com.br",
+      "variety.com"
     ],
     "tamgrt.com": [
       "tripadvisor.com",
@@ -6853,7 +7237,7 @@
       "sina.com.cn",
       "alibaba.com",
       "ifeng.com",
-      "sohu.com"
+      "tmall.com"
     ],
     "taobao.com": [
       "sina.com.cn",
@@ -6866,7 +7250,7 @@
       "yahoo.com",
       "soundcloud.com",
       "paypal.com",
-      "bostonherald.com"
+      "networksolutions.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -6892,8 +7276,7 @@
       "illinois.edu",
       "upenn.edu",
       "uci.edu",
-      "udel.edu",
-      "case.edu"
+      "udel.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -6916,7 +7299,8 @@
     "theadex.com": [
       "t-online.de",
       "gnu.org",
-      "spiegel.de"
+      "spiegel.de",
+      "focus.de"
     ],
     "theatlas.com": [
       "qz.com"
@@ -6960,7 +7344,7 @@
       "businessinsider.com",
       "techcrunch.com",
       "kickstarter.com",
-      "cnbc.com",
+      "bloomberg.com",
       "gizmodo.com"
     ],
     "tiqcdn.com": [
@@ -7090,7 +7474,7 @@
       "bloomberg.com",
       "wired.com",
       "webmd.com",
-      "hp.com",
+      "tinyurl.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
@@ -7113,13 +7497,15 @@
       "chicagotribune.com",
       "nytimes.com",
       "cnn.com",
-      "cnet.com",
-      "rfi.fr"
+      "msn.com",
+      "lexisnexis.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com"
+      "washingtontimes.com",
+      "salon.com",
+      "dailycaller.com"
     ],
     "ubi.com": [
       "ubisoft.com"
@@ -7149,6 +7535,9 @@
       "cnn.com",
       "nba.com"
     ],
+    "ultimedia.com": [
+      "sfgate.com"
+    ],
     "undertone.com": [
       "dallasnews.com",
       "alternet.org"
@@ -7162,8 +7551,7 @@
     "unrulymedia.com": [
       "nypost.com",
       "earthlink.net",
-      "boingboing.net",
-      "networkadvertising.org"
+      "boingboing.net"
     ],
     "upravel.com": [
       "rambler.ru",
@@ -7195,7 +7583,6 @@
       "scotsman.com"
     ],
     "uservoice.com": [
-      "scoop.it",
       "theknot.com"
     ],
     "ustream.tv": [
@@ -7249,24 +7636,26 @@
       "cbc.ca"
     ],
     "videoamp.com": [
-      "hpe.com"
+      "hpe.com",
+      "alternet.org"
     ],
     "videohub.tv": [
       "liveuamap.com",
       "wsj.com",
-      "bloomberg.com"
+      "uci.edu"
     ],
     "vidible.tv": [
       "aol.com",
       "nydailynews.com",
       "autoblog.com",
-      "huffingtonpost.com"
+      "techcrunch.com"
     ],
     "viglink.com": [
       "zdnet.com",
       "softonic.com",
       "techrepublic.com",
-      "cnet.com"
+      "cnet.com",
+      "dailycaller.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
@@ -7301,8 +7690,7 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru",
-      "yandex.ru"
+      "ria.ru"
     ],
     "vmmpxl.com": [
       "networksolutions.com"
@@ -7331,7 +7719,7 @@
       "hpe.com",
       "ebay.com",
       "sourceforge.net",
-      "pbs.org"
+      "hp.com"
     ],
     "wal.co": [
       "walmart.com"
@@ -7438,8 +7826,7 @@
     "wistia.com": [
       "zendesk.com",
       "typeform.com",
-      "photoshelter.com",
-      "buffer.com"
+      "photoshelter.com"
     ],
     "wistia.net": [
       "nielsen.com"
@@ -7536,7 +7923,8 @@
     "xplosion.de": [
       "t-online.de",
       "spiegel.de",
-      "faz.net"
+      "faz.net",
+      "focus.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
@@ -7589,7 +7977,8 @@
       "spiegel.de",
       "heise.de",
       "faz.net",
-      "t-online.de"
+      "t-online.de",
+      "focus.de"
     ],
     "yieldoptimizer.com": [
       "ihg.com",
@@ -7600,6 +7989,9 @@
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
+      "dropbox.com",
+      "iop.org",
+      "sbs.com.au",
       "eset.com"
     ],
     "yldbt.com": [
@@ -7632,7 +8024,7 @@
       "nih.gov",
       "telegraph.co.uk",
       "caltech.edu",
-      "ahajournals.org",
+      "dailykos.com",
       "honeywell.com"
     ],
     "youvisit.com": [
@@ -7673,7 +8065,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "marketwatch.com"
+      "wunderground.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -7705,5 +8097,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.24"
+  "version": "2018.8.25"
 }

--- a/results.json
+++ b/results.json
@@ -3,13 +3,13 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535295667139,
+      "nextUpdateTime": 1535131518617,
       "userAction": ""
     },
     "112-tzm-766.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535189289123,
+      "nextUpdateTime": 1535149513388,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -24,45 +24,111 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "126.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "127.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "15gifts.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535312804098,
+      "nextUpdateTime": 1535203312039,
       "userAction": ""
     },
-    "20798148p.rfihub.com": {
+    "1dmp.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535134607453,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "2771890.fls.doubleclick.net": {
+    "1rx.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535331723304,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "23video.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "247-inc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535040469247,
+      "nextUpdateTime": 1535391580217,
       "userAction": ""
     },
-    "2ecd5.v.fwmrm.net": {
+    "2mdnsys.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535364762306,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "2o7.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "33across.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360buyimg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360yield.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "3gl.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -75,145 +141,223 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535356269183,
+      "nextUpdateTime": 1535288564686,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535074621092,
-      "userAction": ""
-    },
-    "4303900.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535426959834,
+      "nextUpdateTime": 1535556755499,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535137738544,
+      "nextUpdateTime": 1535616677370,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535183264209,
+      "nextUpdateTime": 1535547398351,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535280524361,
+      "nextUpdateTime": 1535592234323,
+      "userAction": ""
+    },
+    "4924464.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535440457062,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535472616612,
+      "nextUpdateTime": 1535276170445,
+      "userAction": ""
+    },
+    "4dsply.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "50bang.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535031682414,
+      "nextUpdateTime": 1535593380762,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535215572202,
+      "nextUpdateTime": 1535321145910,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535177286890,
+      "nextUpdateTime": 1535482911467,
+      "userAction": ""
+    },
+    "58.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "58cdn.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "5p4rk13.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535018916902,
+      "nextUpdateTime": 1535371657297,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535274302650,
+      "nextUpdateTime": 1535167279610,
       "userAction": ""
     },
-    "6954342.fls.doubleclick.net": {
+    "6sc.co": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535389775911,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "7eer.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "7grid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445598247,
+      "nextUpdateTime": 1535524131585,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535518717819,
+      "nextUpdateTime": 1535340362267,
+      "userAction": ""
+    },
+    "8329645.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535353449192,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535325869162,
+      "nextUpdateTime": 1535615993684,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535522409644,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535133497126,
+      "userAction": ""
+    },
+    "a.quora.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535405357388,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535199928678,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535490342215,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535405476367,
+      "nextUpdateTime": 1535378457839,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535121490945,
+      "nextUpdateTime": 1535161779696,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535247839389,
+      "nextUpdateTime": 1535211637737,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535208406610,
+      "nextUpdateTime": 1535563194232,
       "userAction": ""
     },
-    "aa.agkn.com": {
+    "aamcftag.aamsitecertifier.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535518074755,
+      "userAction": ""
+    },
+    "aamsitecertifier.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535357668253,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535409461357,
+      "nextUpdateTime": 1535119827399,
+      "userAction": ""
+    },
+    "aaxads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "abmr.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "accessatlanta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -222,16 +366,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.us1.gigya.com": {
+    "accuweather.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535156435397,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535108086040,
+      "nextUpdateTime": 1535429731669,
+      "userAction": ""
+    },
+    "acint.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "acpm.fr": {
@@ -240,39 +390,123 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "action.media6degrees.com": {
+    "acquia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535233559120,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "actionnetwork.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1534640190001,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445319044,
+      "nextUpdateTime": 1535338170348,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535108800392,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535559735121,
       "userAction": ""
     },
-    "ad-score.com": {
+    "acuityplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "acxiomapac.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-stir.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-survey.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad.adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535280536254,
+      "userAction": ""
+    },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535102726609,
+      "nextUpdateTime": 1535264413152,
+      "userAction": ""
+    },
+    "ad.yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535443152680,
+      "userAction": ""
+    },
+    "adapf.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adaraanalytics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adc-srv.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adclear.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "addtoany.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adentifi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -282,9 +516,57 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adfox.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adfront.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adidas.fi": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adingo.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adition.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adjust-net.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adlmerge.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -294,16 +576,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "admaster.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "admiral.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535437438641,
+      "userAction": ""
+    },
+    "admission.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "admixer.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ado.pro-market.net": {
+    "adobe.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535519674298,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adotmob.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adroll.com": {
@@ -312,52 +636,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ads.adfox.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535192940943,
+      "userAction": ""
+    },
+    "ads.pro-market.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535166695414,
+      "userAction": ""
+    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535398864857,
+      "nextUpdateTime": 1535492314435,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535306789983,
+      "nextUpdateTime": 1535135614621,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535092678429,
-      "userAction": ""
-    },
-    "ads.twitter.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535426799358,
-      "userAction": ""
-    },
-    "ads.yahoo.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535030171231,
+      "nextUpdateTime": 1535549461468,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535335292087,
+      "nextUpdateTime": 1535393595473,
+      "userAction": ""
+    },
+    "adscale.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535060659368,
+      "nextUpdateTime": 1535585040406,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535399234345,
+      "nextUpdateTime": 1535485571758,
       "userAction": ""
     },
     "adsnative.com": {
@@ -366,7 +696,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adsniper.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "adsrvr.org": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -378,9 +720,63 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adtags.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adtdp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "advertur.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adwstats.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx.com.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adx1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adzerk.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aetnd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "afilio.com.br": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -390,10 +786,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aimfar.solution.weborama.fr": {
+    "aid-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aidata.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aili.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aimfr.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535397031257,
+      "nextUpdateTime": 1535494521452,
+      "userAction": ""
+    },
+    "ajx130.online": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "akamaihd.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "akamaized.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "albacross.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alibaba.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alicdn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alipay.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aliyun.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "allure.com": {
@@ -402,9 +864,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "am15.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "amazon.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -420,40 +894,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazonwebservices.d2.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535475655145,
+      "userAction": ""
+    },
+    "amazonwebservicesinc.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535384144806,
+      "userAction": ""
+    },
+    "ameba.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535221452777,
+      "nextUpdateTime": 1535542954455,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535417025823,
+      "nextUpdateTime": 1535381037838,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535346469077,
+      "nextUpdateTime": 1535613174595,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535137200226,
+      "nextUpdateTime": 1535108485791,
       "userAction": ""
     },
-    "an.yandex.ru": {
+    "and.co.uk": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535052792707,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "analytics.twitter.com": {
+    "answcdn.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535128575286,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -462,70 +954,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "antdsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aol.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aol.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ap.lijit.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535275471737,
+      "userAction": ""
+    },
+    "ap.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "apester.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535122809239,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535528849979,
+      "nextUpdateTime": 1535336991540,
       "userAction": ""
     },
-    "api-iam.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478349814,
-      "userAction": ""
-    },
-    "api-public.addthis.com": {
+    "api-cache.adsnative.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535028419051,
+      "nextUpdateTime": 1535575652992,
       "userAction": ""
     },
-    "api-v3.tinypass.com": {
+    "api.circularhub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535072558804,
+      "nextUpdateTime": 1535169145890,
       "userAction": ""
     },
-    "api.autopilothq.com": {
+    "api.company-target.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535149168850,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535317179596,
       "userAction": ""
     },
-    "api.bounceexchange.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535356553700,
-      "userAction": ""
-    },
-    "api.flyertown.ca": {
+    "api.ooyala.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535476779656,
-      "userAction": ""
-    },
-    "api.nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535271136144,
-      "userAction": ""
-    },
-    "api.pymx5.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535191722826,
-      "userAction": ""
-    },
-    "api.viglink.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535274925730,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apis.google.com": {
@@ -534,10 +1026,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "apn.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535159823561,
+      "nextUpdateTime": 1535218695801,
+      "userAction": ""
+    },
+    "appdynamics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "apple.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aqtracker.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "arcgis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -546,10 +1068,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "areyouahuman.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "arrivalist.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "art19.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535209374580,
+      "nextUpdateTime": 1535501468829,
+      "userAction": ""
+    },
+    "as.casalemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535229691374,
+      "userAction": ""
+    },
+    "asos-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "assets.adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535391921965,
+      "userAction": ""
+    },
+    "assets.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535530764372,
+      "userAction": ""
+    },
+    "atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atemda.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atgsvcs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ati-host.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "att.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -561,7 +1155,25 @@
     "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535345318345,
+      "nextUpdateTime": 1535164070585,
+      "userAction": ""
+    },
+    "audtd.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "auth.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "autoimg.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "autopilothq.com": {
@@ -573,43 +1185,133 @@
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535329606520,
+      "nextUpdateTime": 1535355659377,
+      "userAction": ""
+    },
+    "b.nativendo.de": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535538712482,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535101895013,
+      "nextUpdateTime": 1535483331527,
+      "userAction": ""
+    },
+    "b1img.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535115362722,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535505370686,
       "userAction": ""
     },
-    "ba.demdex.net": {
+    "b92.yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535152380703,
+      "nextUpdateTime": 1535148881205,
+      "userAction": ""
+    },
+    "baidu.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bam-x.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535143260433,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529473453,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535136901003,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535541829645,
+      "userAction": ""
+    },
+    "bazaarvoice.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbb.org": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbbpromos.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbc.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbelements.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535032191274,
+      "nextUpdateTime": 1535487258088,
+      "userAction": ""
+    },
+    "beacon.sojern.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529821305,
+      "userAction": ""
+    },
+    "beatport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "beemray.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "benchtag2.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "betweendigital.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bfmio.com": {
@@ -618,28 +1320,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bfmtv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535492243358,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535526427623,
       "userAction": ""
     },
     "bid.contextweb.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535179689143,
+      "nextUpdateTime": 1535484981338,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535233305767,
+      "nextUpdateTime": 1535558241739,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535143686901,
+      "nextUpdateTime": 1535327480100,
+      "userAction": ""
+    },
+    "biddingx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bidr.io": {
@@ -654,15 +1368,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bigmining.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bigmir.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bing.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "bitbucket.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizibly.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizrate.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "blogos.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bloomberg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluecava.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluemix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluetoad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bnidx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -684,16 +1476,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bounceexchange.com": {
+    "boston.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boxinc.sc.omtrdc.net": {
+    "botradar.tech": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535385321750,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "boudja.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bounceexchange.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535062904378,
+      "userAction": ""
+    },
+    "brandcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "brides.com": {
@@ -702,58 +1512,112 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bs.serving-sys.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535067213156,
-      "userAction": ""
-    },
-    "bs.yandex.ru": {
+    "brightcove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535529949166,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "britishairways.d3.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535552042196,
+      "userAction": ""
+    },
+    "bs.serving-sys.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535430149297,
+      "userAction": ""
+    },
+    "btlr.sharethrough.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535546439609,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535054886709,
+      "nextUpdateTime": 1535375679856,
+      "userAction": ""
+    },
+    "btttag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bumlam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c-ctrip.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535137900056,
+      "nextUpdateTime": 1535505105536,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535357523797,
+      "nextUpdateTime": 1535571444799,
       "userAction": ""
     },
-    "c.liadm.com": {
+    "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535145618083,
+      "nextUpdateTime": 1535584627640,
       "userAction": ""
     },
-    "c.statcounter.com": {
+    "c.jsrdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535528454733,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535253163372,
+      "userAction": ""
+    },
+    "c.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315021536,
+      "nextUpdateTime": 1535565223252,
       "userAction": ""
     },
-    "cache.vindicosuite.com": {
+    "c212.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535244807153,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c3tag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cadreon.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -762,22 +1626,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "caltat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "candlewoodsuites.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535234001824,
+      "nextUpdateTime": 1535596662850,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535045856033,
+      "nextUpdateTime": 1535590260745,
       "userAction": ""
     },
-    "casale-match.dotomi.com": {
+    "capturehighered.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535126325622,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "carambo.la": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -786,34 +1668,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cbsi.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cbsistatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ccgateway.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cdn-apple.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535438164044,
+      "nextUpdateTime": 1535214837676,
+      "userAction": ""
+    },
+    "cdn-hotels.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cdn-net.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535185919291,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535608709373,
+      "userAction": ""
+    },
+    "cdn.blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535256296804,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535051441601,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535493360512,
+      "userAction": ""
+    },
+    "cdn.districtm.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535490700346,
+      "userAction": ""
+    },
+    "cdn.dynamicyield.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535411948604,
+      "userAction": ""
+    },
+    "cdn.engine.addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535446078859,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535128940934,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535382379876,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535215121020,
+      "nextUpdateTime": 1535601702055,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -822,40 +1764,82 @@
       "nextUpdateTime": 1529084908284,
       "userAction": ""
     },
-    "cdn.oas-c18.adnxs.com": {
+    "cdn.onthe.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535290993902,
+      "nextUpdateTime": 1535353300697,
+      "userAction": ""
+    },
+    "cdn.pardot.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535617791411,
+      "userAction": ""
+    },
+    "cdn.static.zdbb.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535400873241,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535233843557,
+      "nextUpdateTime": 1535121167406,
       "userAction": ""
     },
-    "cdn.tt.omtrdc.net": {
+    "cdn.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535041458150,
+      "nextUpdateTime": 1535467316593,
       "userAction": ""
     },
     "cdn.viglink.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535427235391,
+      "nextUpdateTime": 1535566437816,
+      "userAction": ""
+    },
+    "cdn.yldbt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535334881641,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535106027323,
+      "nextUpdateTime": 1535143354964,
       "userAction": ""
     },
-    "cdns.gigya.com": {
+    "cdn2.lockerdome.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535141757175,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529533114,
+      "userAction": ""
+    },
+    "cdnwidget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cern.ch": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "changeagain.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "charitynavigator.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -867,7 +1851,79 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535242569428,
+      "nextUpdateTime": 1535134554501,
+      "userAction": ""
+    },
+    "chei.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chicagotribune.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinajob.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinaso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinavivaki.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "choozle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "circularhub.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "civicscience.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ckies.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clickability.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clicktale.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clicktripz.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -882,16 +1938,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "clmbtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cloudflare.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cm.e.qq.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535362642071,
+      "userAction": ""
+    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315162739,
+      "nextUpdateTime": 1535429314447,
+      "userAction": ""
+    },
+    "cm.l.qq.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535280560755,
+      "userAction": ""
+    },
+    "cms.tanx.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535240105058,
+      "userAction": ""
+    },
+    "cnet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535414582808,
+      "nextUpdateTime": 1535142903454,
+      "userAction": ""
+    },
+    "cnn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -900,10 +1998,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "collecte.audience.acpm.fr": {
+    "cnzz.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cobaltgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "coherentpath.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cohesionapps.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483507215,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "collector-963.tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535346254938,
+      "userAction": ""
+    },
+    "collegenet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "comm100.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "commander1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "company-target.com": {
@@ -912,10 +2052,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "condenast.demdex.net": {
+    "complex.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535403196330,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "conative.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -924,10 +2070,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "conductrics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "configusa.veinteractive.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535543444411,
+      "userAction": ""
+    },
+    "connatix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535381483975,
+      "nextUpdateTime": 1535174547715,
+      "userAction": ""
+    },
+    "connexity.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "consensu.org": {
@@ -936,22 +2106,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "consent.cmp.oath.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535501732621,
+      "userAction": ""
+    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumer.krxd.net": {
+    "consumable.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535345800844,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "contextual.media.net": {
+    "contentabc.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535058410852,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "contextweb.com": {
@@ -963,19 +2139,61 @@
     "conv-blizzard-emea.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535068114235,
+      "nextUpdateTime": 1535326160739,
       "userAction": ""
     },
     "conv-blizzard-na.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434015564,
+      "nextUpdateTime": 1535228455740,
+      "userAction": ""
+    },
+    "convertful.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "convertro.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "convio.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cornell.edu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535232747387,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535193184634,
+      "userAction": ""
+    },
+    "cox.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "coxbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cpex.cz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cpx.to": {
@@ -984,7 +2202,49 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cquotient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cr-nielsen.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecommons.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "criteo.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "croissed.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "crowneplaza.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "crsspxl.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -996,69 +2256,207 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cssrvsync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cstatic.weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535218329476,
+      "userAction": ""
+    },
+    "ct.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535231836071,
+      "userAction": ""
+    },
+    "ctv.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "curse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "custhelp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cx.atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535375224707,
+      "userAction": ""
+    },
     "cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "d.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535381374242,
-      "userAction": ""
-    },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535298770056,
-      "userAction": ""
-    },
-    "d.la1-c2-dfw.salesforceliveagent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535372426642,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535510911863,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535024017932,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535402065299,
       "userAction": ""
     },
-    "data.ad-score.com": {
+    "d1af033869koo7.cloudfront.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535525960694,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "data.dianomi.com": {
+    "d1rv23qj5kas56.cloudfront.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535390484851,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datacloud-us-east-1.tealiumiq.com": {
+    "d2-apps.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535073773964,
+      "nextUpdateTime": 1535313149602,
+      "userAction": ""
+    },
+    "d41.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "da-ads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dailymail.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dailymotion.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535167766489,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535127779521,
       "userAction": ""
     },
-    "dc.ads.linkedin.com": {
+    "datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "datasteam.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "daum.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "daumcdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "daumdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dc-storm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "de.ioam.de": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535494300698,
+      "nextUpdateTime": 1535553465126,
+      "userAction": ""
+    },
+    "deep.bi": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "delivery.h.switchadhub.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535249908051,
+      "userAction": ""
+    },
+    "dell.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "departapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "deployads.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "deqwas.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "developermedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1068,7 +2466,49 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dezeenjobs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dhs.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "di-dtaectolog-us-prod-1.appspot.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dictionary.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digikulture-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535473213147,
+      "userAction": ""
+    },
+    "digitaladsystems.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "digitaltarget.ru": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1080,16 +2520,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dis.us.criteo.com": {
+    "disney.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535051700652,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535248736855,
+      "nextUpdateTime": 1535514492739,
+      "userAction": ""
+    },
+    "disqus.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "distiltag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "districtm.io": {
@@ -1098,15 +2550,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "djv99sxoqpv11.cloudfront.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535207581785,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535278571573,
+      "userAction": ""
+    },
+    "dmxleo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dnnapi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dol.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "domdex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1116,16 +2598,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dotsub.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "doublemax.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "doublepimpssl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "doubleverify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dpm.demdex.net": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535220813510,
+      "userAction": ""
+    },
+    "dpmsrv.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535141129266,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1134,10 +2646,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dsum-sec.casalemedia.com": {
+    "dx.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535450697822,
+      "nextUpdateTime": 1535284046783,
+      "userAction": ""
+    },
+    "dynad.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1146,10 +2664,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eb2.3lift.com": {
+    "dynatrace-managed.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535466272567,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dyntrk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebay-us.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebay.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1158,7 +2700,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ebaystatic.com": {
+    "ebdr3.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ebis.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ecdn.firstimpression.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535480744702,
+      "userAction": ""
+    },
+    "econda-monitor.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ecustomeropinions.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "edge-cdn.net": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1167,7 +2739,13 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503094601,
+      "nextUpdateTime": 1535109055535,
+      "userAction": ""
+    },
+    "edmunds.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1182,10 +2760,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "em.licasd.com": {
+    "elsevier.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "elsevierhealth.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535483929811,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "emc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "emlgrid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "emxdgt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "engage.commander1.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535417679010,
+      "userAction": ""
+    },
+    "envato.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "epicurious.com": {
@@ -1194,22 +2808,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "equalstyle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "eset.marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535324409999,
+      "userAction": ""
+    },
     "eset.tt.omtrdc.net": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535172647379,
+      "userAction": ""
+    },
+    "espn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "estara.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "estat.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535323726127,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "etracker.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "etsystudio.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510670417,
+      "nextUpdateTime": 1535233686356,
       "userAction": ""
     },
-    "events.mediarithmics.com": {
+    "evenhotels.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535114411199,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "eventsabout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1218,10 +2880,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "everyaction.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535054385053,
+      "nextUpdateTime": 1535412667318,
+      "userAction": ""
+    },
+    "evise.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "evolok.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "evyy.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ew3.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ewscripps.hb.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535440360689,
+      "userAction": ""
+    },
+    "exactag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "excite.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "exe.bid": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "exelator.com": {
@@ -1230,10 +2946,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "exosrv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "expedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535128843717,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535550982016,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1242,28 +2970,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "eyereturn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ezoic.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 1535067712368,
+      "userAction": ""
+    },
+    "facetz.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fairfax.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fastcompany.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535385394512,
+      "nextUpdateTime": 1535532544281,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535108377514,
+      "nextUpdateTime": 1535476086076,
+      "userAction": ""
+    },
+    "fdlstatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "feathr.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1278,34 +3048,172 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ffx.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fidelity-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "filepicker.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "firstimpression.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flashtalking.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flickr.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flipboard.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flyercity.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "fo-api.omnitagjs.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535110977981,
+      "userAction": ""
+    },
+    "fontawesome.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foresee.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "forms.hubspot.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535114875943,
+      "userAction": ""
+    },
+    "formstack.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fout.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fox.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxbusiness.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535512337961,
+      "nextUpdateTime": 1535397455637,
+      "userAction": ""
+    },
+    "foxnews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxsports.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxycart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "freeskreen.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436668569,
+      "nextUpdateTime": 1535263330795,
+      "userAction": ""
+    },
+    "freshdesk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "friendbuy.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "funcaptcha.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "funnyordie.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "fusiontables.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "futurenet-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535071225476,
       "userAction": ""
     },
     "fwmrm.net": {
@@ -1316,62 +3224,104 @@
     },
     "g.cn.miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535399901695,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535463525932,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535240351512,
+      "userAction": ""
+    },
+    "g2crowd.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535330828661,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535259298411,
+      "nextUpdateTime": 1535282616525,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535101364820,
+      "nextUpdateTime": 1535324356929,
+      "userAction": ""
+    },
+    "gamer-network.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535176199996,
+      "nextUpdateTime": 1535406151780,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535402637759,
-      "userAction": ""
-    },
-    "gannett.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535343921291,
+      "nextUpdateTime": 1535595384247,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529600416,
+      "userAction": ""
+    },
+    "gemius.pl": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535452798906,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gentags.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535333296953,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535470476213,
       "userAction": ""
     },
-    "geosync.solution.weborama.fr": {
+    "getclicky.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535160445716,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getdrip.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getpocket.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "getsmartcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gfycat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gigya.com": {
@@ -1380,9 +3330,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "giphy.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "github.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "globalwebindex.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "gmossp-sp.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1398,6 +3372,18 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "goo.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "google.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "google.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1407,7 +3393,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535491836597,
+      "nextUpdateTime": 1535299738930,
       "userAction": ""
     },
     "gq.com": {
@@ -1419,7 +3405,19 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535227663022,
+      "nextUpdateTime": 1535232994108,
+      "userAction": ""
+    },
+    "gridsumdissector.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "groupondata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1428,27 +3426,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gscounters.us1.gigya.com": {
+    "gsimedia.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535212137627,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gslbeacon.lijit.com": {
+    "gssprt.jp": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535485285651,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gum.criteo.com": {
+    "gtags.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535290294755,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "guoshipartners.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1458,88 +3462,298 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hatena.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "hb-api.omnitagjs.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535189695673,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535149948702,
       "userAction": ""
     },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535078071521,
+      "nextUpdateTime": 1535528458660,
       "userAction": ""
     },
-    "i.liadm.com": {
+    "healte.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hearstnp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535529602945,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "help.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hiexpress.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "highwire.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hitslink.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hive.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hlserve.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hm.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535592367417,
+      "userAction": ""
+    },
+    "holidayinn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "holidayinnresorts.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "horyzon-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hotelindigo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hotelsapi.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "htmedia.in": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hubspot.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huffingtonpost.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huffingtonpost.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huihui.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hwcdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hypemarks.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "i.gridsumdissector.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535258286357,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535170174461,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535560008032,
       "userAction": ""
     },
-    "ib.3lift.com": {
+    "i.ua": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535403265784,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "i1img.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ib-ibi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535288809150,
+      "nextUpdateTime": 1535558901666,
       "userAction": ""
     },
-    "ic.tynt.com": {
+    "ibclick.stream": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535495293493,
+      "nextUpdateTime": 1535168630812,
       "userAction": ""
     },
-    "id.cxense.com": {
+    "ibillboard.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535496907922,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ibt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535476999744,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535611501989,
       "userAction": ""
     },
     "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535383207086,
+      "nextUpdateTime": 1535224773713,
       "userAction": ""
     },
-    "idsync.rlcdn.com": {
+    "idealmedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535075793702,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "image2.pubmatic.com": {
+    "ign.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535291313527,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "image6.pubmatic.com": {
+    "igodigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535365119943,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "img.youtube.com": {
+    "iheart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "im-apps.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imagetopng.club": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imedia.cz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "img.ak.impact-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535376841775,
+      "userAction": ""
+    },
+    "img.purch.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535505276490,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imgfarm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imgur.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "impact-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1548,19 +3762,85 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "infinity-tracking.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "infinityid.condenastdigital.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535609251930,
+      "userAction": ""
+    },
+    "infolinks.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "innovid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "inq.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535249104973,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "inquisitr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "inside-graph.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535325186526,
+      "nextUpdateTime": 1535259006632,
       "userAction": ""
     },
     "insightexpressai.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "instagram.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "insticator-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535313547846,
+      "userAction": ""
+    },
+    "instinctiveads.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentmedia.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1572,10 +3852,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "intergient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "internetbrands.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535164044525,
+      "nextUpdateTime": 1535212585331,
+      "userAction": ""
+    },
+    "investingchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "investis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "invoc.us": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ioam.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "iperceptions.com": {
@@ -1584,22 +3906,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ips-invite.iperceptions.com": {
+    "ipinyou.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535325289627,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ipredictive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "irs01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "izooto.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535319029672,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535302445154,
       "userAction": ""
     },
-    "js.adsrvr.org": {
+    "janrainsso.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535465747682,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jd.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jquery.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jrs5.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1614,9 +3972,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "justpremium.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jword.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jyxo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kakao.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kameleoon.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1662,9 +4050,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "kinja.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kiwiirc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "l.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1674,16 +4080,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "lcidc.liadm.com": {
+    "ladsp.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535169102934,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "li.pxl.ace.advertising.com": {
+    "leadintel.io": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535477346565,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "leaf.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "legocdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lejwaengv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "liadm.com": {
@@ -1692,9 +4116,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "libero.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "licasd.com": {
       "dnt": false,
       "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "licdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ligadx.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1710,7 +4152,43 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "lincoln.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "link-page.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "linkedin.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "linksynergy.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "list-manage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "listrakbi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "live.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1722,40 +4200,166 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load77.exelator.com": {
+    "livedoor.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "livejournal.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lkqd.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "load.instinctiveads.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535166623245,
+      "nextUpdateTime": 1535156309565,
+      "userAction": ""
+    },
+    "load.sumo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535193129482,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535068047141,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535330758728,
       "userAction": ""
     },
-    "log.outbrain.com": {
+    "loc.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lockerdome.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535602667578,
+      "userAction": ""
+    },
+    "log.mmstat.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535473321187,
+      "nextUpdateTime": 1535614693593,
+      "userAction": ""
+    },
+    "logc187.xiti.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535533148953,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535491014034,
+      "nextUpdateTime": 1535423452721,
+      "userAction": ""
+    },
+    "logly.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535260738970,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535260246626,
       "userAction": ""
     },
-    "m.addthis.com": {
+    "logs1136.xiti.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399926820,
+      "nextUpdateTime": 1535620450441,
+      "userAction": ""
+    },
+    "lptag.liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535381494449,
+      "userAction": ""
+    },
+    "lqm.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lrcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lucklayed.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lwcal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lytics.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "m.reachmax.cn": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535177699423,
+      "userAction": ""
+    },
+    "m6r.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "madeleine.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mail.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mailchimp.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mantisadnetwork.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1776,16 +4380,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "match.adsrvr.org": {
+    "marinsm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535234844708,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketo.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "match.adsrvr.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535382731107,
       "userAction": ""
     },
     "match.prod.bidr.io": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535338080427,
+      "userAction": ""
+    },
+    "matheranalytics.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535264504925,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1794,10 +4422,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mc.yandex.ru": {
+    "me-ssl.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535318601438,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535545627821,
       "userAction": ""
     },
     "media.net": {
@@ -1815,12 +4443,90 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535489306691,
+      "nextUpdateTime": 1535562992042,
+      "userAction": ""
+    },
+    "mediaforge.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medialand.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediaplex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediav.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediawallahscript.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medscape.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medtargetsystem.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mendeley.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "messenger.live.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "metadsp.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mg2connext.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mgid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "miamiherald.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1830,10 +4536,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mid.rkdms.com": {
+    "microad.jp": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535201966174,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoft.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoftonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mid.rkdms.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535261768429,
+      "userAction": ""
+    },
+    "mirtesen.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1845,7 +4575,91 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535082082006,
+      "nextUpdateTime": 1535088403217,
+      "userAction": ""
+    },
+    "mlb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mlive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mmstat.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mmtro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "molefefiseranis.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "monetate.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "monster.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mookie1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mouseflow.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mpnrs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mrpfd.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msgapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mssl.fwmrm.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535132799668,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1860,10 +4674,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mthsense.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mtrx.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535142954690,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535349304856,
       "userAction": ""
     },
     "mts0.google.com": {
@@ -1878,7 +4698,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mtty.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mtvnservices.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "musthird.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "muumuu-domain.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1898,8 +4742,44 @@
     },
     "mx.technolutions.net": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535512750016,
+      "userAction": ""
+    },
+    "mybuys.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myhard.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mynativeplatform.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myregistry.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myspacecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myvisualiq.net": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535404018448,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "nanigans.com": {
@@ -1908,9 +4788,117 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nasdaq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nationalgeographic.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "native.ai": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "native.sharethrough.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535458022322,
+      "userAction": ""
+    },
+    "nativendo.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nbcnews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nbcu.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535351358779,
+      "userAction": ""
+    },
+    "nbcuni.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "netdna-ssl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newatlas.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "neweggimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newscdn.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1923,7 +4911,31 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535018230678,
+      "nextUpdateTime": 1535270929625,
+      "userAction": ""
+    },
+    "newsinc.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsmemory.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsvine.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsweekgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1932,16 +4944,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-a.intercom.io": {
+    "nexac.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535498883050,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-b.intercom.io": {
+    "ngpvan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nih.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nineto5mac-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535229374587,
+      "nextUpdateTime": 1535458910130,
+      "userAction": ""
+    },
+    "nokia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "norton.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1950,16 +4986,124 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oclc.112.2o7.net": {
+    "nsaudience.pl": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535425842674,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "odb.outbrain.com": {
+    "nscontext.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nuggad.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535016850629,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nxtck.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nymag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nzaza.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "o0bg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oasc10.247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535205066735,
+      "userAction": ""
+    },
+    "oath.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ocdn.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oclc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ofapes.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "office.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "office365.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ojrq.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ok.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olark.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olympicchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omkt.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnidsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "omnitagjs.com": {
@@ -1974,9 +5118,75 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "onclickmega.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onecount.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onet.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onetag.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535417103733,
+      "userAction": ""
+    },
     "onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onevision.com.tw": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "online-metrix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onsugar.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onthe.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openhub.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openstat.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1986,15 +5196,75 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "optimize-stats.voxmedia.com": {
+    "opf.ooyala.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535525515019,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "opinionstage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optaim.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optimix.asia": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optimove.events": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ora.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oracleimg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "orangeads.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oreilly.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "otm-r.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "otto.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2004,52 +5274,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ovh.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "owox.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "p.adsymptotic.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535203430840,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535365238469,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535414888339,
+      "nextUpdateTime": 1535168480502,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535206307068,
-      "userAction": ""
-    },
-    "p.liadm.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535075363187,
-      "userAction": ""
-    },
-    "p.rfihub.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535358438619,
-      "userAction": ""
-    },
-    "p.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535256790030,
+      "nextUpdateTime": 1535348749572,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535087119968,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535338824891,
+      "userAction": ""
+    },
+    "paddle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pardot.com": {
@@ -2064,39 +5334,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pba.lijit.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535115013415,
-      "userAction": ""
-    },
-    "pbbl.co": {
+    "paypal.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pbid.pro-market.net": {
+    "paypalobjects.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535136510150,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pd.sharethis.com": {
+    "payroll.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pba.lijit.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535543859020,
+      "userAction": ""
+    },
+    "pbskids.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pcmag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pdmp.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "performgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "perimeterx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535153992015,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pewresearch.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "phonograph2.voxmedia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535325549253,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535441500485,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535354151599,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pingan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2109,79 +5433,79 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535221836104,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pixel-geo.prfct.co": {
+    "pixanalytics.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535035427244,
-      "userAction": ""
-    },
-    "pixel-sync.sitescout.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535122200195,
-      "userAction": ""
-    },
-    "pixel-us-east.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535379825285,
-      "userAction": ""
-    },
-    "pixel.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535237799393,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535126888506,
+      "nextUpdateTime": 1535444780876,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535139385386,
-      "userAction": ""
-    },
-    "pixel.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535292610867,
+      "nextUpdateTime": 1535344368148,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535355794721,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535558880509,
       "userAction": ""
     },
-    "pixel.rubiconproject.com": {
+    "pixel.s3xified.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535486117158,
+      "nextUpdateTime": 1535454023503,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535164323168,
+      "nextUpdateTime": 1535559337523,
       "userAction": ""
     },
-    "pixeltrack.eyeviewads.com": {
+    "pixel.zprk.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535144814767,
+      "userAction": ""
+    },
+    "piximedia.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535195842399,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pixnet.cc": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "placed.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "placelocal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535484478744,
+      "nextUpdateTime": 1535124167487,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2196,16 +5520,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "player.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535105086109,
+      "nextUpdateTime": 1535505151187,
+      "userAction": ""
+    },
+    "players.brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535030196338,
+      "nextUpdateTime": 1535388410492,
+      "userAction": ""
+    },
+    "playwire.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "plista.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2217,13 +5565,37 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535441634636,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "polymorphicads.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "popin.cc": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "popsugar-assets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pos.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535294459416,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535168204261,
+      "nextUpdateTime": 1535469659560,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2232,15 +5604,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pr-bh.ybp.yahoo.com": {
+    "powerlinks.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535271792808,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pressboard.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "prfct.co": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2250,28 +5628,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "profile.justuno.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535039428012,
-      "userAction": ""
-    },
-    "ps.eyeota.net": {
+    "prod-mng-proxy-connext.azurewebsites.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535044042579,
+      "nextUpdateTime": 1535243906722,
+      "userAction": ""
+    },
+    "proparm.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "provenpixel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "providesupport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "proximus.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535564390419,
+      "userAction": ""
+    },
+    "proximustv.be": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pscp.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pub.network": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535111836244,
+      "nextUpdateTime": 1535611640025,
       "userAction": ""
     },
-    "pubmatic-match.dotomi.com": {
+    "publishme.se": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535502071689,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2280,69 +5694,141 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pubmatic2waycm-atl.netmng.com": {
+    "pubmine.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535177396397,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "purch-match.dotomi.com": {
+    "pulpix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535459595542,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purechat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "px.adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535176013543,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535250433294,
-      "userAction": ""
-    },
-    "px.dynamicyield.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535405852313,
+      "nextUpdateTime": 1535131329876,
       "userAction": ""
     },
-    "px.owneriq.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535291856491,
-      "userAction": ""
-    },
-    "px.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535296720309,
-      "userAction": ""
-    },
-    "px0.pbbl.co": {
+    "pxf.io": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535076873350,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pxtres.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pxuno.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pxzwei.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535420663273,
+      "nextUpdateTime": 1535033233942,
       "userAction": ""
     },
-    "q.quora.com": {
+    "qantas.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535401599359,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535490587938,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535242881020,
+      "nextUpdateTime": 1535345306051,
+      "userAction": ""
+    },
+    "qnsr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qq.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qsstats.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qtmojo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "qualtrics.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quantcast.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535217833076,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quantummetric.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooks.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooksonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2352,10 +5838,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.skimresources.com": {
+    "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535170004392,
+      "nextUpdateTime": 1535217930912,
+      "userAction": ""
+    },
+    "rackcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "radiotime.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rakuten.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2364,39 +5868,135 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rand.d1.sc.omtrdc.net": {
+    "rbnt.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535263109404,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rcom.dynamicyield.com": {
+    "rcsmetrics.it": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535384795636,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reachmax.cn": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535535765113,
+      "nextUpdateTime": 1535304923654,
       "userAction": ""
     },
-    "registercom.sc.omtrdc.net": {
+    "reddit.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535462594322,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "registercom.tt.omtrdc.net": {
+    "redlink.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535189737074,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reference.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "regmedia.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "relap.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "republer.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "researchintel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reson8.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "responsetap.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reutersmedia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revjet.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rezync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ria.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richmetrics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richrelevance.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rightnowtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2412,28 +6012,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rp.gwallet.com": {
+    "rnengage.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535380552995,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rs.gwallet.com": {
+    "rockyou.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535231527445,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "roomkey.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "roymorgan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rtax.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535104158026,
+      "nextUpdateTime": 1535222519189,
       "userAction": ""
     },
-    "rtb.districtm.io": {
+    "rtb.com.ru": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535035055571,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rtk.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ru4.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -2444,8 +6068,20 @@
     },
     "rudy.adsnative.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535223087702,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535347337543,
+      "userAction": ""
+    },
+    "rundsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rutarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "s-static.ak.facebook.com": {
@@ -2457,79 +6093,85 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535410059142,
+      "nextUpdateTime": 1535352076386,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535439279491,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535561577916,
       "userAction": ""
     },
-    "s.cpx.to": {
+    "s.clickability.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535479648873,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535224844708,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535058060751,
-      "userAction": ""
-    },
-    "s.jsrdn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535459842092,
-      "userAction": ""
-    },
-    "s.po.st": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535253080228,
+      "nextUpdateTime": 1535201225344,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535135587742,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535214890098,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535507972811,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535434341417,
       "userAction": ""
     },
     "s.yimg.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535314953789,
+      "nextUpdateTime": 1535216141835,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535242557490,
+      "nextUpdateTime": 1535580705625,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535479363146,
+      "nextUpdateTime": 1535131999264,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535493968964,
+      "userAction": ""
+    },
+    "s3-us-west-2.amazonaws.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "s3xified.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535039569298,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535523380151,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535477270241,
+      "userAction": ""
+    },
+    "sabavision.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2538,34 +6180,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "salesloft.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "salesmanago.pl": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "samba.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535072165940,
+      "nextUpdateTime": 1535121885101,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535215807271,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535435991656,
       "userAction": ""
     },
-    "sbnationbidder-d.openx.net": {
+    "sbal4kp.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535218882947,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scarabresearch.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535515673197,
+      "nextUpdateTime": 1535441459044,
       "userAction": ""
     },
-    "scomcluster.cxense.com": {
+    "scholarlyiq.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535069100437,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirect.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirectassets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciverse.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scoop.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scopus.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2574,16 +6270,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "scribblelive.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535020426187,
+      "nextUpdateTime": 1535244758147,
+      "userAction": ""
+    },
+    "scripps.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535227106148,
+      "userAction": ""
+    },
+    "script.ioam.de": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sddan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "se.monetate.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535391241554,
+      "userAction": ""
+    },
+    "seadform.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535485865391,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535453750224,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2592,87 +6324,135 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "searchmarketing.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535061912370,
-      "userAction": ""
-    },
-    "secfld.vmmpxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535411085544,
+      "nextUpdateTime": 1535243571282,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418977196,
+      "nextUpdateTime": 1535119927597,
+      "userAction": ""
+    },
+    "secure-cf-c.ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "secure-dcr.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535335494368,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535188699282,
+      "nextUpdateTime": 1535584481337,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535356996177,
+      "nextUpdateTime": 1535177741800,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535326763580,
+      "nextUpdateTime": 1535107082511,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535483067072,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535292364343,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535133299962,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535562920063,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535402768464,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535398828987,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535195438164,
+      "nextUpdateTime": 1535351110245,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535504287312,
+      "nextUpdateTime": 1535579341049,
+      "userAction": ""
+    },
+    "secure.statcounter.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535254601040,
+      "userAction": ""
+    },
+    "securedvisit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535282607731,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535591583698,
       "userAction": ""
     },
-    "segments.company-target.com": {
+    "seekingalpha.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535259895831,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sekindo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "selectablemedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "semasio.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sendtonews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2682,9 +6462,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "servedby-buysellads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "serverbid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sessioncam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "shareaholic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2694,27 +6498,87 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sharethrough.adnxs.com": {
+    "sharethrough.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535439209850,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simage2.pubmatic.com": {
+    "sheego.de": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535373129653,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simage4.pubmatic.com": {
+    "shop.pe": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535066804433,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1534791910138,
+      "userAction": ""
+    },
+    "shopify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "simplereach.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "simpli.fi": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.com.cn": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sinoptik.ua": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitehelix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "siteimproveanalytics.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitelabweb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitelock.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2730,9 +6594,69 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sjs.bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535196852776,
+      "userAction": ""
+    },
     "skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sky.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "slashdotmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartadserver.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartclip.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smashing-delivery.herokuapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smi2.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smi2.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smithsonian.museum": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smyte.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2742,9 +6666,99 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "snapwidget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "snplow.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "so.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "socdm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sociomantic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "soflopxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "softonic-analytics.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sogou.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sohu.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sojern.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sokrati.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "solarwinds.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535180937040,
+      "userAction": ""
+    },
+    "soliditet.se": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "solocpm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sonyentertainmentnetwork.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2754,21 +6768,87 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sourceforge.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418102706,
+      "nextUpdateTime": 1535161310463,
       "userAction": ""
     },
-    "sp1cluster.cxense.com": {
+    "sp.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spectate.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sphereup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spiceworks.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535265282354,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spineuniverse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spingo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sportz.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spot.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spotify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spots.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2778,52 +6858,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "springernature.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "springserve.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-22-08.config.parsely.com": {
+    "sprinklr.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535226346743,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-22-09.config.parsely.com": {
+    "srv-2018-08-23-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535482395839,
+      "nextUpdateTime": 1535292359742,
+      "userAction": ""
+    },
+    "srv-2018-08-23-10.config.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535475527218,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535222239514,
+      "nextUpdateTime": 1535550468582,
       "userAction": ""
     },
-    "ssl.siteimprove.com": {
+    "srx.com.sg": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535484066342,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ss3.zedo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535129275153,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535486723866,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535229607025,
       "userAction": ""
     },
-    "ssum-sec.casalemedia.com": {
+    "ssp.adriver.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535090326798,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535203697827,
       "userAction": ""
     },
-    "st.dynamicyield.com": {
+    "st.hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535164370467,
+      "userAction": ""
+    },
+    "stackadapt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535143155903,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "staples-sparx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "staples-static.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "starfieldtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2838,22 +6960,40 @@
       "nextUpdateTime": 1529315030088,
       "userAction": ""
     },
+    "static.apester.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535270017993,
+      "userAction": ""
+    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535046610826,
+      "nextUpdateTime": 1535289627794,
+      "userAction": ""
+    },
+    "static.getclicky.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535459656103,
+      "userAction": ""
+    },
+    "static.mediarithmics.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535318289140,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535212699887,
+      "nextUpdateTime": 1535229325922,
       "userAction": ""
     },
-    "static.quantcast.mgr.consensu.org": {
+    "staticimgfarm.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535515390425,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2865,18 +7005,72 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535271064884,
+      "nextUpdateTime": 1535508331167,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535237146011,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535190455456,
+      "userAction": ""
+    },
+    "staybridge.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "steepto.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stg-sp.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stg8.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stickyadstv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storage.googleapis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storygize.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "streem.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "streetscout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2889,7 +7083,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535269383338,
+      "nextUpdateTime": 1535231190644,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2898,58 +7092,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "suning.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sunrtb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "supplyframe.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "survata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535018613611,
+      "nextUpdateTime": 1535421948525,
+      "userAction": ""
+    },
+    "surveymonkey.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535172174965,
+      "nextUpdateTime": 1535311993890,
       "userAction": ""
     },
-    "sync-tm.everesttech.net": {
+    "switchadhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535283029520,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sync.adaptv.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535249046647,
-      "userAction": ""
-    },
-    "sync.adkernel.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535071305588,
-      "userAction": ""
-    },
-    "sync.bfmio.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535427669787,
-      "userAction": ""
-    },
-    "sync.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535093224646,
-      "userAction": ""
-    },
-    "sync.multiview.com": {
+    "symantec.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535154068185,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "synacor.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sync.1rx.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436844877,
+      "userAction": ""
+    },
+    "sync.audtd.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535423682583,
+      "userAction": ""
+    },
+    "sync.datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535591448993,
+      "userAction": ""
+    },
+    "sync.republer.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535227536756,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535057971306,
+      "nextUpdateTime": 1535404928871,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2958,21 +7188,135 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "t.go.sohu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535161788370,
+      "userAction": ""
+    },
     "taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tacdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tag-st.contextweb.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535575760736,
+      "userAction": ""
+    },
+    "tag.1rx.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535224096496,
+      "userAction": ""
+    },
+    "tag.audience.acpm.fr": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535587928642,
+      "userAction": ""
+    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535198760139,
+      "nextUpdateTime": 1535172809545,
+      "userAction": ""
+    },
+    "tag.marinsm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535169314524,
+      "userAction": ""
+    },
+    "tag.mtrcs.samba.tv": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535482405835,
+      "userAction": ""
+    },
+    "tag.sp.advertising.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535108288134,
+      "userAction": ""
+    },
+    "tag4arm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tagdelivery.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tailtarget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "talkgadget.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tamgrt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tanx.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "taobao.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tapad.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "targetimg1.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tawk.to": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tcell.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "teads.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2988,9 +7332,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "techweb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "telegraph.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "telekom.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tenmax.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "theadex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "theatlas.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3000,28 +7380,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thrtle.com": {
+    "theglobeandmail.ca": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535305777635,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "thumbs.ebaystatic.com": {
+    "theguardian.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535105272905,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "thesaurus.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "thomsonreuters.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535432484423,
+      "nextUpdateTime": 1535536640170,
+      "userAction": ""
+    },
+    "tidaltv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tidelinedata.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "timecommerce.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535420021607,
+      "nextUpdateTime": 1535335023989,
+      "userAction": ""
+    },
+    "timewarnercable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tinypass.com": {
@@ -3030,10 +7446,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tiqcdn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tl813.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535026689669,
+      "nextUpdateTime": 1535210811276,
+      "userAction": ""
+    },
+    "tm-awx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tmall.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3044,32 +7484,92 @@
     },
     "token.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535233393938,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535573160300,
       "userAction": ""
     },
-    "top100.rambler.ru": {
+    "toutapp.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535125035641,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535406490099,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535515643596,
+      "userAction": ""
+    },
+    "tracc.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535061545317,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535424312057,
       "userAction": ""
     },
-    "track.eyeviewads.com": {
+    "track.hubspot.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535155370781,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535264130780,
+      "userAction": ""
+    },
+    "trackad.cz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trackalyzer.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tracking.g2crowd.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535237778325,
+      "userAction": ""
+    },
+    "tradedoubler.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tradelab.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "traffic-media.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficgate.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficjam.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficjunky.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3078,10 +7578,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trc.taboola.com": {
+    "travelzoo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trb.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "treasuredata.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535140806281,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tremorhub.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "trends.google.com": {
@@ -3090,9 +7608,99 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "trends.revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535603923908,
+      "userAction": ""
+    },
+    "tribalfusion.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tribl.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535233893141,
+      "userAction": ""
+    },
+    "tripadvisor.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tronc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trumba.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "truoptik.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustarc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustev.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustpilot.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trvl-px.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tumblr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tutorialize.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "twimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3108,40 +7716,178 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "u.openx.net": {
+    "ubi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uciservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uconnect.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535092934568,
+      "nextUpdateTime": 1535393886670,
+      "userAction": ""
+    },
+    "ucoz.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "udmserve.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535539694388,
+      "userAction": ""
+    },
+    "udnfunlife.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uefa.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ufpcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ugdturner.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "unagi-eu.amazon.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535382929843,
+      "nextUpdateTime": 1535196808939,
       "userAction": ""
     },
-    "us-u.openx.net": {
+    "undertone.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unicc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unity.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "universal.iperceptions.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535165883589,
+      "nextUpdateTime": 1535325388047,
       "userAction": ""
     },
-    "us.pixel.newscgp.com": {
+    "unrulymedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535390643472,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us4.siteimprove.com": {
+    "upravel.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535170950487,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us5.siteimprove.com": {
+    "ups.xplosion.de": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535407396093,
+      "userAction": ""
+    },
+    "upsellit.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uptolike.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "urbandictionary.store": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "usa.gov": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535361402673,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "useproof.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "usergram.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "userreport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ustream.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "utarget.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "utarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uuidksinc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "v12group.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -3150,10 +7896,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vid.springserve.com": {
+    "veinteractive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535169227544,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "velaro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "velemh.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vendorlist.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535354855735,
+      "userAction": ""
+    },
+    "verticalhealth.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "veruta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "video.google.com": {
@@ -3162,7 +7950,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "videoamp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "videohub.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vidible.tv": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vilynx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3180,22 +7992,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "visitor-service-us-east-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535199238726,
-      "userAction": ""
-    },
-    "vmmpxl.com": {
+    "virgilio.it": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vmss.boldchat.com": {
+    "visitor-service.tealiumiq.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535207908950,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535281447453,
+      "userAction": ""
+    },
+    "visualstudio.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vizury.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vk.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535214742233,
       "userAction": ""
     },
     "vogue.com": {
@@ -3204,10 +8028,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vop.sundaysky.com": {
+    "volvelle.tech": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535027449792,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3216,31 +8040,97 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "w.soundcloud.com": {
+    "vtracy.de": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535180305355,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wam-yahoo.solution.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535313044985,
-      "userAction": ""
-    },
-    "wamfactory.solution.weborama.fr": {
+    "w55c.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535283879516,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wallst.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "waptime.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "warnerbros.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wbtrk.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wcfbc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "weather.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315460235,
+      "nextUpdateTime": 1535205349790,
+      "userAction": ""
+    },
+    "webmd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webpush.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "websimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webspectator.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webtrekk.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3252,15 +8142,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "widgets.outbrain.com": {
+    "weibo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "welt.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "whistleout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "widget.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535484411512,
+      "nextUpdateTime": 1535613320681,
+      "userAction": ""
+    },
+    "wikia-services.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wikimedia.org": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wired.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wise.space": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3270,7 +8196,79 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wishpond.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wishpond.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wkxppshj-qx.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1534814085104,
+      "userAction": ""
+    },
     "wmagazine.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wnyc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wolfram.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woobi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woopic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wordpress.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wrating.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3279,25 +8277,49 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535220842816,
+      "nextUpdateTime": 1535133343141,
       "userAction": ""
     },
-    "ww.steelhousemedia.com": {
+    "wsj.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535108380967,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wsj.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wsod.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wt-eu02.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wurfl.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535451698656,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535160363763,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478914675,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535121108712,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3308,44 +8330,44 @@
     },
     "www.bonappetit.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535198678997,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535515298218,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535335746123,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535253088334,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535523057317,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535377541215,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535385380509,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535332528512,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535341462375,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535086092034,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535373992834,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535118488381,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535478659047,
       "userAction": ""
     },
     "www.google.com": {
@@ -3356,103 +8378,145 @@
     },
     "www.gq.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535056845706,
-      "userAction": ""
-    },
-    "www.justuno.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535134268596,
+      "nextUpdateTime": 1535109212248,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535412347346,
-      "userAction": ""
-    },
-    "www.linkedin.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503327200,
+      "nextUpdateTime": 1535353938304,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535191271791,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535324760182,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478932878,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535412184727,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535236669569,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535371018711,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535386103543,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535524961484,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535446262570,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535401655245,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535037751236,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535364193938,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535528753563,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535307422760,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535365974182,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535212366928,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535532430753,
-      "userAction": ""
-    },
-    "www.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535024452155,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535257180613,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535040980033,
+      "nextUpdateTime": 1535432091170,
+      "userAction": ""
+    },
+    "wwwimages.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wywyuserservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535454366224,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535372826747,
+      "userAction": ""
+    },
+    "xad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xg4ken.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xinhuanet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xlisting.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xplosion.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xs4all.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xsdownload.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xxxlutz.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3463,6 +8527,12 @@
       "userAction": ""
     },
     "yadro.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3480,13 +8550,67 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yandex.ua": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yastatic.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535352911929,
+      "nextUpdateTime": 1535288290126,
+      "userAction": ""
+    },
+    "yieldify.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yieldlab.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yieldoptimizer.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yldbt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ymetrica1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535543854128,
+      "userAction": ""
+    },
+    "yoox.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yotpo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "youtube-nocookie.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
@@ -3498,25 +8622,109 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "youvisit.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ypcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yudu.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535507962998,
+      "nextUpdateTime": 1535312844355,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535038311647,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535168425931,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535217382463,
+      "nextUpdateTime": 1535346541264,
+      "userAction": ""
+    },
+    "zedo.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "zemanta.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zendesk.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zergnet.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zhaopin.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zhiziyun.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zidtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ziffdavis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zoho.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zohopublic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zoomph.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3560,12 +8768,7 @@
     "2o7.net": [
       "mysql.com",
       "cdc.gov",
-      "theatlantic.com",
-      "prnewswire.com",
-      "fastcompany.com",
-      "earthlink.net",
-      "qz.com",
-      "oclc.org"
+      "theatlantic.com"
     ],
     "33across.com": [
       "accuweather.com"
@@ -3588,11 +8791,7 @@
     "3lift.com": [
       "nature.com",
       "springer.com",
-      "theverge.com",
-      "usatoday.com",
-      "weather.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "theverge.com"
     ],
     "4dsply.com": [
       "wnd.com"
@@ -3650,8 +8849,7 @@
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr",
-      "leparisien.fr"
+      "liberation.fr"
     ],
     "acquia.com": [
       "panasonic.com",
@@ -3669,9 +8867,6 @@
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
-    ],
-    "ad-score.com": [
-      "wnd.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
@@ -3702,10 +8897,7 @@
     "addthis.com": [
       "nasa.gov",
       "jimdo.com",
-      "yahoo.com",
-      "who.int",
-      "columbia.edu",
-      "gulfnews.com"
+      "yahoo.com"
     ],
     "addtoany.com": [
       "irs.gov"
@@ -3717,9 +8909,7 @@
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com",
-      "shutterstock.com",
-      "helsinki.fi"
+      "springer.com"
     ],
     "adfox.ru": [
       "livejournal.com",
@@ -3743,8 +8933,7 @@
     "adition.com": [
       "bloomberg.com",
       "dailymotion.com",
-      "spiegel.de",
-      "lemonde.fr"
+      "spiegel.de"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -3753,8 +8942,7 @@
     "adkernel.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com",
-      "xda-developers.com"
+      "space.com"
     ],
     "adlmerge.com": [
       "tomsk.ru"
@@ -3773,22 +8961,18 @@
     "adnxs.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net",
-      "nytimes.com",
-      "cisco.com",
-      "jsonline.com",
-      "rfi.fr"
+      "sourceforge.net"
     ],
     "adobe.com": [
       "wikipedia.org",
+      "apache.org",
       "behance.net",
-      "history.com"
+      "msnbc.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
       "bbb.org",
-      "bizjournals.com",
-      "worldbank.org"
+      "bizjournals.com"
     ],
     "adotmob.com": [
       "standard.co.uk",
@@ -3802,22 +8986,17 @@
     "adroll.com": [
       "stumbleupon.com",
       "nature.com",
-      "nginx.org",
-      "cloudflare.com",
-      "ning.com",
-      "case.edu"
+      "nginx.org"
     ],
     "adscale.de": [
       "t-online.de",
       "bloomberg.com",
-      "springer.com",
-      "statista.com"
+      "springer.com"
     ],
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "informationweek.com",
-      "bostonherald.com"
+      "informationweek.com"
     ],
     "adsniper.ru": [
       "rambler.ru"
@@ -3825,11 +9004,7 @@
     "adsrvr.org": [
       "adobe.com",
       "yahoo.com",
-      "googletagmanager.com",
-      "sourceforge.net",
-      "cisco.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "googletagmanager.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -3839,10 +9014,7 @@
     "adsymptotic.com": [
       "tinyurl.com",
       "etsy.com",
-      "tripadvisor.com",
-      "foursquare.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "tripadvisor.com"
     ],
     "adtags.pro": [
       "tomsk.ru"
@@ -3853,10 +9025,7 @@
     "advertising.com": [
       "amazon.com",
       "sourceforge.net",
-      "dropbox.com",
-      "wsj.com",
-      "theverge.com",
-      "walgreens.com"
+      "dropbox.com"
     ],
     "advertur.ru": [
       "radikal.ru"
@@ -3885,10 +9054,7 @@
     "agkn.com": [
       "amazon.com",
       "t-online.de",
-      "bloomberg.com",
-      "cnet.com",
-      "zdnet.com",
-      "zerohedge.com"
+      "bloomberg.com"
     ],
     "aid-ad.jp": [
       "shinobi.jp"
@@ -3904,14 +9070,10 @@
     "ajx130.online": [
       "radikal.ru"
     ],
-    "akamai.net": [
-      "newscientist.com"
-    ],
     "akamaihd.net": [
       "voanews.com",
       "repubblica.it",
-      "iyfubh.com",
-      "forbes.com"
+      "iyfubh.com"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -3931,7 +9093,7 @@
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
-      "sohu.com"
+      "aliexpress.com"
     ],
     "alipay.com": [
       "alibaba.com",
@@ -3943,8 +9105,7 @@
     "allure.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "am15.net": [
       "radikal.ru"
@@ -3952,10 +9113,7 @@
     "amazon-adsystem.com": [
       "amazon.com",
       "nytimes.com",
-      "reddit.com",
-      "cnn.com",
-      "goodreads.com",
-      "bostonherald.com"
+      "reddit.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
@@ -3980,8 +9138,7 @@
     "answerscloud.com": [
       "worldbank.org",
       "acs.org",
-      "fbi.gov",
-      "realtor.com"
+      "fbi.gov"
     ],
     "antdsp.com": [
       "hc360.com"
@@ -4008,8 +9165,7 @@
     "app.link": [
       "foursquare.com",
       "history.com",
-      "nbc.com",
-      "strava.com"
+      "nbc.com"
     ],
     "appdynamics.com": [
       "nfl.com"
@@ -4022,17 +9178,13 @@
     "aqtracker.com": [
       "nikkei.com"
     ],
-    "aralego.com": [
-      "accuweather.com"
-    ],
     "arcgis.com": [
       "chron.com"
     ],
     "architecturaldigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
@@ -4054,8 +9206,7 @@
     "atdmt.com": [
       "facebook.com",
       "yahoo.com",
-      "msn.com",
-      "t-online.de"
+      "msn.com"
     ],
     "atemda.com": [
       "springer.com",
@@ -4082,8 +9233,7 @@
     "autopilothq.com": [
       "bitbucket.org",
       "rfc-editor.org",
-      "typeform.com",
-      "quantcast.com"
+      "typeform.com"
     ],
     "b1img.com": [
       "threadless.com"
@@ -4091,15 +9241,10 @@
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com",
-      "sohu.com",
-      "51.la"
+      "ifeng.com"
     ],
     "bam-x.com": [
       "gq.com"
-    ],
-    "barnebys.com": [
-      "lemonde.fr"
     ],
     "bazaarvoice.com": [
       "target.com",
@@ -4141,9 +9286,7 @@
     "bfmio.com": [
       "symantec.com",
       "tinypic.com",
-      "venturebeat.com",
-      "livescience.com",
-      "xda-developers.com"
+      "venturebeat.com"
     ],
     "bfmtv.com": [
       "liberation.fr",
@@ -4155,18 +9298,12 @@
     "bidr.io": [
       "adobe.com",
       "dailymotion.com",
-      "hootsuite.com",
-      "symantec.com",
-      "box.com"
+      "hootsuite.com"
     ],
     "bidswitch.net": [
       "yahoo.com",
       "google.com",
-      "amazon.com",
-      "dropbox.com",
-      "theverge.com",
-      "jsonline.com",
-      "walgreens.com"
+      "amazon.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -4179,9 +9316,7 @@
       "vimeo.com",
       "cnn.com",
       "weebly.com",
-      "msn.com",
-      "parallels.com",
-      "pingdom.com"
+      "msn.com"
     ],
     "bitbucket.org": [
       "atlassian.com"
@@ -4189,9 +9324,7 @@
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com",
-      "ibm.com",
-      "gitlab.com"
+      "zendesk.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
@@ -4199,16 +9332,12 @@
     "bizographics.com": [
       "zend.com",
       "nginx.com",
-      "oreilly.com",
-      "jimdo.com",
-      "ox.ac.uk"
+      "oreilly.com"
     ],
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com",
-      "slashdot.org"
+      "ew.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -4223,8 +9352,7 @@
     "blueconic.net": [
       "nationalgeographic.com",
       "theatlantic.com",
-      "sfgate.com",
-      "chron.com"
+      "sfgate.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -4236,23 +9364,21 @@
       "jigsy.com",
       "bravenet.com"
     ],
+    "bobo.com": [
+      "163.com"
+    ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org",
-      "networksolutions.com"
+      "cancer.org"
     ],
     "bonappetit.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "boston.com": [
       "bostonglobe.com"
-    ],
-    "bostonglobemedia.com": [
-      "boston.com"
     ],
     "botradar.tech": [
       "radikal.ru"
@@ -4263,11 +9389,7 @@
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com",
-      "usatoday.com",
-      "fortune.com",
-      "jsonline.com",
-      "pitchfork.com"
+      "wired.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
@@ -4275,14 +9397,14 @@
     "brides.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "brightcove.com": [
       "scholastic.com",
       "si.com",
       "federalreserve.gov",
-      "informationweek.com"
+      "informationweek.com",
+      "straitstimes.com"
     ],
     "brightcove.net": [
       "lefigaro.fr",
@@ -4292,9 +9414,7 @@
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
-      "zendesk.com",
-      "livescience.com",
-      "dailydot.com"
+      "zendesk.com"
     ],
     "btttag.com": [
       "samsung.com",
@@ -4334,18 +9454,12 @@
     "casalemedia.com": [
       "amazon.com",
       "dropbox.com",
-      "myspace.com",
-      "washingtonpost.com",
-      "theverge.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "myspace.com"
     ],
     "cbsi.com": [
       "zdnet.com",
       "last.fm",
-      "gamespot.com",
-      "cnet.com",
-      "cbsnews.com"
+      "gamespot.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -4408,6 +9522,10 @@
     "ckies.net": [
       "abril.com.br"
     ],
+    "cleveland.com": [
+      "nola.com",
+      "al.com"
+    ],
     "clickability.com": [
       "prnewswire.com",
       "philly.com",
@@ -4429,7 +9547,6 @@
       "uci.edu",
       "nbcnews.com",
       "sciencemag.org",
-      "symantec.com",
       "allaboutcookies.org"
     ],
     "cnet.com": [
@@ -4441,8 +9558,7 @@
     "cntraveler.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "cnzz.com": [
       "zol.com.cn"
@@ -4473,10 +9589,7 @@
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com",
-      "theverge.com",
-      "jsonline.com",
-      "box.com"
+      "redhat.com"
     ],
     "complex.com": [
       "knowyourmeme.com",
@@ -4489,9 +9602,7 @@
     "condenastdigital.com": [
       "wired.com",
       "arstechnica.com",
-      "nj.com",
-      "newyorker.com",
-      "pitchfork.com"
+      "nj.com"
     ],
     "conductrics.com": [
       "nginx.com"
@@ -4506,10 +9617,7 @@
     "consensu.org": [
       "rollingstone.com",
       "variety.com",
-      "adweek.com",
-      "buzzfeed.com",
-      "thetimes.co.uk",
-      "nme.com"
+      "adweek.com"
     ],
     "consumable.com": [
       "xfinity.com"
@@ -4520,10 +9628,7 @@
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "bloomberg.com",
-      "forbes.com",
-      "uci.edu",
-      "walgreens.com"
+      "bloomberg.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -4551,9 +9656,7 @@
     "cpx.to": [
       "express.co.uk",
       "digitaltrends.com",
-      "techradar.com",
-      "independent.co.uk",
-      "rfi.fr"
+      "techradar.com"
     ],
     "cquotient.com": [
       "gopro.com"
@@ -4571,10 +9674,7 @@
     "criteo.com": [
       "tinyurl.com",
       "washingtonpost.com",
-      "dailymail.co.uk",
-      "dropbox.com",
-      "webmd.com",
-      "sedo.com"
+      "dailymail.co.uk"
     ],
     "croissed.info": [
       "4shared.com"
@@ -4586,6 +9686,9 @@
       "sourceforge.net",
       "slashdot.org",
       "bartleby.com"
+    ],
+    "crwdcntrl.net": [
+      "bloomberg.com"
     ],
     "cssrvsync.com": [
       "springer.com",
@@ -4603,10 +9706,7 @@
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
-      "gizmodo.com",
-      "wsj.com",
-      "cbc.ca",
-      "allafrica.com"
+      "gizmodo.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -4664,11 +9764,7 @@
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "amazon.com",
-      "soundcloud.com",
-      "webmd.com",
-      "jsonline.com",
-      "britishairways.com"
+      "amazon.com"
     ],
     "departapp.com": [
       "liveuamap.com"
@@ -4697,8 +9793,7 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com",
-      "zerohedge.com"
+      "entrepreneur.com"
     ],
     "dictionary.com": [
       "thesaurus.com"
@@ -4714,8 +9809,7 @@
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk",
-      "bostonherald.com"
+      "express.co.uk"
     ],
     "disney.com": [
       "starwars.com"
@@ -4724,19 +9818,15 @@
       "pnas.org",
       "dyn.com",
       "mercurynews.com",
-      "dw.com",
       "rollingstone.com"
     ],
     "distiltag.com": [
-      "reuters.com",
-      "merriam-webster.com"
+      "reuters.com"
     ],
     "districtm.io": [
       "barnesandnoble.com",
       "urbandictionary.com",
-      "axs.com",
-      "timeanddate.com",
-      "newatlas.com"
+      "axs.com"
     ],
     "djv99sxoqpv11.cloudfront.net": [
       "4shared.com"
@@ -4759,11 +9849,7 @@
     "dotomi.com": [
       "tinyurl.com",
       "samsung.com",
-      "webmd.com",
-      "forbes.com",
-      "illinois.edu",
-      "jsonline.com",
-      "xda-developers.com"
+      "webmd.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -4771,11 +9857,7 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com",
-      "sourceforge.net",
-      "zend.com",
-      "jsonline.com",
-      "britishairways.com"
+      "linkedin.com"
     ],
     "doublemax.net": [
       "udn.com"
@@ -4790,8 +9872,7 @@
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com",
-      "adweek.com"
+      "techtarget.com"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4799,8 +9880,7 @@
     "dynamicyield.com": [
       "t-online.de",
       "cnbc.com",
-      "nbcnews.com",
-      "washingtonexaminer.com"
+      "nbcnews.com"
     ],
     "dynatrace-managed.com": [
       "delta.com"
@@ -4827,9 +9907,6 @@
       "ebay.com",
       "ebay.com.au"
     ],
-    "ebaystatic.com": [
-      "ebay.com.au"
-    ],
     "ebdr3.com": [
       "springer.com"
     ],
@@ -4852,15 +9929,12 @@
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com",
-      "goal.com"
+      "gulfnews.com"
     ],
     "eloqua.com": [
       "intel.com",
       "cisco.com",
-      "prnewswire.com",
-      "siemens.com",
-      "eset.com"
+      "prnewswire.com"
     ],
     "elsevier.com": [
       "sciencedirect.com",
@@ -4887,8 +9961,7 @@
     "epicurious.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
@@ -4919,11 +9992,7 @@
     "everesttech.net": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net",
-      "dailymotion.com",
-      "webmd.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "everyaction.com": [
       "greenpeace.org"
@@ -4954,10 +10023,7 @@
     "exelator.com": [
       "soundcloud.com",
       "forbes.com",
-      "bloomberg.com",
-      "businessinsider.com",
-      "mirror.co.uk",
-      "zerohedge.com"
+      "bloomberg.com"
     ],
     "exosrv.com": [
       "pornhub.com"
@@ -4968,18 +10034,14 @@
     "eyeota.net": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com",
-      "gizmodo.com",
-      "xda-developers.com"
+      "bloomberg.com"
     ],
     "eyereturn.com": [
       "thestar.com",
       "queensu.ca"
     ],
     "eyeviewads.com": [
-      "staples.com",
-      "xda-developers.com",
-      "walgreens.com"
+      "staples.com"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -4988,11 +10050,7 @@
     "facebook.com": [
       "instagram.com",
       "wordpress.org",
-      "adobe.com",
-      "nytimes.com",
-      "goodreads.com",
-      "jsonline.com",
-      "helsinki.fi"
+      "adobe.com"
     ],
     "facetz.net": [
       "novostimira.com",
@@ -5032,8 +10090,7 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu",
-      "bmj.com"
+      "msu.edu"
     ],
     "flickr.com": [
       "state.gov",
@@ -5051,21 +10108,19 @@
     "flyertown.ca": [
       "canada.com",
       "globalnews.ca",
-      "nationalpost.com",
-      "vancouversun.com"
+      "nationalpost.com"
     ],
     "fontawesome.com": [
       "socarrao.com.br",
       "clinicaltrials.gov",
       "moonfruit.com",
-      "webex.com"
+      "webex.com",
+      "sitepoint.com"
     ],
     "foresee.com": [
       "epa.gov",
       "si.edu",
-      "theglobeandmail.com",
-      "sec.gov",
-      "marthastewart.com"
+      "theglobeandmail.com"
     ],
     "formstack.com": [
       "in.gov"
@@ -5112,9 +10167,7 @@
     "fwmrm.net": [
       "yahoo.com",
       "mlb.com",
-      "xfinity.com",
-      "discovery.com",
-      "hgtv.com"
+      "xfinity.com"
     ],
     "g2crowd.com": [
       "prezi.com",
@@ -5157,9 +10210,7 @@
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au",
-      "sfgate.com",
-      "hgtv.com"
+      "abc.net.au"
     ],
     "giphy.com": [
       "urbandictionary.com",
@@ -5172,8 +10223,7 @@
     "glamour.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
@@ -5193,8 +10243,7 @@
     "golfdigest.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
@@ -5206,18 +10255,14 @@
       "youtube.com",
       "linkedin.com",
       "google.de",
-      "godaddy.com",
-      "goodreads.com",
       "scmp.com",
       "chromium.org",
-      "jsonline.com",
-      "britishairways.com"
+      "google.be"
     ],
     "gq.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "gridsumdissector.com": [
       "qq.com",
@@ -5226,6 +10271,9 @@
     ],
     "groupondata.com": [
       "groupon.com"
+    ],
+    "grubstreet.com": [
+      "nymag.com"
     ],
     "gsimedia.net": [
       "acehardware.com"
@@ -5241,8 +10289,7 @@
     "gumgum.com": [
       "liveuamap.com",
       "colourlovers.com",
-      "infoplease.com",
-      "coindesk.com"
+      "infoplease.com"
     ],
     "guoshipartners.com": [
       "udn.com"
@@ -5250,9 +10297,10 @@
     "gwallet.com": [
       "adobe.com",
       "ox.ac.uk",
-      "ihg.com",
-      "economist.com",
-      "business2community.com"
+      "ihg.com"
+    ],
+    "gwmtracking.com": [
+      "proofpoint.com"
     ],
     "hadcs.de": [
       "t-online.de"
@@ -5315,8 +10363,7 @@
     "hubspot.com": [
       "wpengine.com",
       "shopify.com",
-      "technologyreview.com",
-      "scoop.it"
+      "technologyreview.com"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
@@ -5367,9 +10414,7 @@
     "id5-sync.com": [
       "bloomberg.com",
       "venturebeat.com",
-      "dailymotion.com",
-      "livescience.com",
-      "xda-developers.com"
+      "dailymotion.com"
     ],
     "idealmedia.com": [
       "alternet.org",
@@ -5413,14 +10458,7 @@
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com",
-      "wsj.com",
-      "altervista.org",
-      "marthastewart.com",
-      "hgtv.com"
-    ],
-    "ineity.pro": [
-      "4shared.com"
+      "bbc.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
@@ -5446,22 +10484,18 @@
     "insightexpressai.com": [
       "unsplash.com",
       "standard.co.uk",
-      "motorola.com",
-      "reddit.com",
-      "gopro.com"
+      "motorola.com"
     ],
     "instagram.com": [
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu",
-      "tmz.com"
+      "arizona.edu"
     ],
     "instinctiveads.com": [
       "variety.com",
       "dp.ua",
-      "blackberry.com",
-      "rollingstone.com"
+      "blackberry.com"
     ],
     "intentiq.com": [
       "sourceforge.net",
@@ -5475,8 +10509,7 @@
     "intercom.io": [
       "themeforest.net",
       "ft.com",
-      "elegantthemes.com",
-      "iconfinder.com"
+      "elegantthemes.com"
     ],
     "intergient.com": [
       "infoplease.com"
@@ -5505,8 +10538,7 @@
     "iperceptions.com": [
       "ford.com",
       "seagate.com",
-      "honeywell.com",
-      "boeing.com"
+      "honeywell.com"
     ],
     "ipinyou.com": [
       "autohome.com.cn"
@@ -5543,8 +10575,7 @@
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com",
-      "vancouversun.com"
+      "dallasnews.com"
     ],
     "justpremium.com": [
       "tvtropes.org"
@@ -5552,8 +10583,7 @@
     "justuno.com": [
       "gartner.com",
       "searchengineland.com",
-      "zenfolio.com",
-      "gopro.com"
+      "zenfolio.com"
     ],
     "jword.jp": [
       "excite.co.jp"
@@ -5572,10 +10602,7 @@
     "keywee.co": [
       "latimes.com",
       "nationalgeographic.com",
-      "chicagotribune.com",
-      "nytimes.com",
-      "rollingstone.com",
-      "apartmenttherapy.com"
+      "chicagotribune.com"
     ],
     "kinja.com": [
       "gizmodo.com",
@@ -5588,11 +10615,7 @@
     "krxd.net": [
       "inhabitat.com",
       "bgr.com",
-      "jalopnik.com",
-      "cnn.com",
-      "gizmodo.com",
-      "jsonline.com",
-      "realtor.com"
+      "jalopnik.com"
     ],
     "ladsp.com": [
       "exblog.jp",
@@ -5615,16 +10638,13 @@
     "liadm.com": [
       "webmd.com",
       "nj.com",
-      "patch.com",
-      "bloomberg.com",
-      "usmagazine.com"
+      "patch.com"
     ],
     "libero.it": [
       "virgilio.it"
     ],
     "licasd.com": [
-      "nj.com",
-      "usmagazine.com"
+      "nj.com"
     ],
     "licdn.com": [
       "linkedin.com"
@@ -5637,16 +10657,12 @@
     "lightboxcdn.com": [
       "zdnet.com",
       "fastcompany.com",
-      "adweek.com",
-      "lifehacker.com",
-      "usmagazine.com"
+      "adweek.com"
     ],
     "lijit.com": [
       "sourceforge.net",
       "bloomberg.com",
-      "deviantart.com",
-      "howstuffworks.com",
-      "infoplease.com"
+      "deviantart.com"
     ],
     "lincoln.com": [
       "ford.com"
@@ -5658,11 +10674,7 @@
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net",
-      "dropbox.com",
-      "cisco.com",
-      "unity3d.com",
-      "helsinki.fi"
+      "sourceforge.net"
     ],
     "linksynergy.com": [
       "rakuten.co.jp",
@@ -5697,8 +10709,7 @@
     "liveperson.net": [
       "apache.org",
       "prnewswire.com",
-      "ibm.com",
-      "earthlink.net"
+      "ibm.com"
     ],
     "lkqd.net": [
       "allafrica.com"
@@ -5732,8 +10743,7 @@
     "lytics.io": [
       "adweek.com",
       "digitaltrends.com",
-      "fool.com",
-      "economist.com"
+      "fool.com"
     ],
     "m6r.eu": [
       "t-online.de",
@@ -5745,15 +10755,12 @@
     "mail.ru": [
       "vk.com",
       "novostimira.com",
-      "google.com",
-      "yandex.ru",
-      "ok.ru"
+      "google.com"
     ],
     "mailchimp.com": [
       "colorlib.com",
       "fas.org",
-      "tias.com",
-      "nap.edu"
+      "tias.com"
     ],
     "mantisadnetwork.com": [
       "tvtropes.org"
@@ -5761,20 +10768,18 @@
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "hootsuite.com",
-      "smugmug.com"
+      "hootsuite.com"
     ],
     "marketlinc.com": [
       "kaspersky.com",
       "norton.com",
-      "eset.com",
-      "teamviewer.us"
+      "eset.com"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
       "dyn.com",
-      "ubuntu.com"
+      "domaintools.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
@@ -5784,25 +10789,17 @@
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
-      "sourceforge.net",
-      "forbes.com",
-      "prnewswire.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
-      "forbes.com",
-      "reuters.com",
-      "webmd.com",
-      "cracked.com"
+      "forbes.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
       "uci.edu",
-      "autodesk.com",
-      "box.com"
+      "autodesk.com"
     ],
     "mediaforge.com": [
       "nike.com",
@@ -5820,8 +10817,7 @@
     "mediarithmics.com": [
       "orange.fr",
       "lynda.com",
-      "liberation.fr",
-      "leparisien.fr"
+      "liberation.fr"
     ],
     "mediav.com": [
       "ctrip.com",
@@ -5848,9 +10844,6 @@
       "nypost.com",
       "standard.co.uk"
     ],
-    "mfadsrvr.com": [
-      "jsonline.com"
-    ],
     "mg2connext.com": [
       "mercurynews.com",
       "philly.com",
@@ -5867,9 +10860,7 @@
     "miaozhen.com": [
       "sina.com.cn",
       "163.com",
-      "dzwww.com",
-      "sohu.com",
-      "autohome.com.cn"
+      "dzwww.com"
     ],
     "microad.jp": [
       "rakuten.co.jp",
@@ -5896,18 +10887,12 @@
     "mktoresp.com": [
       "parallels.com",
       "prnewswire.com",
-      "zend.com",
-      "nginx.com",
-      "oreilly.com",
-      "pingdom.com"
+      "zend.com"
     ],
     "ml314.com": [
       "sourceforge.net",
       "forbes.com",
-      "bloomberg.com",
-      "wsj.com",
-      "zdnet.com",
-      "xda-developers.com"
+      "bloomberg.com"
     ],
     "mlb.com": [
       "nhl.com"
@@ -5918,9 +10903,7 @@
     "mmstat.com": [
       "alibaba.com",
       "youku.com",
-      "taobao.com",
-      "sohu.com",
-      "51.la"
+      "taobao.com"
     ],
     "mmtro.com": [
       "upwork.com"
@@ -5939,8 +10922,7 @@
     "mookie1.com": [
       "t-online.de",
       "nbcnews.com",
-      "theglobeandmail.com",
-      "thetimes.co.uk"
+      "theglobeandmail.com"
     ],
     "mouseflow.com": [
       "bbb.org",
@@ -5975,8 +10957,7 @@
       "cc.com"
     ],
     "multiview.com": [
-      "symantec.com",
-      "nutrition.org"
+      "symantec.com"
     ],
     "musthird.com": [
       "airbnb.com"
@@ -6003,15 +10984,12 @@
     "myvisualiq.net": [
       "soundcloud.com",
       "surveymonkey.com",
-      "spotify.com",
-      "paypal.com",
-      "dell.com"
+      "spotify.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
       "overstock.com",
-      "squareup.com",
-      "zappos.com"
+      "squareup.com"
     ],
     "narrative.io": [
       "sourceforge.net"
@@ -6047,8 +11025,7 @@
     "nbcuni.com": [
       "cnbc.com",
       "msnbc.com",
-      "nbc.com",
-      "nbcnews.com"
+      "nbc.com"
     ],
     "netdna-ssl.com": [
       "alternet.org"
@@ -6056,9 +11033,7 @@
     "netmng.com": [
       "lenovo.com",
       "theknot.com",
-      "shopko.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "shopko.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -6083,10 +11058,7 @@
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
-      "thesun.co.uk",
-      "wsj.com",
-      "news.com.au",
-      "realtor.com"
+      "thesun.co.uk"
     ],
     "newsinc.com": [
       "latimes.com",
@@ -6107,8 +11079,7 @@
     "newyorker.com": [
       "wired.com",
       "vanityfair.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "nexac.com": [
       "edmunds.com"
@@ -6121,7 +11092,7 @@
       "clinicaltrials.gov"
     ],
     "nj.com": [
-      "nola.com"
+      "bleacherreport.com"
     ],
     "nokia.com": [
       "bell-labs.com"
@@ -6132,11 +11103,7 @@
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com",
-      "washingtonpost.com",
-      "domainmarket.com",
-      "jsonline.com",
-      "helsinki.fi"
+      "oracle.com"
     ],
     "nsaudience.pl": [
       "interia.pl"
@@ -6207,15 +11174,12 @@
     "omnitagjs.com": [
       "springer.com",
       "standard.co.uk",
-      "home.pl",
-      "newatlas.com"
+      "home.pl"
     ],
     "omtrdc.net": [
       "adobe.com",
       "amazon.com",
-      "telegraph.co.uk",
-      "dell.com",
-      "eset.com"
+      "telegraph.co.uk"
     ],
     "onclickmega.com": [
       "brothersoft.com"
@@ -6229,9 +11193,7 @@
     "onetrust.com": [
       "themeisle.com",
       "bitbucket.org",
-      "namecheap.com",
-      "thesun.co.uk",
-      "active.com"
+      "namecheap.com"
     ],
     "onevision.com.tw": [
       "udn.com"
@@ -6262,11 +11224,7 @@
     "openx.net": [
       "yahoo.com",
       "amazon.com",
-      "nytimes.com",
-      "dropbox.com",
-      "theverge.com",
-      "jsonline.com",
-      "active.com"
+      "nytimes.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -6281,18 +11239,17 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
+      "nytimes.com",
       "bbc.com",
       "live.com",
       "ibm.com",
-      "wiley.com",
+      "hp.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
-      "constantcontact.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
-      "scientificamerican.com",
       "evernote.com",
       "box.com",
       "prezi.com",
@@ -6302,7 +11259,6 @@
       "accorhotels.com",
       "uber.com",
       "xbox.com",
-      "history.com",
       "bestbuy.com",
       "jamanetwork.com",
       "imageshack.com",
@@ -6311,12 +11267,12 @@
       "metmuseum.org",
       "intuit.com",
       "blizzard.com",
+      "office.com",
       "squareup.com",
       "starbucks.com",
       "ajc.com",
       "justgiving.com",
       "dreamhost.com",
-      "microsoft.com",
       "edx.org",
       "bartleby.com",
       "malwarebytes.com",
@@ -6355,10 +11311,7 @@
     "outbrain.com": [
       "nature.com",
       "scribd.com",
-      "foxnews.com",
-      "cnn.com",
-      "news.com.au",
-      "rfi.fr"
+      "foxnews.com"
     ],
     "ovh.com": [
       "ovh.co.uk"
@@ -6366,8 +11319,7 @@
     "owneriq.net": [
       "lycos.com",
       "lg.com",
-      "washingtontimes.com",
-      "walgreens.com"
+      "washingtontimes.com"
     ],
     "owox.com": [
       "simplesite.com"
@@ -6378,16 +11330,12 @@
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org",
-      "propublica.org"
+      "ap.org"
     ],
     "parsely.com": [
       "time.com",
       "wired.com",
-      "wikia.com",
-      "wsj.com",
-      "fortune.com",
-      "rfi.fr"
+      "wikia.com"
     ],
     "paypal.com": [
       "paypal.me"
@@ -6399,9 +11347,6 @@
     ],
     "payroll.com": [
       "intuit.com"
-    ],
-    "pbbl.co": [
-      "zappos.com"
     ],
     "pbskids.org": [
       "pbs.org"
@@ -6430,16 +11375,12 @@
     "pinterest.com": [
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "nytimes.com",
-      "themeforest.net",
-      "booking.com",
-      "marthastewart.com"
+      "nytimes.com"
     ],
     "pitchfork.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "epicurious.com"
+      "vanityfair.com"
     ],
     "pixanalytics.com": [
       "pixnet.net"
@@ -6466,8 +11407,7 @@
     "po.st": [
       "smithsonianmag.com",
       "wnd.com",
-      "business2community.com",
-      "nme.com"
+      "business2community.com"
     ],
     "polymorphicads.jp": [
       "shinobi.jp"
@@ -6481,10 +11421,7 @@
     "postrelease.com": [
       "reuters.com",
       "independent.co.uk",
-      "chicagotribune.com",
-      "wsj.com",
-      "marketwatch.com",
-      "bostonherald.com"
+      "chicagotribune.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
@@ -6496,14 +11433,12 @@
     ],
     "prfct.co": [
       "smugmug.com",
-      "marthastewart.com",
-      "business2community.com"
+      "marthastewart.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
       "symantec.com",
-      "slashdot.org",
-      "business2community.com"
+      "slashdot.org"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
@@ -6537,11 +11472,7 @@
     "pubmatic.com": [
       "dropbox.com",
       "tinyurl.com",
-      "bloomberg.com",
-      "usatoday.com",
-      "webmd.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "bloomberg.com"
     ],
     "pubmine.com": [
       "foreignpolicy.com",
@@ -6574,8 +11505,7 @@
     "pymx5.com": [
       "seattletimes.com",
       "seattlepi.com",
-      "sfgate.com",
-      "cracked.com"
+      "sfgate.com"
     ],
     "qnsr.com": [
       "serverwatch.com"
@@ -6595,16 +11525,13 @@
     "qualtrics.com": [
       "adidas.com",
       "cnet.com",
-      "babycenter.com"
+      "babycenter.com",
+      "mayoclinic.org"
     ],
     "quantserve.com": [
       "wordpress.org",
       "vimeo.com",
-      "reddit.com",
-      "soundcloud.com",
-      "goodreads.com",
-      "jsonline.com",
-      "rfi.fr"
+      "reddit.com"
     ],
     "quantummetric.com": [
       "macys.com"
@@ -6618,9 +11545,7 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com",
-      "nypost.com",
-      "eset.com"
+      "ning.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -6635,8 +11560,7 @@
       "livejournal.com",
       "washingtonpost.com",
       "novostimira.com",
-      "ria.ru",
-      "kharkov.ua"
+      "ria.ru"
     ],
     "rbnt.org": [
       "radikal.ru"
@@ -6652,9 +11576,6 @@
     "reddit.com": [
       "acm.org",
       "perl.com"
-    ],
-    "redditmedia.com": [
-      "reddit.com"
     ],
     "redlink.com": [
       "jamanetwork.com",
@@ -6698,16 +11619,12 @@
       "bankrate.com"
     ],
     "rezync.com": [
-      "economist.com",
-      "accuweather.com"
+      "economist.com"
     ],
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
-      "npr.org",
-      "forbes.com",
-      "foursquare.com",
-      "gopro.com"
+      "npr.org"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6727,18 +11644,12 @@
     "rkdms.com": [
       "time.com",
       "wired.com",
-      "cbsnews.com",
-      "zdnet.com",
-      "pitchfork.com"
+      "cbsnews.com"
     ],
     "rlcdn.com": [
       "adobe.com",
       "yahoo.com",
-      "sourceforge.net",
-      "reddit.com",
-      "uci.edu",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "rnengage.com": [
       "oracle.com",
@@ -6765,17 +11676,12 @@
     ],
     "ru4.com": [
       "dropbox.com",
-      "bloomberg.com",
-      "uci.edu"
+      "bloomberg.com"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
-      "sourceforge.net",
-      "nytimes.com",
-      "gizmodo.com",
-      "jsonline.com",
-      "xda-developers.com"
+      "sourceforge.net"
     ],
     "rundsp.com": [
       "hpe.com",
@@ -6800,8 +11706,7 @@
       "constantcontact.com",
       "marriott.com",
       "prweb.com",
-      "salesforce.com",
-      "eset.com"
+      "salesforce.com"
     ],
     "salesloft.com": [
       "techtarget.com",
@@ -6848,11 +11753,7 @@
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
-      "tumblr.com",
-      "nytimes.com",
-      "goodreads.com",
-      "jsonline.com",
-      "drugs.com"
+      "tumblr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
@@ -6881,15 +11782,12 @@
     "selectablemedia.com": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com",
-      "marthastewart.com"
+      "ew.com"
     ],
     "self.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "semasio.net": [
       "bloomberg.com"
@@ -6901,8 +11799,7 @@
     "servebom.com": [
       "venturebeat.com",
       "livescience.com",
-      "space.com",
-      "xda-developers.com"
+      "space.com"
     ],
     "servedby-buysellads.com": [
       "dribbble.com"
@@ -6913,9 +11810,7 @@
     "serving-sys.com": [
       "dropbox.com",
       "t-online.de",
-      "nbcnews.com",
-      "news.com.au",
-      "hgtv.com"
+      "nbcnews.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
@@ -6928,16 +11823,12 @@
     "sharethis.com": [
       "www.uk.com",
       "whatsapp.com",
-      "lycos.com",
-      "uci.edu",
-      "dailycaller.com"
+      "lycos.com"
     ],
     "sharethrough.com": [
       "yahoo.com",
       "cnn.com",
-      "time.com",
-      "cnet.com",
-      "fortune.com"
+      "time.com"
     ],
     "sheego.de": [
       "t-online.de"
@@ -6977,11 +11868,7 @@
     "siteimprove.com": [
       "usda.gov",
       "verisign.com",
-      "udel.edu",
-      "berkeley.edu",
-      "helsinki.fi",
-      "case.edu",
-      "oclc.org"
+      "udel.edu"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
@@ -6997,16 +11884,12 @@
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "seattletimes.com",
-      "accuweather.com",
-      "newatlas.com"
+      "seattletimes.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com",
-      "arstechnica.com",
-      "coindesk.com"
+      "gizmodo.com"
     ],
     "sky.com": [
       "skygroup.sky",
@@ -7043,10 +11926,7 @@
     "snapchat.com": [
       "jimdo.com",
       "overstock.com",
-      "complex.com",
-      "wsj.com",
-      "giphy.com",
-      "zappos.com"
+      "complex.com"
     ],
     "snapwidget.com": [
       "udel.edu"
@@ -7097,11 +11977,7 @@
     "sonobi.com": [
       "photobucket.com",
       "deviantart.com",
-      "springer.com",
-      "forbes.com",
-      "theverge.com",
-      "jsonline.com",
-      "couchsurfing.com"
+      "springer.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -7110,7 +11986,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "mo.gov"
+      "irishtimes.com"
     ],
     "sourceforge.net": [
       "libpng.org"
@@ -7151,9 +12027,7 @@
     "spotxchange.com": [
       "amazon.com",
       "dropbox.com",
-      "dailymotion.com",
-      "thenextweb.com",
-      "bostonherald.com"
+      "dailymotion.com"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -7167,8 +12041,7 @@
     "springserve.com": [
       "tinypic.com",
       "liveuamap.com",
-      "magento.com",
-      "dailydot.com"
+      "magento.com"
     ],
     "sprinklr.com": [
       "autodesk.com"
@@ -7193,9 +12066,7 @@
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org",
-      "cbslocal.com",
-      "zerohedge.com"
+      "man7.org"
     ],
     "staticimgfarm.com": [
       "excite.com"
@@ -7206,8 +12077,7 @@
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "istockphoto.com",
-      "careerbuilder.com"
+      "istockphoto.com"
     ],
     "steepto.com": [
       "liveleak.com"
@@ -7248,14 +12118,12 @@
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com",
-      "makezine.com"
+      "studiopress.com"
     ],
     "sundaysky.com": [
       "overstock.com",
       "alternet.org",
-      "infoplease.com",
-      "dailydot.com"
+      "infoplease.com"
     ],
     "suning.com": [
       "qq.com",
@@ -7279,8 +12147,7 @@
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
-      "indianexpress.com",
-      "springer.com"
+      "indianexpress.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -7292,11 +12159,7 @@
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
-      "t-online.de",
-      "msn.com",
-      "zdnet.com",
-      "jsonline.com",
-      "edmunds.com"
+      "t-online.de"
     ],
     "tacdn.com": [
       "tripadvisor.com"
@@ -7323,14 +12186,12 @@
       "sina.com.cn",
       "1688.com",
       "tmall.com",
-      "51.la"
+      "alibaba.com"
     ],
     "tapad.com": [
       "adobe.com",
       "yahoo.com",
-      "soundcloud.com",
-      "dropbox.com",
-      "newyorker.com"
+      "soundcloud.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -7347,20 +12208,12 @@
     "tealiumiq.com": [
       "ibm.com",
       "cbsnews.com",
-      "evernote.com",
-      "cnet.com",
-      "politico.com",
-      "usmagazine.com"
+      "evernote.com"
     ],
     "technolutions.net": [
       "illinois.edu",
       "upenn.edu",
-      "uci.edu",
-      "udel.edu",
-      "case.edu"
-    ],
-    "technoratimedia.com": [
-      "accuweather.com"
+      "uci.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -7368,8 +12221,7 @@
     "teenvogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "telegraph.co.uk": [
       "wordpress.com"
@@ -7391,8 +12243,7 @@
     "thebrighttag.com": [
       "netflix.com",
       "wufoo.com",
-      "playstation.com",
-      "zappos.com"
+      "playstation.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -7406,9 +12257,6 @@
     "thomsonreuters.com": [
       "reuters.com"
     ],
-    "thrtle.com": [
-      "xda-developers.com"
-    ],
     "tidaltv.com": [
       "dailymotion.com",
       "nationalgeographic.com",
@@ -7420,9 +12268,7 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com",
-      "marthastewart.com"
+      "ew.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -7430,19 +12276,14 @@
     "tinypass.com": [
       "businessinsider.com",
       "techcrunch.com",
-      "kickstarter.com",
-      "bloomberg.com",
-      "gizmodo.com",
-      "vancouversun.com"
+      "kickstarter.com"
     ],
     "tiqcdn.com": [
       "cisco.com",
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
-      "marketwatch.com",
-      "hpe.com",
-      "orange.fr"
+      "hpe.com"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -7457,10 +12298,7 @@
     "tns-counter.ru": [
       "livejournal.com",
       "vk.com",
-      "yandex.ru",
-      "mail.ru",
-      "ok.ru",
-      "radikal.ru"
+      "yandex.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
@@ -7516,8 +12354,7 @@
     "tribalfusion.com": [
       "dailymotion.com",
       "pastebin.com",
-      "liveleak.com",
-      "marriott.com"
+      "liveleak.com"
     ],
     "tribl.io": [
       "prezi.com",
@@ -7562,10 +12399,7 @@
     "turn.com": [
       "bloomberg.com",
       "wired.com",
-      "webmd.com",
-      "economist.com",
-      "booking.com",
-      "pitchfork.com"
+      "webmd.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
@@ -7573,9 +12407,7 @@
     "tvsquared.com": [
       "telegraph.co.uk",
       "jimdo.com",
-      "squarespace.com",
-      "economist.com",
-      "booking.com"
+      "squarespace.com"
     ],
     "twimg.com": [
       "coe.int",
@@ -7586,21 +12418,13 @@
       "wordpress.org",
       "yahoo.com",
       "chicagotribune.com",
-      "nytimes.com",
       "cnn.com",
-      "msn.com",
-      "ca.gov",
-      "parallels.com",
-      "sfgate.com",
-      "marthastewart.com",
-      "helsinki.fi",
-      "edmunds.com"
+      "cnet.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com",
-      "dailycaller.com"
+      "washingtontimes.com"
     ],
     "ubi.com": [
       "ubisoft.com"
@@ -7663,8 +12487,7 @@
     "usa.gov": [
       "transportation.gov",
       "dhs.gov",
-      "usembassy.gov",
-      "osha.gov"
+      "usembassy.gov"
     ],
     "useproof.com": [
       "iconosquare.com"
@@ -7696,8 +12519,7 @@
     "vanityfair.com": [
       "wired.com",
       "newyorker.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "veinteractive.com": [
       "prweb.com",
@@ -7729,23 +12551,17 @@
       "hpe.com"
     ],
     "videohub.tv": [
-      "liveuamap.com",
-      "wsj.com",
-      "uci.edu"
+      "liveuamap.com"
     ],
     "vidible.tv": [
       "aol.com",
       "nydailynews.com",
-      "autoblog.com",
-      "huffingtonpost.com"
+      "autoblog.com"
     ],
     "viglink.com": [
       "zdnet.com",
       "softonic.com",
-      "techrepublic.com",
-      "cnet.com",
-      "thedailybeast.com",
-      "xda-developers.com"
+      "techrepublic.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
@@ -7758,16 +12574,12 @@
       "livestream.com",
       "wufoo.com",
       "heroku.com",
-      "emarketer.com",
-      "oclc.org"
+      "designboom.com"
     ],
     "vindicosuite.com": [
       "myspace.com",
       "fortune.com",
-      "people.com",
-      "time.com",
-      "marthastewart.com",
-      "zappos.com"
+      "people.com"
     ],
     "virgilio.it": [
       "libero.it"
@@ -7781,17 +12593,12 @@
     "vk.com": [
       "rt.com",
       "templatemonster.com",
-      "ria.ru",
-      "yandex.ru"
-    ],
-    "vmmpxl.com": [
-      "networksolutions.com"
+      "ria.ru"
     ],
     "vogue.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "volvelle.tech": [
       "prweb.com",
@@ -7807,11 +12614,13 @@
     "vtracy.de": [
       "bloomberg.com"
     ],
+    "vulture.com": [
+      "nymag.com"
+    ],
     "w55c.net": [
       "hpe.com",
       "ebay.com",
-      "sourceforge.net",
-      "pbs.org"
+      "sourceforge.net"
     ],
     "wallst.com": [
       "reuters.com"
@@ -7840,8 +12649,7 @@
     "weborama.fr": [
       "lemonde.fr",
       "rbc.ru",
-      "lexpress.fr",
-      "leparisien.fr"
+      "lexpress.fr"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -7865,8 +12673,7 @@
     "webtrendslive.com": [
       "nature.com",
       "abc.net.au",
-      "oup.com",
-      "dhl.com"
+      "oup.com"
     ],
     "weibo.com": [
       "sina.com.cn"
@@ -7890,8 +12697,7 @@
     "wired.com": [
       "newyorker.com",
       "vanityfair.com",
-      "vogue.com",
-      "pitchfork.com"
+      "vogue.com"
     ],
     "wise.space": [
       "purevolume.com"
@@ -7901,7 +12707,7 @@
       "suntimes.com",
       "canada.com",
       "globalnews.ca",
-      "bostonherald.com"
+      "vancouversun.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
@@ -7928,8 +12734,7 @@
     "wmagazine.com": [
       "wired.com",
       "newyorker.com",
-      "vanityfair.com",
-      "pitchfork.com"
+      "vanityfair.com"
     ],
     "wnyc.org": [
       "newyorker.com",
@@ -7997,9 +12802,7 @@
     "xiti.com": [
       "lemonde.fr",
       "unblog.fr",
-      "uefa.com",
-      "skyrock.com",
-      "leparisien.fr"
+      "uefa.com"
     ],
     "xlisting.jp": [
       "rakuten.co.jp",
@@ -8020,25 +12823,17 @@
     "yadro.ru": [
       "vk.com",
       "novostimira.com",
-      "mail.ru",
-      "rt.com",
-      "ok.ru",
-      "radikal.ru"
+      "mail.ru"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
       "exblog.jp",
-      "rakuten.co.jp",
-      "economist.com",
-      "biglobe.ne.jp"
+      "rakuten.co.jp"
     ],
     "yahoo.com": [
       "amazon.com",
       "vimeo.com",
-      "flickr.com",
-      "sourceforge.net",
-      "theverge.com",
-      "xda-developers.com"
+      "flickr.com"
     ],
     "yahoosmallbusiness.com": [
       "yahoo.com"
@@ -8048,12 +12843,7 @@
       "opera.com",
       "stanford.edu",
       "ning.com",
-      "rt.com",
-      "fourseasons.com",
-      "radikal.ru",
-      "yandex.com",
-      "kharkov.ua",
-      "rambler.ru"
+      "fourseasons.com"
     ],
     "yandex.ua": [
       "kharkov.ua",
@@ -8062,8 +12852,7 @@
     "yastatic.net": [
       "qip.ru",
       "tass.ru",
-      "radikal.ru",
-      "yandex.com"
+      "radikal.ru"
     ],
     "yieldify.com": [
       "logitech.com"
@@ -8071,8 +12860,7 @@
     "yieldlab.net": [
       "spiegel.de",
       "heise.de",
-      "faz.net",
-      "statista.com"
+      "faz.net"
     ],
     "yieldoptimizer.com": [
       "ihg.com",
@@ -8084,15 +12872,12 @@
       "flickr.com",
       "nytimes.com",
       "dropbox.com",
-      "aol.com",
-      "qualtrics.com",
       "eset.com"
     ],
     "yldbt.com": [
       "wired.com",
       "arstechnica.com",
-      "newyorker.com",
-      "pcworld.com"
+      "newyorker.com"
     ],
     "ymetrica1.com": [
       "kharkov.ua",
@@ -8117,12 +12902,9 @@
       "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
-      "redhat.com",
-      "skyrock.com",
       "caltech.edu",
-      "dailykos.com",
-      "honeywell.com",
-      "amazon.com"
+      "acm.org",
+      "honeywell.com"
     ],
     "youvisit.com": [
       "osu.edu",
@@ -8138,8 +12920,7 @@
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com",
-      "everydayhealth.com"
+      "ign.com"
     ],
     "zedo.com": [
       "tinypic.com",
@@ -8149,10 +12930,7 @@
     "zemanta.com": [
       "independent.co.uk",
       "thehill.com",
-      "farfetch.com",
-      "paypal.com",
-      "lemonde.fr",
-      "infoplease.com"
+      "farfetch.com"
     ],
     "zendesk.com": [
       "jugem.jp",
@@ -8163,7 +12941,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "marketwatch.com"
+      "wunderground.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -8189,14 +12967,11 @@
       "biglobe.ne.jp",
       "uga.edu"
     ],
-    "zopim.com": [
-      "lulu.com"
-    ],
     "zprk.io": [
       "news.com.au",
       "theaustralian.com.au",
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.22"
+  "version": "2018.8.23"
 }

--- a/results.json
+++ b/results.json
@@ -3,7 +3,13 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537523787722,
+      "nextUpdateTime": 1535295667139,
+      "userAction": ""
+    },
+    "112-tzm-766.mktoresp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535189289123,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,43 +33,31 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537882843856,
-      "userAction": ""
-    },
-    "1dmp.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535312804098,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537605774759,
-      "userAction": ""
-    },
-    "247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535134607453,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537672087946,
+      "nextUpdateTime": 1535331723304,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537759773496,
+      "nextUpdateTime": 1535040469247,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537525630119,
+      "nextUpdateTime": 1535364762306,
       "userAction": ""
     },
     "2o7.net": {
@@ -78,220 +72,148 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "4139589.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537489663543,
-      "userAction": ""
-    },
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537839020503,
+      "nextUpdateTime": 1535356269183,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537806789164,
+      "nextUpdateTime": 1535074621092,
+      "userAction": ""
+    },
+    "4303900.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535426959834,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550836808,
-      "userAction": ""
-    },
-    "4488211.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537634827185,
+      "nextUpdateTime": 1535137738544,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537660954849,
+      "nextUpdateTime": 1535183264209,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537616474930,
+      "nextUpdateTime": 1535280524361,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537903679851,
-      "userAction": ""
-    },
-    "5035317.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537641921682,
-      "userAction": ""
-    },
-    "516-dgm-318.mktoresp.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537562933555,
+      "nextUpdateTime": 1535472616612,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537758474854,
+      "nextUpdateTime": 1535031682414,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537647432807,
+      "nextUpdateTime": 1535215572202,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537658367928,
+      "nextUpdateTime": 1535177286890,
       "userAction": ""
     },
     "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537467654547,
+      "nextUpdateTime": 1535018916902,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537755076104,
+      "nextUpdateTime": 1535274302650,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537709469941,
+      "nextUpdateTime": 1535389775911,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537696294907,
-      "userAction": ""
-    },
-    "8136595.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537582726061,
+      "nextUpdateTime": 1535445598247,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537660816632,
-      "userAction": ""
-    },
-    "8329645.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537554078620,
+      "nextUpdateTime": 1535518717819,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537684895391,
+      "nextUpdateTime": 1535325869162,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537837354591,
-      "userAction": ""
-    },
-    "a.postrelease.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537515526187,
+      "nextUpdateTime": 1535522409644,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537636809064,
-      "userAction": ""
-    },
-    "a.tribalfusion.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537958298176,
-      "userAction": ""
-    },
-    "a.volvelle.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537841163145,
+      "nextUpdateTime": 1535199928678,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537476962673,
-      "userAction": ""
-    },
-    "a2.zassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537619523629,
-      "userAction": ""
-    },
-    "a2352870194.cdn.optimizely.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537899708209,
+      "nextUpdateTime": 1535405476367,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537759103890,
+      "nextUpdateTime": 1535121490945,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537776388617,
+      "nextUpdateTime": 1535247839389,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537630083868,
+      "nextUpdateTime": 1535208406610,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537555408578,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535357668253,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537905178162,
-      "userAction": ""
-    },
-    "aax-us-east.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537913502506,
-      "userAction": ""
-    },
-    "aax.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537906291842,
+      "nextUpdateTime": 1535409461357,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -302,14 +224,14 @@
     },
     "accounts.us1.gigya.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537601074233,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535156435397,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537557514250,
+      "nextUpdateTime": 1535108086040,
       "userAction": ""
     },
     "acpm.fr": {
@@ -318,34 +240,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "action.media6degrees.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535233559120,
+      "userAction": ""
+    },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537770198983,
+      "nextUpdateTime": 1535445319044,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537767132056,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535108800392,
+      "userAction": ""
+    },
+    "ad-score.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537485350920,
-      "userAction": ""
-    },
-    "ad.wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537516510407,
-      "userAction": ""
-    },
-    "addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535102726609,
       "userAction": ""
     },
     "addthis.com": {
@@ -372,22 +294,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "admission.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adobedtm.com": {
+    "ado.pro-market.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535519674298,
       "userAction": ""
     },
     "adroll.com": {
@@ -396,46 +312,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ads.investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537516218769,
-      "userAction": ""
-    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537626134365,
+      "nextUpdateTime": 1535398864857,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537724241784,
+      "nextUpdateTime": 1535306789983,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537486989192,
+      "nextUpdateTime": 1535092678429,
+      "userAction": ""
+    },
+    "ads.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535426799358,
+      "userAction": ""
+    },
+    "ads.yahoo.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535030171231,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537708083756,
+      "nextUpdateTime": 1535335292087,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537655918135,
+      "nextUpdateTime": 1535060659368,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537843092747,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535399234345,
       "userAction": ""
     },
     "adsnative.com": {
@@ -462,40 +384,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adzerk.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aidata.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "aimfar.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537722347207,
-      "userAction": ""
-    },
-    "aimfr.solution.weborama.fr": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537807566362,
-      "userAction": ""
-    },
-    "akamaihd.net": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535397031257,
       "userAction": ""
     },
     "allure.com": {
@@ -510,6 +408,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazon.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "amazoncustomerservice.d2.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -519,25 +423,37 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537524155167,
+      "nextUpdateTime": 1535221452777,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537553863674,
+      "nextUpdateTime": 1535417025823,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537697793123,
+      "nextUpdateTime": 1535346469077,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537579018050,
+      "nextUpdateTime": 1535137200226,
+      "userAction": ""
+    },
+    "an.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535052792707,
+      "userAction": ""
+    },
+    "analytics.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535128575286,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -549,61 +465,67 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537594235413,
+      "nextUpdateTime": 1535122809239,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537632246708,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535528849979,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537678263693,
+      "nextUpdateTime": 1535478349814,
+      "userAction": ""
+    },
+    "api-public.addthis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535028419051,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537568296851,
+      "nextUpdateTime": 1535072558804,
       "userAction": ""
     },
-    "api.adsnative.com": {
+    "api.autopilothq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537621901239,
+      "nextUpdateTime": 1535149168850,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537740805532,
-      "userAction": ""
-    },
-    "api.circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537919792740,
+      "nextUpdateTime": 1535356553700,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537467277113,
+      "nextUpdateTime": 1535476779656,
+      "userAction": ""
+    },
+    "api.nanigans.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535271136144,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537525258759,
+      "nextUpdateTime": 1535191722826,
       "userAction": ""
     },
     "api.viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537628885397,
+      "nextUpdateTime": 1535274925730,
       "userAction": ""
     },
     "apis.google.com": {
@@ -615,7 +537,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537815247633,
+      "nextUpdateTime": 1535159823561,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -624,40 +546,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537452967901,
-      "userAction": ""
-    },
-    "as.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537604250626,
-      "userAction": ""
-    },
-    "assets-gulfnews.sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537535218026,
-      "userAction": ""
-    },
-    "assets.adobedtm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537685560379,
-      "userAction": ""
-    },
-    "atlasobscura-travel.t.domdex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537769347318,
+      "nextUpdateTime": 1535209374580,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -666,76 +558,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.pixel.newscgp.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537470177567,
-      "userAction": ""
-    },
     "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537753859069,
+      "nextUpdateTime": 1535345318345,
       "userAction": ""
     },
-    "avn.innity.com": {
+    "autopilothq.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537492777061,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537781953417,
+      "nextUpdateTime": 1535329606520,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537708713404,
+      "nextUpdateTime": 1535101895013,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537850537520,
+      "nextUpdateTime": 1535115362722,
       "userAction": ""
     },
-    "baidu.com": {
+    "ba.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535152380703,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537861157001,
+      "nextUpdateTime": 1535143260433,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537750898790,
+      "nextUpdateTime": 1535136901003,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537689859400,
-      "userAction": ""
-    },
-    "beacon.sojern.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537672342487,
-      "userAction": ""
-    },
-    "beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535032191274,
       "userAction": ""
     },
     "bfmio.com": {
@@ -746,26 +620,26 @@
     },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537876030242,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535492243358,
       "userAction": ""
     },
     "bid.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537727034118,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535179689143,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537674443840,
+      "nextUpdateTime": 1535233305767,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537764450557,
+      "nextUpdateTime": 1535143686901,
       "userAction": ""
     },
     "bidr.io": {
@@ -792,18 +666,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bizrate.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "block.lp1block.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537539284902,
-      "userAction": ""
-    },
     "boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -828,6 +690,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "boxinc.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535385321750,
+      "userAction": ""
+    },
     "brides.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -837,61 +705,55 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537847715087,
+      "nextUpdateTime": 1535067213156,
+      "userAction": ""
+    },
+    "bs.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535529949166,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537560032812,
+      "nextUpdateTime": 1535054886709,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537515889831,
+      "nextUpdateTime": 1535137900056,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537837415606,
-      "userAction": ""
-    },
-    "c.deployads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537858571539,
+      "nextUpdateTime": 1535357523797,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537866121849,
-      "userAction": ""
-    },
-    "c.pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537906295980,
+      "nextUpdateTime": 1535145618083,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537569480916,
-      "userAction": ""
-    },
-    "c1.neweggimages.com": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537830208904,
+      "nextUpdateTime": 1535528454733,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537459132298,
+      "nextUpdateTime": 1535315021536,
+      "userAction": ""
+    },
+    "cache.vindicosuite.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535244807153,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -900,10 +762,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "canwestglobal.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535234001824,
+      "userAction": ""
+    },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537860188041,
+      "nextUpdateTime": 1535045856033,
+      "userAction": ""
+    },
+    "casale-match.dotomi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535126325622,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -915,115 +789,73 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537952708382,
+      "nextUpdateTime": 1535438164044,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537894424784,
-      "userAction": ""
-    },
-    "cdn.conversant.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537839731513,
+      "nextUpdateTime": 1535185919291,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537882453116,
+      "nextUpdateTime": 1535051441601,
       "userAction": ""
     },
-    "cdn.districtm.io": {
+    "cdn.justuno.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537652824451,
-      "userAction": ""
-    },
-    "cdn.dynamicyield.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537702491205,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535128940934,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537558524129,
+      "nextUpdateTime": 1535215121020,
+      "userAction": ""
+    },
+    "cdn.native.ai": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1529084908284,
       "userAction": ""
     },
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537636079695,
-      "userAction": ""
-    },
-    "cdn.onthe.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537786940871,
-      "userAction": ""
-    },
-    "cdn.selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537631039742,
-      "userAction": ""
-    },
-    "cdn.siftscience.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537918282363,
-      "userAction": ""
-    },
-    "cdn.static.zdbb.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537690344667,
+      "nextUpdateTime": 1535290993902,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537519408272,
+      "nextUpdateTime": 1535233843557,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537558429193,
-      "userAction": ""
-    },
-    "cdn.tynt.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537664574694,
-      "userAction": ""
-    },
-    "cdn.useproof.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537581699904,
+      "nextUpdateTime": 1535041458150,
       "userAction": ""
     },
     "cdn.viglink.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537893245832,
+      "nextUpdateTime": 1535427235391,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537510786988,
+      "nextUpdateTime": 1535106027323,
       "userAction": ""
     },
-    "changeagain.me": {
+    "cdns.gigya.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537608291316,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535141757175,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -1035,37 +867,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537543528064,
-      "userAction": ""
-    },
-    "chirp.bizrate.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537767361677,
-      "userAction": ""
-    },
-    "circularhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ck.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537813214078,
-      "userAction": ""
-    },
-    "ckies.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537727954791,
-      "userAction": ""
-    },
-    "clickability.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535242569428,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -1083,31 +885,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537874053443,
-      "userAction": ""
-    },
-    "cm.ipinyou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537867900784,
-      "userAction": ""
-    },
-    "cm.pos.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537608629045,
-      "userAction": ""
-    },
-    "cmp.smartadserver.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537552077164,
+      "nextUpdateTime": 1535315162739,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537834017634,
+      "nextUpdateTime": 1535414582808,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -1116,34 +900,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "collect-eu-west-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537881878643,
-      "userAction": ""
-    },
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537839202775,
-      "userAction": ""
-    },
-    "collector-pxbecn7fqx.perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537708477519,
-      "userAction": ""
-    },
-    "commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535483507215,
       "userAction": ""
     },
     "company-target.com": {
@@ -1155,7 +915,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537532540484,
+      "nextUpdateTime": 1535403196330,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -1164,40 +924,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "config.lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537725971184,
-      "userAction": ""
-    },
-    "configusa.veinteractive.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537500033910,
-      "userAction": ""
-    },
-    "connatix.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537748225044,
+      "nextUpdateTime": 1535381483975,
       "userAction": ""
     },
     "consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "consent-pref.trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537709448258,
       "userAction": ""
     },
     "consent.google.com": {
@@ -1209,13 +945,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537501606547,
+      "nextUpdateTime": 1535345800844,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537773991938,
+      "nextUpdateTime": 1535058410852,
       "userAction": ""
     },
     "contextweb.com": {
@@ -1227,43 +963,25 @@
     "conv-blizzard-emea.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537925186078,
+      "nextUpdateTime": 1535068114235,
       "userAction": ""
     },
     "conv-blizzard-na.cd.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537555515485,
-      "userAction": ""
-    },
-    "core.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537786354696,
+      "nextUpdateTime": 1535434015564,
       "userAction": ""
     },
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537671549081,
+      "nextUpdateTime": 1535232747387,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cquotient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "cr.frontend.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537492445133,
       "userAction": ""
     },
     "criteo.com": {
@@ -1275,19 +993,7 @@
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537613129543,
-      "userAction": ""
-    },
-    "csi.gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537727420108,
-      "userAction": ""
-    },
-    "cstatic.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537815897116,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cxense.com": {
@@ -1299,76 +1005,58 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537760155029,
-      "userAction": ""
-    },
-    "d.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537624262906,
+      "nextUpdateTime": 1535381374242,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537517182021,
+      "nextUpdateTime": 1535298770056,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537841732692,
+      "nextUpdateTime": 1535372426642,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537846817170,
+      "nextUpdateTime": 1535024017932,
       "userAction": ""
     },
-    "d3kkw-y716t.ads.tremorhub.com": {
+    "data.ad-score.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537748341344,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535525960694,
       "userAction": ""
     },
     "data.dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537599056552,
+      "nextUpdateTime": 1535390484851,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537601944767,
+      "nextUpdateTime": 1535073773964,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537599995118,
+      "nextUpdateTime": 1535167766489,
       "userAction": ""
     },
-    "daum.net": {
+    "dc.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "delivery.zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537523645440,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535494300698,
       "userAction": ""
     },
     "demdex.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1380,27 +1068,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "dianomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "digikulture-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537523129525,
-      "userAction": ""
-    },
-    "digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1410,16 +1080,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dis.criteo.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537527991706,
-      "userAction": ""
-    },
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537834942901,
+      "nextUpdateTime": 1535051700652,
+      "userAction": ""
+    },
+    "display.bfmio.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535248736855,
       "userAction": ""
     },
     "districtm.io": {
@@ -1428,27 +1098,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dmg.digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537599597142,
-      "userAction": ""
-    },
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537456298791,
+      "nextUpdateTime": 1535207581785,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "domdex.com": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1467,7 +1125,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537753424164,
+      "nextUpdateTime": 1535141129266,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1476,22 +1134,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dt.admission.net": {
+    "dsum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537648146014,
-      "userAction": ""
-    },
-    "dt.cobaltgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537780764105,
-      "userAction": ""
-    },
-    "dudintrec.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537533439543,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535450697822,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1500,28 +1146,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "e-2072.adzerk.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537905006966,
-      "userAction": ""
-    },
     "eb2.3lift.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537507933433,
-      "userAction": ""
-    },
-    "ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535466272567,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1530,16 +1158,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "echo.intergient.com": {
+    "ebaystatic.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537592599902,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537936892363,
+      "nextUpdateTime": 1535503094601,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1557,25 +1185,7 @@
     "em.licasd.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537958553018,
-      "userAction": ""
-    },
-    "embed.sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537911579947,
-      "userAction": ""
-    },
-    "engage.commander1.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537768821556,
-      "userAction": ""
-    },
-    "engine.addroplet.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537919419023,
+      "nextUpdateTime": 1535483929811,
       "userAction": ""
     },
     "epicurious.com": {
@@ -1584,22 +1194,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eset.marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537501049394,
-      "userAction": ""
-    },
     "eset.tt.omtrdc.net": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535323726127,
+      "userAction": ""
+    },
+    "eus.rubiconproject.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537948559383,
+      "nextUpdateTime": 1535510670417,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537902234192,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535114411199,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1611,7 +1221,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537909681312,
+      "nextUpdateTime": 1535054385053,
       "userAction": ""
     },
     "exelator.com": {
@@ -1623,7 +1233,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537914393364,
+      "nextUpdateTime": 1535128843717,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1634,7 +1244,7 @@
     },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1647,13 +1257,13 @@
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537575820847,
+      "nextUpdateTime": 1535385394512,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537545195020,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535108377514,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1668,18 +1278,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "fls-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537946679180,
-      "userAction": ""
-    },
-    "fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537876172595,
-      "userAction": ""
-    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1689,7 +1287,13 @@
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537689231760,
+      "nextUpdateTime": 1535512337961,
+      "userAction": ""
+    },
+    "freestar-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436668569,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1698,76 +1302,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "futurenet-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535071225476,
+      "userAction": ""
+    },
     "fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.ign.com": {
+    "g.cn.miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537541650706,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535399901695,
       "userAction": ""
     },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537627486048,
+      "nextUpdateTime": 1535330828661,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537665925657,
+      "nextUpdateTime": 1535259298411,
+      "userAction": ""
+    },
+    "gakogedifoda.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535101364820,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537702487137,
+      "nextUpdateTime": 1535176199996,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537759846881,
+      "nextUpdateTime": 1535402637759,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537478628987,
+      "nextUpdateTime": 1535343921291,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537711670087,
-      "userAction": ""
-    },
-    "geocoding.internetbrands.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537874591769,
+      "nextUpdateTime": 1535452798906,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537510348476,
+      "nextUpdateTime": 1535333296953,
       "userAction": ""
     },
     "geosync.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537682619526,
-      "userAction": ""
-    },
-    "getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535160445716,
       "userAction": ""
     },
     "gigya.com": {
@@ -1777,12 +1381,6 @@
       "userAction": ""
     },
     "glamour.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "globalwebindex.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1809,7 +1407,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537812333564,
+      "nextUpdateTime": 1535491836597,
       "userAction": ""
     },
     "gq.com": {
@@ -1821,7 +1419,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537913818401,
+      "nextUpdateTime": 1535227663022,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1833,25 +1431,19 @@
     "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537826644903,
+      "nextUpdateTime": 1535212137627,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537616533756,
-      "userAction": ""
-    },
-    "gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535485285651,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537604908756,
+      "nextUpdateTime": 1535290294755,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1866,130 +1458,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gwiq-v3.globalwebindex.net": {
+    "hb-api.omnitagjs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537903525761,
+      "nextUpdateTime": 1535189695673,
       "userAction": ""
     },
-    "hdslb.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "hm.baidu.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537567498875,
-      "userAction": ""
-    },
-    "hmcdn.baidu.com": {
+    "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537776901148,
-      "userAction": ""
-    },
-    "i.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537762278852,
+      "nextUpdateTime": 1535078071521,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537847658666,
+      "nextUpdateTime": 1535529602945,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537816173449,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535170174461,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537663039777,
+      "nextUpdateTime": 1535403265784,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537686738742,
+      "nextUpdateTime": 1535288809150,
       "userAction": ""
     },
     "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537737731849,
+      "nextUpdateTime": 1535495293493,
+      "userAction": ""
+    },
+    "id.cxense.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535496907922,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537451086715,
+      "nextUpdateTime": 1535476999744,
       "userAction": ""
     },
-    "identityssl.newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537809654954,
-      "userAction": ""
-    },
-    "idpix.media6degrees.com": {
+    "id5-sync.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537739576272,
+      "nextUpdateTime": 1535383207086,
       "userAction": ""
     },
     "idsync.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537842333111,
-      "userAction": ""
-    },
-    "ign.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535075793702,
       "userAction": ""
     },
     "image2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537592083467,
-      "userAction": ""
-    },
-    "image4.pubmatic.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537704450079,
+      "nextUpdateTime": 1535291313527,
       "userAction": ""
     },
     "image6.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537653168221,
-      "userAction": ""
-    },
-    "images.taboola.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537513469490,
-      "userAction": ""
-    },
-    "img.purch.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535365119943,
       "userAction": ""
     },
     "img.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537501222395,
+      "nextUpdateTime": 1535505276490,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1998,43 +1548,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "in.getclicky.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537565558881,
-      "userAction": ""
-    },
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537568428156,
-      "userAction": ""
-    },
-    "innity.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535249104973,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537950838582,
+      "nextUpdateTime": 1535325186526,
       "userAction": ""
     },
     "insightexpressai.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "insticator-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537956619651,
-      "userAction": ""
-    },
-    "instinctiveads.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2046,91 +1572,49 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "intergient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "internetbrands.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537528784057,
-      "userAction": ""
-    },
-    "investingchannel.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535164044525,
       "userAction": ""
     },
     "iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ipinyou.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "ips-invite.iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537869247546,
-      "userAction": ""
-    },
-    "ir-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537912596310,
-      "userAction": ""
-    },
-    "italiaonline01.wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537811450996,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535325289627,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537570038384,
+      "nextUpdateTime": 1535319029672,
       "userAction": ""
     },
     "js.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537524595439,
-      "userAction": ""
-    },
-    "js.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537709002002,
+      "nextUpdateTime": 1535465747682,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1537453750117,
+      "nextUpdateTime": 1529472262192,
       "userAction": ""
     },
     "jsrdn.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2193,19 +1677,13 @@
     "lcidc.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537480178306,
-      "userAction": ""
-    },
-    "leadintel.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537526964354,
+      "nextUpdateTime": 1535169102934,
       "userAction": ""
     },
     "li.pxl.ace.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537690362083,
+      "nextUpdateTime": 1535477346565,
       "userAction": ""
     },
     "liadm.com": {
@@ -2238,94 +1716,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "live.sekindo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537661966910,
-      "userAction": ""
-    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "load.instinctiveads.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537887139462,
-      "userAction": ""
-    },
     "load77.exelator.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537607433156,
-      "userAction": ""
-    },
-    "loadm.exelator.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537695354708,
+      "nextUpdateTime": 1535166623245,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535068047141,
+      "userAction": ""
+    },
+    "log.outbrain.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537858987653,
-      "userAction": ""
-    },
-    "lockerdome.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537628767640,
-      "userAction": ""
-    },
-    "loggingapi.spingo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537519313806,
+      "nextUpdateTime": 1535473321187,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537938495129,
+      "nextUpdateTime": 1535491014034,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537529381640,
-      "userAction": ""
-    },
-    "lp1block.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "lptag.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537673205510,
-      "userAction": ""
-    },
-    "lrcontent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535260738970,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537931773797,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535399926820,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -2340,40 +1770,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "maps.gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537817500851,
-      "userAction": ""
-    },
     "mapsengine.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "marinsm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "marketlinc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537611772016,
+      "nextUpdateTime": 1535234844708,
       "userAction": ""
     },
     "match.prod.bidr.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537695592254,
+      "nextUpdateTime": 1535264504925,
       "userAction": ""
     },
     "mathtag.com": {
@@ -2385,19 +1797,13 @@
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537781513983,
+      "nextUpdateTime": 1535318601438,
       "userAction": ""
     },
     "media.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "media.workandmoney.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537772218821,
       "userAction": ""
     },
     "media6degrees.com": {
@@ -2409,37 +1815,25 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537450926060,
+      "nextUpdateTime": 1535489306691,
       "userAction": ""
     },
     "mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "mediawallahscript.com": {
+    "miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mediawiki.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mfadsrvr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537740252391,
+      "nextUpdateTime": 1535201966174,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -2451,19 +1845,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537595374693,
-      "userAction": ""
-    },
-    "mps.nbcuni.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537756493707,
-      "userAction": ""
-    },
-    "mssl.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537765088056,
+      "nextUpdateTime": 1535082082006,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -2478,6 +1860,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mtrx.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535142954690,
+      "userAction": ""
+    },
     "mts0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -2487,6 +1875,12 @@
     "mts1.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2502,33 +1896,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nbcu.demdex.net": {
+    "mx.technolutions.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537675565343,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535404018448,
       "userAction": ""
     },
-    "nbcuni.com": {
+    "nanigans.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "news.com.au": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "newscdn.com.au": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2541,7 +1923,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550690745,
+      "nextUpdateTime": 1535018230678,
       "userAction": ""
     },
     "newyorker.com": {
@@ -2550,22 +1932,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexac.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537899672597,
+      "nextUpdateTime": 1535498883050,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537802452858,
+      "nextUpdateTime": 1535229374587,
       "userAction": ""
     },
     "nr-data.net": {
@@ -2574,22 +1950,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oasc10.247realmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537927451218,
-      "userAction": ""
-    },
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537516141999,
+      "nextUpdateTime": 1535425842674,
       "userAction": ""
     },
     "odb.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537837698830,
+      "nextUpdateTime": 1535016850629,
+      "userAction": ""
+    },
+    "omnitagjs.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -2604,39 +1980,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "onthe.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "openx.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ophan.theguardian.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537645962946,
-      "userAction": ""
-    },
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537751703960,
+      "nextUpdateTime": 1535525515019,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ora.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2655,49 +2013,43 @@
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537706817051,
+      "nextUpdateTime": 1535203430840,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537845404551,
-      "userAction": ""
-    },
-    "p.cquotient.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537936279314,
+      "nextUpdateTime": 1535414888339,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537493433158,
+      "nextUpdateTime": 1535206307068,
+      "userAction": ""
+    },
+    "p.liadm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535075363187,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537487063788,
+      "nextUpdateTime": 1535358438619,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537505785246,
-      "userAction": ""
-    },
-    "p.yotpo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537699522129,
+      "nextUpdateTime": 1535256790030,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537845781986,
+      "nextUpdateTime": 1535087119968,
       "userAction": ""
     },
     "pardot.com": {
@@ -2712,45 +2064,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "partner.mediawallahscript.com": {
+    "pba.lijit.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535115013415,
+      "userAction": ""
+    },
+    "pbbl.co": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537679554534,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pbid.pro-market.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535136510150,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537675608382,
-      "userAction": ""
-    },
-    "performgroup.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "perimeterx.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535153992015,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537856276772,
+      "nextUpdateTime": 1535441500485,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2760,106 +2106,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pixel-sc2.adsymptotic.com": {
+    "pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537605179109,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535221836104,
+      "userAction": ""
+    },
+    "pixel-geo.prfct.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535035427244,
       "userAction": ""
     },
     "pixel-sync.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537687745697,
+      "nextUpdateTime": 1535122200195,
+      "userAction": ""
+    },
+    "pixel-us-east.rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535379825285,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537661479633,
+      "nextUpdateTime": 1535237799393,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537936618740,
+      "nextUpdateTime": 1535126888506,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537885552749,
+      "nextUpdateTime": 1535139385386,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537802852606,
-      "userAction": ""
-    },
-    "pixel.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537539611639,
+      "nextUpdateTime": 1535292610867,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537793705979,
+      "nextUpdateTime": 1535355794721,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537853122548,
-      "userAction": ""
-    },
-    "pixel.servebom.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537887790446,
+      "nextUpdateTime": 1535486117158,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537516043381,
-      "userAction": ""
-    },
-    "pixel.zprk.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537669815103,
+      "nextUpdateTime": 1535164323168,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537574398798,
-      "userAction": ""
-    },
-    "placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "platform-api.sharethis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537618692470,
+      "nextUpdateTime": 1535195842399,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537458677035,
+      "nextUpdateTime": 1535484478744,
       "userAction": ""
     },
     "platform.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537800409757,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "play.google.com": {
@@ -2868,22 +2196,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "player.performgroup.com": {
+    "player.vimeo.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537896826240,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535105086109,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537773917321,
-      "userAction": ""
-    },
-    "plugin.tianqijun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537748776986,
+      "nextUpdateTime": 1535030196338,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2894,8 +2216,14 @@
     },
     "po.st": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537500258193,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535441634636,
+      "userAction": ""
+    },
+    "postmedia.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535168204261,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2904,46 +2232,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "privacy.purch.com": {
+    "pr-bh.ybp.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537879271663,
+      "nextUpdateTime": 1535271792808,
       "userAction": ""
     },
-    "proximus.be": {
+    "prfct.co": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "proximus.demdex.net": {
+    "pro-market.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "profile.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537649779975,
+      "nextUpdateTime": 1535039428012,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537770609852,
-      "userAction": ""
-    },
-    "pub.network": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535044042579,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537688216070,
+      "nextUpdateTime": 1535111836244,
       "userAction": ""
     },
     "pubmatic-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537799110233,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535502071689,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2955,73 +2283,61 @@
     "pubmatic2waycm-atl.netmng.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537511161551,
+      "nextUpdateTime": 1535177396397,
       "userAction": ""
     },
     "purch-match.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537491674953,
-      "userAction": ""
-    },
-    "purch-sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537615213593,
-      "userAction": ""
-    },
-    "purch.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535459595542,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537796909603,
+      "nextUpdateTime": 1535250433294,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537576171296,
+      "nextUpdateTime": 1535405852313,
       "userAction": ""
     },
     "px.owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537837144843,
+      "nextUpdateTime": 1535291856491,
       "userAction": ""
     },
     "px.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537627831473,
+      "nextUpdateTime": 1535296720309,
       "userAction": ""
     },
-    "pxlsfvwe-a.akamaihd.net": {
+    "px0.pbbl.co": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537456582086,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535076873350,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537534907217,
+      "nextUpdateTime": 1535420663273,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537631387420,
+      "nextUpdateTime": 1535401599359,
       "userAction": ""
     },
-    "quantcast.mgr.consensu.org": {
+    "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537550668996,
+      "nextUpdateTime": 1535242881020,
       "userAction": ""
     },
     "quantserve.com": {
@@ -3036,58 +2352,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.dmp.sina.com.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537556220411,
-      "userAction": ""
-    },
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537777511413,
+      "nextUpdateTime": 1535170004392,
       "userAction": ""
     },
-    "r.turn.com": {
+    "rambler.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537632510659,
+      "nextUpdateTime": 1535263109404,
       "userAction": ""
     },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537739633160,
+      "nextUpdateTime": 1535384795636,
       "userAction": ""
     },
-    "rd.frontend.weborama.fr": {
+    "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537866844315,
+      "nextUpdateTime": 1535535765113,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537950836227,
+      "nextUpdateTime": 1535462594322,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537482418879,
-      "userAction": ""
-    },
-    "res.suning.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537813301024,
-      "userAction": ""
-    },
-    "revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535189737074,
       "userAction": ""
     },
     "rfihub.com": {
@@ -3110,44 +2414,26 @@
     },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537908971962,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535380552995,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537804281708,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535231527445,
       "userAction": ""
     },
-    "rss.art19.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537506168486,
-      "userAction": ""
-    },
-    "rtb.connatix.com": {
+    "rtax.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537662261105,
+      "nextUpdateTime": 1535104158026,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537891050192,
-      "userAction": ""
-    },
-    "rtb.mfadsrvr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537514930749,
-      "userAction": ""
-    },
-    "rtve.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537766130426,
+      "nextUpdateTime": 1535035055571,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -3158,8 +2444,8 @@
     },
     "rudy.adsnative.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537806612737,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535223087702,
       "userAction": ""
     },
     "s-static.ak.facebook.com": {
@@ -3168,100 +2454,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "s-v6exp1-ds.metric.gstatic.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537824622166,
-      "userAction": ""
-    },
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537718290259,
+      "nextUpdateTime": 1535410059142,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537774137149,
-      "userAction": ""
-    },
-    "s.clickability.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537615272003,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535439279491,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537650324477,
+      "nextUpdateTime": 1535479648873,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537704922531,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535058060751,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537846016887,
+      "nextUpdateTime": 1535459842092,
       "userAction": ""
     },
-    "s.nexac.com": {
+    "s.po.st": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537448578396,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535253080228,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537510193603,
-      "userAction": ""
-    },
-    "s.spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537567561362,
+      "nextUpdateTime": 1535135587742,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537637515918,
+      "nextUpdateTime": 1535507972811,
       "userAction": ""
     },
-    "s1.hdslb.com": {
+    "s.yimg.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537678226590,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535314953789,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537894278733,
+      "nextUpdateTime": 1535242557490,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537945122061,
+      "nextUpdateTime": 1535479363146,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537781342146,
+      "nextUpdateTime": 1535039569298,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537811788622,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535523380151,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -3270,34 +2538,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "samba.tv": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537578272771,
+      "nextUpdateTime": 1535072165940,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537823324902,
+      "nextUpdateTime": 1535215807271,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537733366525,
+      "nextUpdateTime": 1535218882947,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537618963583,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535515673197,
+      "userAction": ""
+    },
+    "scomcluster.cxense.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535069100437,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -3309,19 +2577,13 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537533436741,
-      "userAction": ""
-    },
-    "sdc-qczj.pingan.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537450956832,
+      "nextUpdateTime": 1535020426187,
       "userAction": ""
     },
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537656187416,
+      "nextUpdateTime": 1535485865391,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -3333,114 +2595,84 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537671345425,
+      "nextUpdateTime": 1535061912370,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1537786730710,
+      "nextUpdateTime": 1535411085544,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537738916180,
-      "userAction": ""
-    },
-    "secure-dcr.imrworldwide.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537699103277,
+      "nextUpdateTime": 1535418977196,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537597100597,
+      "nextUpdateTime": 1535188699282,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537856608472,
+      "nextUpdateTime": 1535356996177,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537818295597,
+      "nextUpdateTime": 1535326763580,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537766934140,
+      "nextUpdateTime": 1535483067072,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537525528622,
+      "nextUpdateTime": 1535133299962,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537738077212,
+      "nextUpdateTime": 1535402768464,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537715006767,
+      "nextUpdateTime": 1535195438164,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537949451895,
+      "nextUpdateTime": 1535504287312,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537771009211,
-      "userAction": ""
-    },
-    "segapi.quantserve.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537799252076,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535282607731,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537705585446,
-      "userAction": ""
-    },
-    "sekindo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "selectablemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535259895831,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sendtonews.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3450,27 +2682,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "servicer.traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537770562636,
-      "userAction": ""
-    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "session.timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537902227193,
-      "userAction": ""
-    },
-    "sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3483,25 +2697,19 @@
     "sharethrough.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537848455982,
-      "userAction": ""
-    },
-    "siftscience.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535439209850,
       "userAction": ""
     },
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537498910884,
+      "nextUpdateTime": 1535373129653,
       "userAction": ""
     },
-    "sina.com.cn": {
+    "simage4.pubmatic.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535066804433,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -3528,27 +2736,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "smartlock.google.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537590634754,
-      "userAction": ""
-    },
-    "smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sojern.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3566,31 +2756,19 @@
     },
     "sp.analytics.yahoo.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535418102706,
+      "userAction": ""
+    },
+    "sp1cluster.cxense.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537785069352,
-      "userAction": ""
-    },
-    "spingo.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "sportz.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535265282354,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "spoutable.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3600,64 +2778,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "src.ebay-us.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537556536901,
-      "userAction": ""
-    },
-    "srv-2018-09-19-11.config.parsely.com": {
+    "springserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537798885889,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-09-19-11.pixel.parsely.com": {
+    "srv-2018-08-22-08.config.parsely.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537840754975,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535226346743,
       "userAction": ""
     },
-    "srv-2018-09-19-12.config.parsely.com": {
+    "srv-2018-08-22-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537742571634,
+      "nextUpdateTime": 1535482395839,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537457643347,
+      "nextUpdateTime": 1535222239514,
       "userAction": ""
     },
-    "ssl.gstatic.com": {
+    "ssl.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537647056340,
+      "nextUpdateTime": 1535484066342,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537451072989,
+      "nextUpdateTime": 1535486723866,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537693049279,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535090326798,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537823064117,
-      "userAction": ""
-    },
-    "stanza-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537829817249,
+      "nextUpdateTime": 1535143155903,
       "userAction": ""
     },
     "statcounter.com": {
@@ -3666,22 +2832,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "static.addtoany.com": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1529315030088,
+      "userAction": ""
+    },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537800009124,
+      "nextUpdateTime": 1535046610826,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537792793168,
+      "nextUpdateTime": 1535212699887,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537692165307,
+      "nextUpdateTime": 1535515390425,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -3693,13 +2865,13 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537699249146,
+      "nextUpdateTime": 1535271064884,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537944166201,
+      "nextUpdateTime": 1535237146011,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -3717,7 +2889,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537816897557,
+      "nextUpdateTime": 1535269383338,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -3726,88 +2898,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "suning.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537489764549,
+      "nextUpdateTime": 1535018613611,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537910804572,
+      "nextUpdateTime": 1535172174965,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537852480724,
-      "userAction": ""
-    },
-    "sync.1dmp.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537632266172,
+      "nextUpdateTime": 1535283029520,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537655833858,
+      "nextUpdateTime": 1535249046647,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537809960844,
+      "nextUpdateTime": 1535071305588,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537547540738,
-      "userAction": ""
-    },
-    "sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537713247533,
+      "nextUpdateTime": 1535427669787,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537572759329,
+      "nextUpdateTime": 1535093224646,
+      "userAction": ""
+    },
+    "sync.multiview.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535154068185,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537835499899,
-      "userAction": ""
-    },
-    "sync.teads.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537624685346,
+      "nextUpdateTime": 1535057971306,
       "userAction": ""
     },
     "syndication.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "t.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537621436426,
       "userAction": ""
     },
     "taboola.com": {
@@ -3819,25 +2967,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537914093330,
-      "userAction": ""
-    },
-    "tag.mtrcs.samba.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537709296119,
-      "userAction": ""
-    },
-    "tag.placelocal.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537534262582,
-      "userAction": ""
-    },
-    "tags.news.com.au": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537538118661,
+      "nextUpdateTime": 1535198760139,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -3846,31 +2976,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tap-secure.rubiconproject.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537538702540,
-      "userAction": ""
-    },
-    "target.smi2.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537577942085,
-      "userAction": ""
-    },
-    "tawk.to": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "teads.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "tealiumiq.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "technolutions.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3888,34 +3000,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "theguardian.com": {
+    "thrtle.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535305777635,
+      "userAction": ""
+    },
+    "thumbs.ebaystatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535105272905,
       "userAction": ""
     },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537640116700,
+      "nextUpdateTime": 1535432484423,
       "userAction": ""
     },
-    "tianqijun.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "timecommerce.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "timeinc.demdex.net": {
+    "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537729256682,
+      "nextUpdateTime": 1535420021607,
       "userAction": ""
     },
     "tinypass.com": {
@@ -3926,8 +3032,8 @@
     },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537937981013,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535026689669,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3936,34 +3042,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "token.rubiconproject.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535233393938,
+      "userAction": ""
+    },
+    "top100.rambler.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535125035641,
+      "userAction": ""
+    },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537465663923,
+      "nextUpdateTime": 1535406490099,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537563288279,
+      "nextUpdateTime": 1535061545317,
       "userAction": ""
     },
-    "track.tiara.daum.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537497236250,
-      "userAction": ""
-    },
-    "tracker.marinsm.com": {
+    "track.eyeviewads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537499812373,
-      "userAction": ""
-    },
-    "traffic-media.co": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535155370781,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3975,49 +3081,13 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537523400406,
-      "userAction": ""
-    },
-    "tremorhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535140806281,
       "userAction": ""
     },
     "trends.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trends.revcontent.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537901532266,
-      "userAction": ""
-    },
-    "tribalfusion.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "trk.connatix.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537686193338,
-      "userAction": ""
-    },
-    "trustarc.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "tt.onthe.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537581901703,
       "userAction": ""
     },
     "turn.com": {
@@ -4038,76 +3108,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "udmserve.net": {
+    "u.openx.net": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537562185323,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535092934568,
       "userAction": ""
     },
-    "uid1.vindicosuite.com": {
+    "unagi-eu.amazon.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537610408164,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535382929843,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537452363796,
+      "nextUpdateTime": 1535165883589,
+      "userAction": ""
+    },
+    "us.pixel.newscgp.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535390643472,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537575881910,
+      "nextUpdateTime": 1535170950487,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537608830235,
-      "userAction": ""
-    },
-    "useproof.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "usw-lax.adsrvr.org": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537763324807,
-      "userAction": ""
-    },
-    "utarget.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537715148141,
-      "userAction": ""
-    },
-    "utarget.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537682726445,
-      "userAction": ""
-    },
-    "uuidksinc.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537618704274,
-      "userAction": ""
-    },
-    "va.tawk.to": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537805440945,
-      "userAction": ""
-    },
-    "va.v.liveperson.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1537878052703,
+      "nextUpdateTime": 1535361402673,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -4116,10 +3150,10 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "veinteractive.com": {
+    "vid.springserve.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535169227544,
       "userAction": ""
     },
     "video.google.com": {
@@ -4128,15 +3162,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vidthm.ora.tv": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537694615731,
-      "userAction": ""
-    },
     "viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vimeo.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4149,7 +3183,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537952472327,
+      "nextUpdateTime": 1535199238726,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -4161,25 +3195,19 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537657186694,
+      "nextUpdateTime": 1535207908950,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "volvelle.tech": {
-      "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537667727470,
+      "nextUpdateTime": 1535027449792,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -4191,42 +3219,30 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537733912036,
+      "nextUpdateTime": 1535180305355,
       "userAction": ""
     },
-    "wal.wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537708569754,
-      "userAction": ""
-    },
-    "walker.zdbb.net": {
+    "wam-yahoo.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537817167307,
+      "nextUpdateTime": 1535313044985,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535283879516,
+      "userAction": ""
+    },
+    "web.hb.ad.cpe.dotomi.com": {
+      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537870871496,
+      "nextUpdateTime": 1535315460235,
       "userAction": ""
     },
     "weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "webservices.webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537861304752,
-      "userAction": ""
-    },
-    "webspectator.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4239,12 +3255,12 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537948250508,
+      "nextUpdateTime": 1535484411512,
       "userAction": ""
     },
     "wired.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4260,70 +3276,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "wms-na.amazon-adsystem.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537745601171,
-      "userAction": ""
-    },
-    "wolfram.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "workandmoney.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "ws.sessioncam.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537883425353,
-      "userAction": ""
-    },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537679101909,
-      "userAction": ""
-    },
-    "wsod.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "wt-eu02.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535220842816,
       "userAction": ""
     },
     "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537627118861,
+      "nextUpdateTime": 1535108380967,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537706516009,
+      "nextUpdateTime": 1535451698656,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537908698667,
-      "userAction": ""
-    },
-    "www.beian.gov.cn": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537855591308,
+      "nextUpdateTime": 1535478914675,
       "userAction": ""
     },
     "www.bing.com": {
@@ -4335,55 +3309,43 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537879830064,
+      "nextUpdateTime": 1535198678997,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537909715373,
+      "nextUpdateTime": 1535335746123,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537937591373,
-      "userAction": ""
-    },
-    "www.dezeenjobs.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537949042270,
-      "userAction": ""
-    },
-    "www.ebay.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537620501826,
+      "nextUpdateTime": 1535523057317,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537576232432,
+      "nextUpdateTime": 1535385380509,
       "userAction": ""
     },
     "www.facebook.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537464851481,
+      "nextUpdateTime": 1535341462375,
       "userAction": ""
     },
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537760960508,
+      "nextUpdateTime": 1535086092034,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537799445735,
+      "nextUpdateTime": 1535118488381,
       "userAction": ""
     },
     "www.google.com": {
@@ -4395,121 +3357,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537796743624,
+      "nextUpdateTime": 1535056845706,
       "userAction": ""
     },
-    "www.gstatic.com": {
+    "www.justuno.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537700151945,
-      "userAction": ""
-    },
-    "www.iolam.it": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537685163688,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535134268596,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537892903107,
+      "nextUpdateTime": 1535412347346,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537512827112,
-      "userAction": ""
-    },
-    "www.mediawiki.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537848643853,
+      "nextUpdateTime": 1535503327200,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537683006702,
+      "nextUpdateTime": 1535191271791,
       "userAction": ""
     },
-    "www.ora.tv": {
+    "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537655020701,
-      "userAction": ""
-    },
-    "www.proximus.be": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537909677592,
+      "nextUpdateTime": 1535478932878,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537623685582,
+      "nextUpdateTime": 1535236669569,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537917019886,
+      "nextUpdateTime": 1535386103543,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537575717845,
+      "nextUpdateTime": 1535446262570,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537930791168,
+      "nextUpdateTime": 1535037751236,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537876466089,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535528753563,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537491819248,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535365974182,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537678614153,
+      "nextUpdateTime": 1535532430753,
+      "userAction": ""
+    },
+    "www.yandex.ru": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535024452155,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1537896897167,
+      "nextUpdateTime": 1535040980033,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537567605963,
-      "userAction": ""
-    },
-    "x01.aidata.io": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537635458423,
-      "userAction": ""
-    },
-    "xe19io.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1537820696009,
+      "nextUpdateTime": 1535454366224,
       "userAction": ""
     },
     "xiti.com": {
@@ -4542,9 +3480,15 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yotpo.com": {
+    "yastatic.net": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535352911929,
+      "userAction": ""
+    },
+    "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -4557,40 +3501,22 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1537634465236,
+      "nextUpdateTime": 1535507962998,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1537573698898,
-      "userAction": ""
-    },
-    "zassets.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535038311647,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1537925998104,
+      "nextUpdateTime": 1535217382463,
       "userAction": ""
     },
     "zemanta.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zidtech.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -4599,26 +3525,46 @@
   },
   "snitch_map": {
     "126.net": [
+      "163.com",
+      "fotki.com"
+    ],
+    "127.net": [
       "163.com"
     ],
     "15gifts.com": [
       "thetimes.co.uk"
     ],
     "1dmp.io": [
-      "radikal.ru"
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "1rx.io": [
+      "tinyurl.com",
+      "lycos.com",
+      "photobucket.com"
+    ],
+    "23video.com": [
+      "bandcamp.com"
+    ],
+    "247-inc.net": [
+      "marriott.com"
     ],
     "247realmedia.com": [
       "bmj.com",
+      "aappublications.org",
       "americanbar.org"
     ],
+    "2mdnsys.com": [
+      "liveuamap.com"
+    ],
     "2o7.net": [
+      "mysql.com",
       "cdc.gov",
+      "theatlantic.com",
       "prnewswire.com",
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
-      "philips.com",
-      "cancer.gov",
       "oclc.org"
     ],
     "33across.com": [
@@ -4627,20 +3573,29 @@
     "360.cn": [
       "so.com"
     ],
+    "360buyimg.com": [
+      "jd.com"
+    ],
     "360yield.com": [
       "springer.com",
-      "economist.com",
-      "home.pl"
+      "home.pl",
+      "allafrica.com"
     ],
     "3gl.net": [
-      "economist.com"
+      "istockphoto.com",
+      "gettyimages.com"
     ],
     "3lift.com": [
-      "msn.com",
+      "nature.com",
+      "springer.com",
+      "theverge.com",
       "usatoday.com",
-      "nginx.org",
-      "space.com",
-      "polygon.com"
+      "weather.com",
+      "jsonline.com",
+      "xda-developers.com"
+    ],
+    "4dsply.com": [
+      "wnd.com"
     ],
     "50bang.org": [
       "2345.com"
@@ -4652,26 +3607,50 @@
       "ganji.com"
     ],
     "5p4rk13.com": [
-      "sfu.ca"
+      "sfu.ca",
+      "cdbaby.com"
     ],
     "6sc.co": [
-      "brightcove.com"
+      "zendesk.com",
+      "gotomeeting.com",
+      "rsa.com"
+    ],
+    "7eer.net": [
+      "lenovo.com",
+      "adidas.com"
+    ],
+    "7grid.com": [
+      "mihanblog.com"
     ],
     "aamsitecertifier.com": [
+      "smh.com.au",
       "theglobeandmail.com",
-      "bostonglobe.com",
-      "post-gazette.com"
+      "bostonglobe.com"
+    ],
+    "aaxads.com": [
+      "forbes.com"
     ],
     "abmr.net": [
-      "nike.com",
-      "freetype.org"
+      "paypal.com",
+      "nike.com"
     ],
     "accessatlanta.com": [
       "ajc.com"
     ],
+    "accuweather.com": [
+      "miamiherald.com",
+      "sacbee.com",
+      "kansascity.com"
+    ],
+    "acint.net": [
+      "tomsk.ru",
+      "radikal.ru",
+      "diary.ru"
+    ],
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
+      "liberation.fr",
       "leparisien.fr"
     ],
     "acquia.com": [
@@ -4686,150 +3665,213 @@
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "dropbox.com",
-      "businessinsider.com"
+      "bartleby.com"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-plus.cn": [
-      "sohu.com"
+    "ad-score.com": [
+      "wnd.com"
     ],
     "ad-stir.com": [
       "sakura.ne.jp",
+      "biglobe.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com"
+      "huanqiu.com",
+      "yesky.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
     ],
+    "adaraanalytics.com": [
+      "hyatt.com"
+    ],
     "adc-srv.net": [
       "autodesk.com"
     ],
+    "adclear.net": [
+      "t-online.de"
+    ],
     "addroplet.com": [
-      "washingtonexaminer.com",
-      "wnd.com"
+      "wallinside.com",
+      "wnd.com",
+      "washingtonexaminer.com"
     ],
     "addthis.com": [
+      "nasa.gov",
+      "jimdo.com",
+      "yahoo.com",
       "who.int",
       "columbia.edu",
-      "giphy.com",
-      "heart.org",
       "gulfnews.com"
     ],
+    "addtoany.com": [
+      "irs.gov"
+    ],
     "adentifi.com": [
-      "metmuseum.org"
+      "metmuseum.org",
+      "infoplease.com"
     ],
     "adform.net": [
       "t-online.de",
       "bloomberg.com",
       "springer.com",
-      "si.com",
-      "goal.com"
+      "shutterstock.com",
+      "helsinki.fi"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "sputniknews.com"
-    ],
-    "adhigh.net": [
       "rambler.ru"
     ],
+    "adfront.org": [
+      "joomla.org"
+    ],
+    "adhigh.net": [
+      "rambler.ru",
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "adidas.fi": [
+      "adidas.com"
+    ],
     "adingo.jp": [
-      "seesaa.jp"
+      "biglobe.ne.jp"
     ],
     "adition.com": [
-      "variety.com",
-      "lemonde.fr",
-      "sueddeutsche.de"
+      "bloomberg.com",
+      "dailymotion.com",
+      "spiegel.de",
+      "lemonde.fr"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
     "adkernel.com": [
+      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "howtogeek.com",
-      "dailydot.com"
+      "xda-developers.com"
+    ],
+    "adlmerge.com": [
+      "tomsk.ru"
+    ],
+    "admaster.com.cn": [
+      "autohome.com.cn",
+      "bshare.cn",
+      "youku.com"
     ],
     "admission.net": [
       "edmunds.com"
     ],
+    "admixer.net": [
+      "space.com"
+    ],
     "adnxs.com": [
+      "yahoo.com",
+      "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "dropbox.com",
-      "seattletimes.com",
+      "cisco.com",
+      "jsonline.com",
       "rfi.fr"
     ],
     "adobe.com": [
+      "wikipedia.org",
       "behance.net",
-      "history.com",
-      "nbc.com"
+      "history.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
-      "worldbank.org",
-      "nbcnews.com",
-      "aarp.org",
-      "networksolutions.com"
+      "bbb.org",
+      "bizjournals.com",
+      "worldbank.org"
     ],
     "adotmob.com": [
-      "variety.com"
+      "standard.co.uk",
+      "upwork.com"
     ],
     "adriver.ru": [
       "ria.ru",
-      "home.pl"
+      "rambler.ru",
+      "tomsk.ru"
     ],
     "adroll.com": [
+      "stumbleupon.com",
+      "nature.com",
       "nginx.org",
       "cloudflare.com",
       "ning.com",
-      "salesforce.com",
       "case.edu"
     ],
     "adscale.de": [
       "t-online.de",
+      "bloomberg.com",
       "springer.com",
-      "home.pl"
+      "statista.com"
     ],
     "adsnative.com": [
       "autodesk.com",
       "thehill.com",
-      "squareup.com",
+      "informationweek.com",
       "bostonherald.com"
+    ],
+    "adsniper.ru": [
+      "rambler.ru"
     ],
     "adsrvr.org": [
       "adobe.com",
+      "yahoo.com",
+      "googletagmanager.com",
       "sourceforge.net",
-      "nytimes.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "cisco.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "adswizz.com": [
-      "variety.com",
       "iheart.com",
-      "tunein.com"
+      "tunein.com",
+      "variety.com"
     ],
     "adsymptotic.com": [
+      "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "economist.com",
-      "space.com",
-      "colourlovers.com"
+      "foursquare.com",
+      "jsonline.com",
+      "xda-developers.com"
+    ],
+    "adtags.pro": [
+      "tomsk.ru"
+    ],
+    "adtdp.com": [
+      "biglobe.ne.jp"
     ],
     "advertising.com": [
+      "amazon.com",
+      "sourceforge.net",
       "dropbox.com",
-      "msn.com",
       "wsj.com",
-      "norton.com",
+      "theverge.com",
       "walgreens.com"
     ],
+    "advertur.ru": [
+      "radikal.ru"
+    ],
+    "adwstats.com": [
+      "cisco.com"
+    ],
     "adx.com.ru": [
-      "rambler.ru"
+      "rambler.ru",
+      "tomsk.ru"
+    ],
+    "adx1.com": [
+      "venturebeat.com",
+      "livescience.com",
+      "space.com"
     ],
     "adzerk.net": [
       "asp.net"
@@ -4837,81 +3879,94 @@
     "aetnd.com": [
       "history.com"
     ],
-    "afkp.net": [
-      "autodesk.com"
+    "afilio.com.br": [
+      "mcafee.com"
     ],
     "agkn.com": [
-      "dropbox.com",
+      "amazon.com",
+      "t-online.de",
+      "bloomberg.com",
       "cnet.com",
-      "businessinsider.com",
-      "cbs.com",
-      "gizmodo.com"
+      "zdnet.com",
+      "zerohedge.com"
+    ],
+    "aid-ad.jp": [
+      "shinobi.jp"
     ],
     "aidata.io": [
+      "rambler.ru",
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "aili.com": [
+      "sina.com.cn"
+    ],
+    "ajx130.online": [
       "radikal.ru"
     ],
+    "akamai.net": [
+      "newscientist.com"
+    ],
     "akamaihd.net": [
-      "forbes.com",
       "voanews.com",
-      "cracked.com"
+      "repubblica.it",
+      "iyfubh.com",
+      "forbes.com"
     ],
     "akamaized.net": [
       "tamu.edu",
       "microsoft.com",
-      "xbox.com",
-      "rice.edu",
-      "blizzard.com",
-      "office.com",
-      "jugem.jp"
+      "nbc.com"
     ],
     "albacross.com": [
       "rebelmouse.com"
     ],
     "alibaba.com": [
-      "tmall.com",
+      "youku.com",
+      "taobao.com",
       "aliexpress.com",
-      "alibabacloud.com"
+      "tmall.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
-      "youku.com",
-      "sohu.com",
-      "taobao.com",
       "alibaba.com",
-      "1688.com",
-      "toutiao.com",
-      "2345.com",
-      "tmall.com"
+      "youku.com",
+      "sohu.com"
     ],
     "alipay.com": [
-      "youku.com",
-      "taobao.com",
-      "tmall.com"
+      "alibaba.com",
+      "youku.com"
     ],
     "aliyun.com": [
-      "alibabacloud.com",
-      "gmw.cn"
+      "alibabacloud.com"
     ],
     "allure.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
+    ],
+    "am15.net": [
+      "radikal.ru"
     ],
     "amazon-adsystem.com": [
       "amazon.com",
-      "vimeo.com",
+      "nytimes.com",
       "reddit.com",
-      "nifty.com",
-      "pitchfork.com"
+      "cnn.com",
+      "goodreads.com",
+      "bostonherald.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
     ],
     "amazon.com": [
+      "qq.com",
       "imdb.com",
       "amazon.co.uk",
       "amazon.de",
-      "amazon.co.jp"
+      "amazon.co.jp",
+      "amazon.es"
     ],
     "ameba.jp": [
       "ameblo.jp"
@@ -4926,73 +3981,119 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "aarp.org",
-      "walgreens.com"
+      "realtor.com"
+    ],
+    "antdsp.com": [
+      "hc360.com"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
     "aol.com": [
-      "techcrunch.com"
+      "engadget.com",
+      "indiatimes.com",
+      "autoblog.com"
+    ],
+    "ap.org": [
+      "post-gazette.com"
+    ],
+    "apester.com": [
+      "deadline.com",
+      "searchenginewatch.com",
+      "nme.com"
     ],
     "apn.co.nz": [
       "nzherald.co.nz"
     ],
     "app.link": [
-      "medium.com",
       "foursquare.com",
       "history.com",
       "nbc.com",
       "strava.com"
     ],
-    "apple.com": [
-      "digitaltrends.com"
+    "appdynamics.com": [
+      "nfl.com"
     ],
-    "apvdr.com": [
-      "goo.ne.jp"
+    "apple.com": [
+      "digitaltrends.com",
+      "icloud.com",
+      "softpedia.com"
+    ],
+    "aqtracker.com": [
+      "nikkei.com"
+    ],
+    "aralego.com": [
+      "accuweather.com"
+    ],
+    "arcgis.com": [
+      "chron.com"
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
     ],
+    "areyouahuman.com": [
+      "reuters.com",
+      "merriam-webster.com",
+      "accuweather.com"
+    ],
+    "arrivalist.com": [
+      "philly.com"
+    ],
     "art19.com": [
       "coindesk.com"
     ],
+    "asos-media.com": [
+      "asos.com"
+    ],
     "atdmt.com": [
       "facebook.com",
-      "shutterfly.com",
-      "xbox.com",
-      "slack.com"
+      "yahoo.com",
+      "msn.com",
+      "t-online.de"
     ],
     "atemda.com": [
       "springer.com",
       "home.pl"
     ],
+    "atgsvcs.com": [
+      "oracle.com",
+      "xerox.com"
+    ],
     "ati-host.net": [
-      "bbc.co.uk",
       "straitstimes.com"
     ],
     "att.com": [
       "att.net"
     ],
-    "auone.jp": [
-      "goo.ne.jp"
+    "audtd.com": [
+      "rambler.ru",
+      "tomsk.ru",
+      "radikal.ru"
+    ],
+    "autoimg.cn": [
+      "autohome.com.cn"
     ],
     "autopilothq.com": [
       "bitbucket.org",
+      "rfc-editor.org",
       "typeform.com",
-      "atlassian.com"
+      "quantcast.com"
+    ],
+    "b1img.com": [
+      "threadless.com"
     ],
     "baidu.com": [
       "sina.com.cn",
       "163.com",
+      "ifeng.com",
       "sohu.com",
-      "ce.cn",
-      "qianlong.com"
+      "51.la"
     ],
     "bam-x.com": [
       "gq.com"
@@ -5000,14 +4101,27 @@
     "barnebys.com": [
       "lemonde.fr"
     ],
-    "baur.de": [
-      "t-online.de"
-    ],
     "bazaarvoice.com": [
+      "target.com",
+      "lenovo.com",
       "motorola.com"
+    ],
+    "bbb.org": [
+      "penders.com",
+      "afternic.com",
+      "sedo.com"
+    ],
+    "bbbpromos.org": [
+      "bbb.org"
     ],
     "bbc.co.uk": [
       "bbc.com"
+    ],
+    "bbelements.com": [
+      "idnes.cz"
+    ],
+    "beatport.com": [
+      "tmall.com"
     ],
     "beemray.com": [
       "telegraph.co.uk",
@@ -5015,74 +4129,102 @@
     ],
     "beian.gov.cn": [
       "dzwww.com",
-      "qianlong.com"
+      "ku6.com"
+    ],
+    "benchtag2.co": [
+      "sbs.com.au"
+    ],
+    "betweendigital.com": [
+      "tomsk.ru",
+      "radikal.ru"
     ],
     "bfmio.com": [
+      "symantec.com",
       "tinypic.com",
+      "venturebeat.com",
       "livescience.com",
-      "space.com",
-      "dailydot.com"
+      "xda-developers.com"
+    ],
+    "bfmtv.com": [
+      "liberation.fr",
+      "lexpress.fr"
     ],
     "biddingx.com": [
       "sina.com.cn"
     ],
     "bidr.io": [
       "adobe.com",
-      "hp.com",
+      "dailymotion.com",
+      "hootsuite.com",
       "symantec.com",
-      "sap.com",
       "box.com"
     ],
     "bidswitch.net": [
+      "yahoo.com",
+      "google.com",
+      "amazon.com",
       "dropbox.com",
-      "tinyurl.com",
-      "usatoday.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "theverge.com",
+      "jsonline.com",
+      "walgreens.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
+    ],
+    "bigmir.net": [
+      "kharkov.ua",
+      "kh.ua"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
       "weebly.com",
       "msn.com",
-      "sap.com",
-      "office.com",
+      "parallels.com",
       "pingdom.com"
+    ],
+    "bitbucket.org": [
+      "atlassian.com"
     ],
     "bizible.com": [
       "eventbrite.com",
       "cloudflare.com",
+      "zendesk.com",
       "ibm.com",
-      "eventbrite.co.uk",
       "gitlab.com"
     ],
     "bizibly.com": [
       "eventbrite.com"
     ],
     "bizographics.com": [
+      "zend.com",
+      "nginx.com",
+      "oreilly.com",
       "jimdo.com",
-      "surveymonkey.com",
-      "techcrunch.com"
+      "ox.ac.uk"
     ],
     "bizrate.com": [
-      "time.com",
       "fortune.com",
+      "people.com",
       "ew.com",
-      "sourceforge.net",
-      "travelandleisure.com"
+      "time.com",
+      "slashdot.org"
+    ],
+    "blogos.com": [
+      "livedoor.com"
+    ],
+    "bloomberg.com": [
+      "macrumors.com"
     ],
     "bluecava.com": [
-      "giphy.com",
-      "walmart.com"
+      "history.com",
+      "biography.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
+      "theatlantic.com",
       "sfgate.com",
-      "chron.com",
-      "startribune.com"
+      "chron.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -5091,19 +4233,19 @@
       "variety.com"
     ],
     "bnidx.com": [
-      "bravenet.com",
-      "jigsy.com"
+      "jigsy.com",
+      "bravenet.com"
     ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
       "cancer.org",
-      "groupon.com",
       "networksolutions.com"
     ],
     "bonappetit.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "boston.com": [
@@ -5112,11 +4254,19 @@
     "bostonglobemedia.com": [
       "boston.com"
     ],
+    "botradar.tech": [
+      "radikal.ru"
+    ],
+    "boudja.com": [
+      "4shared.com"
+    ],
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
+      "wired.com",
       "usatoday.com",
-      "dictionary.com",
+      "fortune.com",
+      "jsonline.com",
       "pitchfork.com"
     ],
     "brandcdn.com": [
@@ -5124,33 +4274,39 @@
     ],
     "brides.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "brightcove.com": [
-      "aarp.org",
-      "theaustralian.com.au",
-      "informationweek.com",
-      "scholastic.com"
+      "scholastic.com",
+      "si.com",
+      "federalreserve.gov",
+      "informationweek.com"
     ],
     "brightcove.net": [
-      "aljazeera.com",
-      "lonelyplanet.com",
-      "techtarget.com",
-      "thenational.ae"
+      "lefigaro.fr",
+      "politico.com",
+      "bostonglobe.com"
     ],
     "bttrack.com": [
-      "mirror.co.uk",
-      "nypost.com",
+      "yahoo.com",
+      "independent.co.uk",
+      "zendesk.com",
       "livescience.com",
-      "salesforce.com",
       "dailydot.com"
     ],
     "btttag.com": [
-      "marriott.com"
+      "samsung.com",
+      "marriott.com",
+      "ihg.com"
+    ],
+    "bumlam.com": [
+      "rambler.ru"
     ],
     "c-ctrip.com": [
-      "ctrip.com"
+      "ctrip.com",
+      "qunar.com"
     ],
     "c212.net": [
       "prnewswire.com"
@@ -5161,24 +4317,35 @@
     "cadreon.com": [
       "economist.com"
     ],
+    "caltat.com": [
+      "live4fun.ru"
+    ],
+    "candlewoodsuites.com": [
+      "ihg.com"
+    ],
+    "capturehighered.net": [
+      "ku.edu",
+      "unm.edu"
+    ],
     "carambo.la": [
-      "salon.com",
-      "accuweather.com"
+      "accuweather.com",
+      "salon.com"
     ],
     "casalemedia.com": [
+      "amazon.com",
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
-      "techradar.com",
-      "colourlovers.com"
+      "theverge.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "cbsi.com": [
-      "cnet.com",
-      "cbsnews.com",
+      "zdnet.com",
       "last.fm",
       "gamespot.com",
-      "cbs.com",
-      "techrepublic.com"
+      "cnet.com",
+      "cbsnews.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -5187,8 +4354,15 @@
       "softonic.com",
       "biography.com"
     ],
-    "cdn-net.com": [
+    "cdn-apple.com": [
+      "icloud.com"
+    ],
+    "cdn-hotels.com": [
       "hotels.com"
+    ],
+    "cdn-net.com": [
+      "hotels.com",
+      "americanexpress.com"
     ],
     "cdnwidget.com": [
       "photoshelter.com"
@@ -5199,48 +4373,75 @@
     "changeagain.me": [
       "iconosquare.com"
     ],
+    "charitynavigator.org": [
+      "heart.org"
+    ],
     "chei.com.cn": [
       "chsi.com.cn"
+    ],
+    "chicagotribune.com": [
+      "wikipedia.org"
+    ],
+    "chinajob.com": [
+      "china.org.cn"
     ],
     "chinaso.com": [
       "weather.com.cn"
     ],
+    "chinavivaki.com": [
+      "bshare.cn"
+    ],
     "choozle.com": [
-      "photobucket.com",
-      "denverpost.com"
+      "denverpost.com",
+      "photobucket.com"
     ],
     "circularhub.com": [
       "suntimes.com",
-      "stltoday.com",
       "tampabay.com",
       "bostonherald.com"
     ],
     "civicscience.com": [
-      "post-gazette.com"
+      "post-gazette.com",
+      "knowyourmeme.com",
+      "ebaumsworld.com"
     ],
     "ckies.net": [
       "abril.com.br"
     ],
     "clickability.com": [
+      "prnewswire.com",
       "philly.com",
       "proquest.com"
+    ],
+    "clicktale.net": [
+      "xbox.com",
+      "office.com",
+      "microsoft.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
       "mapquest.com"
     ],
+    "clmbtech.com": [
+      "indiatimes.com"
+    ],
     "cloudflare.com": [
-      "sciencemag.org",
       "uci.edu",
+      "nbcnews.com",
+      "sciencemag.org",
       "symantec.com",
       "allaboutcookies.org"
     ],
     "cnet.com": [
       "zdnet.com"
     ],
+    "cnn.net": [
+      "cnn.com"
+    ],
     "cntraveler.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "cnzz.com": [
@@ -5249,11 +4450,20 @@
     "cobaltgroup.com": [
       "edmunds.com"
     ],
+    "coherentpath.com": [
+      "staples.com"
+    ],
     "cohesionapps.com": [
+      "americanexpress.com",
+      "admin.ch",
       "bankrate.com"
     ],
     "collegenet.com": [
-      "gmu.edu"
+      "gmu.edu",
+      "ku.edu"
+    ],
+    "comm100.com": [
+      "hobbyking.com"
     ],
     "commander1.com": [
       "ovh.com",
@@ -5263,19 +4473,30 @@
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "hp.com",
-      "sap.com",
+      "redhat.com",
+      "theverge.com",
+      "jsonline.com",
       "box.com"
+    ],
+    "complex.com": [
+      "knowyourmeme.com",
+      "dailydot.com",
+      "ebaumsworld.com"
+    ],
+    "conative.de": [
+      "focus.de"
     ],
     "condenastdigital.com": [
       "wired.com",
-      "newyorker.com",
       "arstechnica.com",
       "nj.com",
+      "newyorker.com",
       "pitchfork.com"
     ],
+    "conductrics.com": [
+      "nginx.com"
+    ],
     "connatix.com": [
-      "jpost.com",
       "alternet.org",
       "dailydot.com"
     ],
@@ -5283,71 +4504,109 @@
       "sourceforge.net"
     ],
     "consensu.org": [
-      "buzzfeed.com",
       "rollingstone.com",
       "variety.com",
-      "upi.com",
-      "washingtonexaminer.com"
+      "adweek.com",
+      "buzzfeed.com",
+      "thetimes.co.uk",
+      "nme.com"
     ],
-    "content.ad": [
-      "tinypic.com"
+    "consumable.com": [
+      "xfinity.com"
+    ],
+    "contentabc.com": [
+      "pornhub.com"
     ],
     "contextweb.com": [
       "sourceforge.net",
       "myspace.com",
-      "usatoday.com",
-      "space.com",
-      "colourlovers.com"
+      "bloomberg.com",
+      "forbes.com",
+      "uci.edu",
+      "walgreens.com"
+    ],
+    "convertful.com": [
+      "lifehack.org"
     ],
     "convertro.com": [
+      "ibm.com",
+      "logitech.com",
       "slack.com"
+    ],
+    "convio.net": [
+      "diabetes.org"
     ],
     "cornell.edu": [
       "arxiv.org"
     ],
-    "coxmediagroup.com": [
-      "ajc.com"
+    "cox.net": [
+      "cox.com"
+    ],
+    "coxbusiness.com": [
+      "cox.com"
+    ],
+    "cpex.cz": [
+      "idnes.cz"
     ],
     "cpx.to": [
-      "independent.co.uk",
-      "mirror.co.uk",
       "express.co.uk",
+      "digitaltrends.com",
       "techradar.com",
+      "independent.co.uk",
       "rfi.fr"
     ],
     "cquotient.com": [
       "gopro.com"
     ],
-    "creative-serving.com": [
-      "tinyurl.com"
+    "cr-nielsen.com": [
+      "youku.com"
     ],
     "creativecdn.com": [
-      "ria.ru"
+      "ria.ru",
+      "udn.com"
+    ],
+    "creativecommons.org": [
+      "perl.com"
     ],
     "criteo.com": [
-      "dropbox.com",
-      "forbes.com",
+      "tinyurl.com",
       "washingtonpost.com",
-      "fool.com",
+      "dailymail.co.uk",
+      "dropbox.com",
+      "webmd.com",
       "sedo.com"
+    ],
+    "croissed.info": [
+      "4shared.com"
+    ],
+    "crowneplaza.com": [
+      "ihg.com"
     ],
     "crsspxl.com": [
       "sourceforge.net",
-      "slashdot.org"
+      "slashdot.org",
+      "bartleby.com"
     ],
     "cssrvsync.com": [
       "springer.com",
       "home.pl"
     ],
-    "ctrmi.com": [
-      "sina.com.cn"
+    "ctv.ca": [
+      "ctvnews.ca"
+    ],
+    "curse.com": [
+      "wowdb.com"
+    ],
+    "custhelp.com": [
+      "oracle.com"
     ],
     "cxense.com": [
       "opera.com",
       "talktalk.co.uk",
       "gizmodo.com",
-      "kotaku.com",
-      "coindesk.com"
+      "wsj.com",
+      "cbc.ca",
+      "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -5356,14 +4615,13 @@
       "webnode.com"
     ],
     "d2-apps.net": [
-      "goo.ne.jp",
-      "asahi.com"
+      "rakuten.co.jp",
+      "yahoo.co.jp"
     ],
     "d41.co": [
-      "hp.com",
       "intel.com",
       "hpe.com",
-      "sap.com"
+      "hp.com"
     ],
     "da-ads.com": [
       "deviantart.com"
@@ -5371,36 +4629,66 @@
     "dailymail.co.uk": [
       "metro.co.uk"
     ],
+    "dailymotion.com": [
+      "google.com"
+    ],
     "datamind.ru": [
+      "novostimira.com",
       "rambler.ru",
-      "novostimira.com"
+      "kharkov.ua"
+    ],
+    "datasteam.io": [
+      "ama-assn.org"
     ],
     "daum.net": [
       "shutterstock.com",
       "tistory.com"
     ],
+    "daumcdn.net": [
+      "daum.net"
+    ],
+    "daumdn.com": [
+      "shutterstock.com"
+    ],
     "dc-storm.com": [
       "nike.com",
-      "alibabacloud.com",
+      "shutterstock.com",
       "bostonglobe.com"
+    ],
+    "deep.bi": [
+      "hrw.org"
+    ],
+    "dell.com": [
+      "rsa.com"
     ],
     "demdex.net": [
       "adobe.com",
+      "yahoo.com",
       "amazon.com",
       "soundcloud.com",
-      "bluehost.com",
-      "syfy.com"
+      "webmd.com",
+      "jsonline.com",
+      "britishairways.com"
+    ],
+    "departapp.com": [
+      "liveuamap.com"
     ],
     "deployads.com": [
       "tinyurl.com",
-      "sciencedaily.com",
-      "zerohedge.com"
+      "lycos.com",
+      "sciencedaily.com"
+    ],
+    "deqwas.net": [
+      "rakuten.co.jp"
+    ],
+    "developermedia.com": [
+      "codeproject.com"
     ],
     "dezeenjobs.com": [
       "dezeen.com"
     ],
-    "df-srv.de": [
-      "sueddeutsche.de"
+    "dhs.gov": [
+      "fema.gov"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
@@ -5409,22 +4697,35 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
+      "entrepreneur.com",
       "zerohedge.com"
     ],
+    "dictionary.com": [
+      "thesaurus.com"
+    ],
+    "digitaladsystems.com": [
+      "tomsk.ru"
+    ],
     "digitaltarget.ru": [
-      "radikal.ru"
+      "liveinternet.ru",
+      "rambler.ru",
+      "tomsk.ru"
     ],
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
       "express.co.uk",
-      "theonion.com",
       "bostonherald.com"
     ],
+    "disney.com": [
+      "starwars.com"
+    ],
     "disqus.com": [
-      "rollingstone.com",
+      "pnas.org",
       "dyn.com",
-      "mercurynews.com"
+      "mercurynews.com",
+      "dw.com",
+      "rollingstone.com"
     ],
     "distiltag.com": [
       "reuters.com",
@@ -5432,12 +4733,20 @@
     ],
     "districtm.io": [
       "barnesandnoble.com",
-      "seattletimes.com",
-      "miamiherald.com",
-      "colourlovers.com"
+      "urbandictionary.com",
+      "axs.com",
+      "timeanddate.com",
+      "newatlas.com"
+    ],
+    "djv99sxoqpv11.cloudfront.net": [
+      "4shared.com"
     ],
     "dmxleo.com": [
-      "pastebin.com"
+      "dailymotion.com"
+    ],
+    "dnnapi.com": [
+      "zenfolio.com",
+      "gob.es"
     ],
     "dol.gov": [
       "osha.gov"
@@ -5445,15 +4754,16 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com",
-      "atlasobscura.com"
+      "tinypic.com"
     ],
     "dotomi.com": [
+      "tinyurl.com",
       "samsung.com",
-      "economist.com",
-      "barnesandnoble.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "webmd.com",
+      "forbes.com",
+      "illinois.edu",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -5462,38 +4772,49 @@
       "youtube.com",
       "twitter.com",
       "linkedin.com",
-      "billboard.com",
-      "syfy.com"
+      "sourceforge.net",
+      "zend.com",
+      "jsonline.com",
+      "britishairways.com"
+    ],
+    "doublemax.net": [
+      "udn.com"
     ],
     "doublepimpssl.com": [
       "pornhub.com"
     ],
-    "dowjones.io": [
-      "marketwatch.com"
+    "doubleverify.com": [
+      "military.com",
+      "allafrica.com"
     ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
+      "techtarget.com",
       "adweek.com"
-    ],
-    "dsp.com": [
-      "qq.com"
-    ],
-    "dudintrec.ru": [
-      "radikal.ru"
     ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
+      "t-online.de",
       "cnbc.com",
       "nbcnews.com",
-      "norton.com",
       "washingtonexaminer.com"
     ],
+    "dynatrace-managed.com": [
+      "delta.com"
+    ],
+    "dyntrk.com": [
+      "dailymotion.com",
+      "infoplease.com"
+    ],
     "ebay-us.com": [
-      "ebay.com",
-      "ebay.com.au"
+      "ebay.com.au",
+      "ebay.com"
+    ],
+    "ebay.co.uk": [
+      "synacor.com"
     ],
     "ebay.com": [
       "ebay.co.uk",
@@ -5503,27 +4824,46 @@
     "ebayrtm.com": [
       "ebay.co.uk",
       "ebay.de",
+      "ebay.com",
       "ebay.com.au"
     ],
+    "ebaystatic.com": [
+      "ebay.com.au"
+    ],
+    "ebdr3.com": [
+      "springer.com"
+    ],
     "ebis.ne.jp": [
-      "exblog.jp"
+      "exblog.jp",
+      "xrea.com"
+    ],
+    "econda-monitor.de": [
+      "expedia.com"
+    ],
+    "ecustomeropinions.com": [
+      "skysports.com"
     ],
     "edge-cdn.net": [
       "biomedcentral.com"
     ],
+    "edmunds.com": [
+      "unenvironment.org"
+    ],
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com"
+      "gulfnews.com",
+      "goal.com"
     ],
     "eloqua.com": [
       "intel.com",
-      "redhat.com",
-      "wisc.edu",
-      "thawte.com",
+      "cisco.com",
+      "prnewswire.com",
+      "siemens.com",
       "eset.com"
     ],
     "elsevier.com": [
+      "sciencedirect.com",
       "thelancet.com",
       "cell.com"
     ],
@@ -5531,7 +4871,14 @@
       "thelancet.com",
       "cell.com"
     ],
+    "emc.com": [
+      "rsa.com"
+    ],
     "emlgrid.com": [
+      "home.pl"
+    ],
+    "emxdgt.com": [
+      "springer.com",
       "home.pl"
     ],
     "envato.com": [
@@ -5539,30 +4886,61 @@
     ],
     "epicurious.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
     ],
+    "espn.com": [
+      "fivethirtyeight.com"
+    ],
+    "estara.com": [
+      "xerox.com"
+    ],
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "tomshardware.com"
+      "lefigaro.fr"
+    ],
+    "etracker.de": [
+      "sedo.com"
+    ],
+    "etsystudio.com": [
+      "etsy.com"
+    ],
+    "evenhotels.com": [
+      "ihg.com"
+    ],
+    "eventsabout.com": [
+      "sacbee.com"
     ],
     "everesttech.net": [
       "adobe.com",
+      "yahoo.com",
       "sourceforge.net",
-      "nytimes.com",
-      "seattletimes.com",
-      "colourlovers.com"
+      "dailymotion.com",
+      "webmd.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "everyaction.com": [
       "greenpeace.org"
     ],
     "evise.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
+    ],
+    "evolok.net": [
+      "scotsman.com"
+    ],
+    "evyy.net": [
+      "office.com"
+    ],
+    "ew3.io": [
+      "liberation.fr"
     ],
     "exactag.com": [
       "t-online.de"
@@ -5570,25 +4948,37 @@
     "excite.co.jp": [
       "exblog.jp"
     ],
+    "exe.bid": [
+      "rambler.ru"
+    ],
     "exelator.com": [
+      "soundcloud.com",
       "forbes.com",
+      "bloomberg.com",
       "businessinsider.com",
-      "talktalk.co.uk",
-      "bluehost.com",
-      "gizmodo.com"
+      "mirror.co.uk",
+      "zerohedge.com"
+    ],
+    "exosrv.com": [
+      "pornhub.com"
+    ],
+    "expedia.com": [
+      "excite.com"
     ],
     "eyeota.net": [
       "sourceforge.net",
-      "dropbox.com",
-      "wsj.com",
-      "space.com",
-      "zerohedge.com"
+      "forbes.com",
+      "bloomberg.com",
+      "gizmodo.com",
+      "xda-developers.com"
     ],
     "eyereturn.com": [
-      "thestar.com"
+      "thestar.com",
+      "queensu.ca"
     ],
     "eyeviewads.com": [
-      "nypost.com",
+      "staples.com",
+      "xda-developers.com",
       "walgreens.com"
     ],
     "ezoic.net": [
@@ -5597,16 +4987,38 @@
     ],
     "facebook.com": [
       "instagram.com",
+      "wordpress.org",
       "adobe.com",
-      "apple.com",
-      "bluehost.com",
-      "syfy.com"
+      "nytimes.com",
+      "goodreads.com",
+      "jsonline.com",
+      "helsinki.fi"
+    ],
+    "facetz.net": [
+      "novostimira.com",
+      "rambler.ru",
+      "kharkov.ua"
+    ],
+    "fairfax.com.au": [
+      "smh.com.au",
+      "theage.com.au"
+    ],
+    "fastcompany.com": [
+      "fastcodesign.com"
     ],
     "fdlstatic.com": [
       "cnet.com"
     ],
     "feathr.co": [
-      "informationweek.com"
+      "informationweek.com",
+      "eurogamer.net"
+    ],
+    "ffx.io": [
+      "smh.com.au",
+      "theage.com.au"
+    ],
+    "fidelity-media.com": [
+      "home.pl"
     ],
     "filepicker.io": [
       "enlightenment.org",
@@ -5614,58 +5026,75 @@
     ],
     "firstimpression.io": [
       "jpost.com",
+      "serverwatch.com",
       "haaretz.com"
     ],
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "aarp.org"
+      "msu.edu",
+      "bmj.com"
     ],
     "flickr.com": [
+      "state.gov",
       "oecd.org",
-      "enable-javascript.com",
-      "cia.gov",
-      "ncsu.edu",
-      "gatech.edu",
-      "colostate.edu"
+      "enable-javascript.com"
     ],
     "flipboard.com": [
       "venturebeat.com",
-      "popsugar.com",
-      "autoblog.com"
+      "autoblog.com",
+      "popsugar.com"
+    ],
+    "flyercity.ca": [
+      "canada.com"
     ],
     "flyertown.ca": [
-      "nationalpost.com",
+      "canada.com",
       "globalnews.ca",
+      "nationalpost.com",
       "vancouversun.com"
     ],
     "fontawesome.com": [
-      "webex.com",
-      "ucsc.edu",
-      "jugem.jp",
-      "sitepoint.com"
-    ],
-    "force.com": [
-      "constantcontact.com",
-      "teamviewer.com",
-      "salesforce.com"
+      "socarrao.com.br",
+      "clinicaltrials.gov",
+      "moonfruit.com",
+      "webex.com"
     ],
     "foresee.com": [
       "epa.gov",
+      "si.edu",
+      "theglobeandmail.com",
       "sec.gov",
-      "bls.gov",
-      "smithsonianmag.com"
+      "marthastewart.com"
     ],
     "formstack.com": [
       "in.gov"
     ],
     "fout.jp": [
       "economist.com",
-      "exblog.jp",
-      "goo.ne.jp"
+      "hatena.ne.jp"
+    ],
+    "fox.com": [
+      "nationalgeographic.com",
+      "foxnews.com",
+      "foxbusiness.com"
+    ],
+    "foxbusiness.com": [
+      "fox.com"
+    ],
+    "foxnews.com": [
+      "foxbusiness.com",
+      "fox.com"
+    ],
+    "foxsports.com": [
+      "fox.com"
     ],
     "foxycart.com": [
       "brookings.edu"
+    ],
+    "freeskreen.com": [
+      "nationalpost.com",
+      "wattpad.com"
     ],
     "freshdesk.com": [
       "podbean.com"
@@ -5673,122 +5102,186 @@
     "friendbuy.com": [
       "lulu.com"
     ],
+    "funcaptcha.com": [
+      "axs.com"
+    ],
+    "funnyordie.com": [
+      "deadline.com",
+      "videojs.com"
+    ],
     "fwmrm.net": [
+      "yahoo.com",
+      "mlb.com",
+      "xfinity.com",
       "discovery.com",
-      "foodnetwork.com",
-      "channel4.com",
       "hgtv.com"
     ],
-    "geetest.com": [
-      "axs.com"
+    "g2crowd.com": [
+      "prezi.com",
+      "teamviewer.us",
+      "wpengine.com"
+    ],
+    "gakogedifoda.ru": [
+      "radikal.ru"
+    ],
+    "gamer-network.net": [
+      "eurogamer.net"
     ],
     "gemius.pl": [
       "sapo.pt",
+      "interia.pl",
       "ria.ru"
+    ],
+    "gentags.net": [
+      "sina.com.cn"
     ],
     "getclicky.com": [
       "icio.us",
       "newatlas.com",
       "cyberchimps.com"
     ],
+    "getdrip.com": [
+      "dreamhost.com"
+    ],
+    "getpocket.com": [
+      "cronolog.org"
+    ],
     "getsmartcontent.com": [
-      "pcworld.com"
+      "pcworld.com",
+      "computerworld.com",
+      "hpe.com"
+    ],
+    "gfycat.com": [
+      "reddit.com"
     ],
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
       "abc.net.au",
-      "redcross.org",
-      "syfy.com"
+      "sfgate.com",
+      "hgtv.com"
     ],
     "giphy.com": [
-      "urbandictionary.com"
+      "urbandictionary.com",
+      "liberation.fr",
+      "webshots.com"
+    ],
+    "github.com": [
+      "wsj.com"
     ],
     "glamour.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com",
-      "ew.com",
-      "travelandleisure.com"
+      "fortune.com"
+    ],
+    "gmossp-sp.jp": [
+      "shinobi.jp",
+      "shop-pro.jp"
     ],
     "go.com": [
       "disney.com",
+      "espn.com",
       "starwars.com",
       "fivethirtyeight.com"
     ],
     "golfdigest.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
+    "google.co.jp": [
+      "forumotion.com"
+    ],
     "google.com": [
       "youtube.com",
       "linkedin.com",
-      "pinterest.com",
+      "google.de",
+      "godaddy.com",
+      "goodreads.com",
+      "scmp.com",
       "chromium.org",
-      "designboom.com"
+      "jsonline.com",
+      "britishairways.com"
     ],
     "gq.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "gridsumdissector.com": [
-      "www.gov.cn"
+      "qq.com",
+      "www.gov.cn",
+      "autohome.com.cn"
     ],
     "groupondata.com": [
       "groupon.com"
     ],
-    "gstatic.com": [
-      "google.ch",
-      "propublica.org",
-      "facebook.com",
-      "google.com.tw",
-      "goal.com",
-      "google.ca"
+    "gsimedia.net": [
+      "acehardware.com"
+    ],
+    "gssprt.jp": [
+      "dropbox.com",
+      "biglobe.ne.jp"
     ],
     "gtags.net": [
+      "sina.com.cn",
       "ctrip.com"
     ],
     "gumgum.com": [
-      "snopes.com",
-      "thehindu.com",
-      "home.pl",
-      "colourlovers.com"
+      "liveuamap.com",
+      "colourlovers.com",
+      "infoplease.com",
+      "coindesk.com"
+    ],
+    "guoshipartners.com": [
+      "udn.com"
     ],
     "gwallet.com": [
       "adobe.com",
-      "economist.com",
       "ox.ac.uk",
-      "alternet.org",
-      "nme.com"
+      "ihg.com",
+      "economist.com",
+      "business2community.com"
+    ],
+    "hadcs.de": [
+      "t-online.de"
     ],
     "hatena.com": [
       "hatena.ne.jp"
     ],
     "hatena.ne.jp": [
-      "hatenablog.com"
-    ],
-    "hdslb.com": [
-      "bilibili.com"
+      "hatenablog.com",
+      "cronolog.org"
     ],
     "healte.de": [
+      "spiegel.de",
       "reuters.com"
     ],
     "hearstnp.com": [
       "sfgate.com",
-      "chron.com"
+      "chron.com",
+      "seattlepi.com"
     ],
     "help.com": [
-      "comodo.com"
+      "comodo.com",
+      "couchsurfing.com"
+    ],
+    "hiexpress.com": [
+      "ihg.com"
+    ],
+    "highwire.org": [
+      "pnas.org"
     ],
     "hitslink.com": [
       "webstarts.com"
@@ -5796,126 +5289,207 @@
     "hive.co": [
       "complex.com"
     ],
+    "hlserve.com": [
+      "bestbuy.com",
+      "macys.com",
+      "kohls.com"
+    ],
+    "holidayinn.com": [
+      "ihg.com"
+    ],
+    "holidayinnresorts.com": [
+      "ihg.com"
+    ],
     "horyzon-media.com": [
       "skyrock.com"
     ],
-    "huanqiu.com": [
-      "sina.com.cn"
+    "hotelindigo.com": [
+      "ihg.com"
+    ],
+    "hotelsapi.io": [
+      "ovh.net"
+    ],
+    "htmedia.in": [
+      "hindustantimes.com"
     ],
     "hubspot.com": [
-      "scoop.it",
-      "500px.com",
-      "thelancet.com"
+      "wpengine.com",
+      "shopify.com",
+      "technologyreview.com",
+      "scoop.it"
     ],
     "huffingtonpost.co.uk": [
       "oath.com"
     ],
-    "hugedata.com.cn": [
-      "miit.gov.cn"
+    "huffingtonpost.com": [
+      "huffingtonpost.co.uk"
     ],
     "huihui.cn": [
       "youdao.com"
     ],
+    "hwcdn.net": [
+      "boingboing.net"
+    ],
     "hybrid.ai": [
-      "rambler.ru"
+      "rambler.ru",
+      "tomsk.ru",
+      "diary.ru"
+    ],
+    "hypemarks.com": [
+      "uchicago.edu",
+      "purdue.edu",
+      "brown.edu"
+    ],
+    "i.ua": [
+      "kharkov.ua",
+      "kh.ua"
+    ],
+    "i1img.com": [
+      "excite.com"
+    ],
+    "ib-ibi.com": [
+      "globo.com"
     ],
     "ibclick.stream": [
-      "webmd.com"
+      "webmd.com",
+      "wikitravel.org",
+      "inhabitat.com"
     ],
     "ibillboard.com": [
       "springer.com",
-      "home.pl"
+      "home.pl",
+      "idnes.cz"
     ],
     "ibt.com": [
       "newsweek.com",
       "ibtimes.com"
     ],
     "id5-sync.com": [
+      "bloomberg.com",
+      "venturebeat.com",
+      "dailymotion.com",
       "livescience.com",
-      "skyrock.com",
-      "space.com"
+      "xda-developers.com"
+    ],
+    "idealmedia.com": [
+      "alternet.org",
+      "thehill.com"
     ],
     "ign.com": [
       "videojs.com"
     ],
     "igodigital.com": [
-      "motorola.com",
-      "nintendo.com"
+      "apa.org",
+      "adidas.com",
+      "motorola.com"
     ],
     "iheart.com": [
       "variety.com"
     ],
     "im-apps.net": [
-      "economist.com",
       "exblog.jp",
-      "biglobe.ne.jp",
-      "nifty.com"
+      "rakuten.co.jp",
+      "biglobe.ne.jp"
+    ],
+    "imagetopng.club": [
+      "4shared.com"
+    ],
+    "imedia.cz": [
+      "idnes.cz"
+    ],
+    "imgfarm.com": [
+      "excite.com"
     ],
     "imgur.com": [
       "stackoverflow.com",
-      "stackexchange.com"
+      "stackexchange.com",
+      "unm.edu"
     ],
     "impact-ad.jp": [
-      "economist.com",
+      "rakuten.co.jp",
       "yahoo.co.jp",
-      "hatena.ne.jp",
-      "nifty.com"
+      "goo.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
+      "bbc.com",
       "wsj.com",
-      "speedtest.net",
-      "syfy.com"
+      "altervista.org",
+      "marthastewart.com",
+      "hgtv.com"
+    ],
+    "ineity.pro": [
+      "4shared.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
       "gartner.com"
     ],
-    "innity.com": [
-      "thestar.com.my"
+    "infolinks.com": [
+      "infoplease.com"
+    ],
+    "innovid.com": [
+      "nationalreview.com"
     ],
     "inq.com": [
+      "att.com",
+      "shutterstock.com",
       "ups.com"
     ],
+    "inquisitr.com": [
+      "www.poznan.pl"
+    ],
+    "inside-graph.com": [
+      "staples.com"
+    ],
     "insightexpressai.com": [
-      "giphy.com",
       "unsplash.com",
+      "standard.co.uk",
+      "motorola.com",
+      "reddit.com",
       "gopro.com"
     ],
     "instagram.com": [
-      "illinois.edu",
       "cam.ac.uk",
+      "illinois.edu",
       "cbslocal.com",
       "arizona.edu",
-      "tmz.com",
-      "patch.com"
+      "tmz.com"
     ],
     "instinctiveads.com": [
-      "rollingstone.com",
       "variety.com",
-      "indiewire.com"
+      "dp.ua",
+      "blackberry.com",
+      "rollingstone.com"
     ],
     "intentiq.com": [
-      "thinkgeek.com"
+      "sourceforge.net",
+      "symantec.com"
     ],
     "intentmedia.net": [
+      "hotels.com",
       "tripadvisor.com",
-      "hotels.com"
+      "expedia.com"
     ],
     "intercom.io": [
-      "visual.ly",
-      "yumpu.com",
+      "themeforest.net",
+      "ft.com",
+      "elegantthemes.com",
       "iconfinder.com"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
-      "wikitravel.org"
+      "wikitravel.org",
+      "inhabitat.com"
     ],
     "investingchannel.com": [
       "zerohedge.com"
+    ],
+    "investis.com": [
+      "ge.com"
     ],
     "invoc.us": [
       "prweb.com"
@@ -5923,41 +5497,48 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com",
-      "welt.de"
+      "xing.com"
     ],
     "iolam.it": [
       "virgilio.it"
     ],
     "iperceptions.com": [
+      "ford.com",
+      "seagate.com",
+      "honeywell.com",
       "boeing.com"
     ],
     "ipinyou.com": [
-      "suning.com"
+      "autohome.com.cn"
     ],
     "ipredictive.com": [
       "myspace.com",
-      "usatoday.com"
+      "dailymotion.com"
     ],
     "irs01.com": [
       "youku.com"
     ],
-    "ixiaa.com": [
-      "businessinsider.com"
+    "izooto.com": [
+      "indianexpress.com"
+    ],
+    "janrainsso.com": [
+      "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
+      "ifeng.com",
       "sohu.com"
     ],
     "jquery.com": [
-      "opensource.org",
-      "lemonde.fr",
-      "businessinsider.com"
+      "dyn.com",
+      "fujitsu.com",
+      "liveleak.com",
+      "lemonde.fr"
     ],
     "jrs5.com": [
       "nike.com",
-      "bostonglobe.com",
-      "coursera.org"
+      "shutterstock.com",
+      "bostonglobe.com"
     ],
     "jsrdn.com": [
       "thestar.com",
@@ -5965,11 +5546,23 @@
       "dallasnews.com",
       "vancouversun.com"
     ],
+    "justpremium.com": [
+      "tvtropes.org"
+    ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com"
+      "searchengineland.com",
+      "zenfolio.com",
+      "gopro.com"
+    ],
+    "jword.jp": [
+      "excite.co.jp"
+    ],
+    "jyxo.com": [
+      "blog.cz"
     ],
     "kakao.com": [
+      "tistory.com",
       "daum.net"
     ],
     "kameleoon.eu": [
@@ -5977,10 +5570,11 @@
       "orange.fr"
     ],
     "keywee.co": [
-      "nytimes.com",
       "latimes.com",
       "nationalgeographic.com",
-      "smithsonianmag.com",
+      "chicagotribune.com",
+      "nytimes.com",
+      "rollingstone.com",
       "apartmenttherapy.com"
     ],
     "kinja.com": [
@@ -5992,72 +5586,100 @@
       "enlightenment.org"
     ],
     "krxd.net": [
-      "businessinsider.com",
-      "usatoday.com",
-      "nature.com",
-      "billboard.com",
-      "gizmodo.com"
+      "inhabitat.com",
+      "bgr.com",
+      "jalopnik.com",
+      "cnn.com",
+      "gizmodo.com",
+      "jsonline.com",
+      "realtor.com"
+    ],
+    "ladsp.com": [
+      "exblog.jp",
+      "biglobe.ne.jp",
+      "shop-pro.jp"
     ],
     "leadintel.io": [
       "nme.com"
     ],
+    "leaf.io": [
+      "ehow.com",
+      "livestrong.com"
+    ],
     "legocdn.com": [
       "lego.com"
     ],
+    "lejwaengv.com": [
+      "rd.com"
+    ],
     "liadm.com": [
+      "webmd.com",
+      "nj.com",
+      "patch.com",
       "bloomberg.com",
-      "time.com",
-      "economist.com",
-      "ew.com",
-      "travelandleisure.com"
+      "usmagazine.com"
+    ],
+    "libero.it": [
+      "virgilio.it"
     ],
     "licasd.com": [
-      "ew.com",
-      "travelandleisure.com"
+      "nj.com",
+      "usmagazine.com"
+    ],
+    "licdn.com": [
+      "linkedin.com"
     ],
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "lefigaro.fr",
       "home.pl"
     ],
     "lightboxcdn.com": [
-      "gizmodo.com",
+      "zdnet.com",
       "fastcompany.com",
+      "adweek.com",
       "lifehacker.com",
-      "theonion.com",
-      "dailycaller.com"
+      "usmagazine.com"
     ],
     "lijit.com": [
       "sourceforge.net",
+      "bloomberg.com",
       "deviantart.com",
-      "mirror.co.uk",
-      "upi.com",
+      "howstuffworks.com",
       "infoplease.com"
     ],
+    "lincoln.com": [
+      "ford.com"
+    ],
     "link-page.info": [
-      "netvibes.com"
+      "netvibes.com",
+      "icq.com"
     ],
     "linkedin.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "sap.com",
-      "lexisnexis.com"
+      "dropbox.com",
+      "cisco.com",
+      "unity3d.com",
+      "helsinki.fi"
     ],
     "linksynergy.com": [
+      "rakuten.co.jp",
       "pcworld.com",
-      "nike.com",
-      "alibabacloud.com",
-      "infoworld.com"
+      "nike.com"
+    ],
+    "list-manage.com": [
+      "boingboing.net"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "microsoft.com",
+      "paypal.com",
+      "skype.com",
       "msn.com",
-      "bing.com",
+      "microsoft.com",
       "office.com"
     ],
     "livechatinc.com": [
@@ -6066,201 +5688,262 @@
       "sophos.com",
       "nazwa.pl"
     ],
+    "livedoor.jp": [
+      "livedoor.com"
+    ],
     "livejournal.net": [
       "livejournal.com"
     ],
     "liveperson.net": [
-      "talktalk.co.uk",
-      "earthlink.net",
-      "thetimes.co.uk",
-      "trendmicro.com",
-      "lexisnexis.com"
+      "apache.org",
+      "prnewswire.com",
+      "ibm.com",
+      "earthlink.net"
+    ],
+    "lkqd.net": [
+      "allafrica.com"
     ],
     "loc.gov": [
+      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
-      "jpost.com",
-      "infoplease.com"
+      "infoplease.com",
+      "coindesk.com",
+      "edmunds.com"
     ],
     "logly.co.jp": [
       "goo.ne.jp",
       "nifty.com"
     ],
-    "lp1block.com": [
-      "radikal.ru"
+    "lqm.io": [
+      "lefigaro.fr"
     ],
     "lrcontent.com": [
       "cbc.ca",
       "arte.tv"
     ],
+    "lucklayed.info": [
+      "4shared.com"
+    ],
+    "lwcal.com": [
+      "sfu.ca"
+    ],
     "lytics.io": [
-      "economist.com",
-      "digitaltrends.com",
       "adweek.com",
-      "fool.com"
+      "digitaltrends.com",
+      "fool.com",
+      "economist.com"
     ],
     "m6r.eu": [
       "t-online.de",
       "statista.com"
     ],
-    "macromill.com": [
-      "asahi.com"
+    "madeleine.de": [
+      "t-online.de"
     ],
     "mail.ru": [
       "vk.com",
+      "novostimira.com",
+      "google.com",
       "yandex.ru",
-      "thehill.com",
-      "icq.com",
-      "ok.ru",
-      "liveinternet.ru",
-      "novostimira.com"
+      "ok.ru"
+    ],
+    "mailchimp.com": [
+      "colorlib.com",
+      "fas.org",
+      "tias.com",
+      "nap.edu"
+    ],
+    "mantisadnetwork.com": [
+      "tvtropes.org"
     ],
     "marinsm.com": [
       "eventbrite.com",
       "webs.com",
-      "smugmug.com",
-      "eventbrite.co.uk",
-      "godaddy.com"
+      "hootsuite.com",
+      "smugmug.com"
     ],
     "marketlinc.com": [
-      "teamviewer.com",
-      "eset.com"
+      "kaspersky.com",
+      "norton.com",
+      "eset.com",
+      "teamviewer.us"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
       "dyn.com",
-      "docker.com",
-      "searchengineland.com",
-      "hootsuite.com",
-      "domaintools.com"
+      "ubuntu.com"
     ],
     "matheranalytics.com": [
+      "theglobeandmail.com",
       "thestar.com",
-      "mercurynews.com",
       "seattletimes.com"
     ],
     "mathtag.com": [
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "ew.com",
-      "colourlovers.com"
+      "forbes.com",
+      "prnewswire.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "media.net": [
       "nytimes.com",
       "dropbox.com",
       "forbes.com",
-      "thestreet.com",
+      "reuters.com",
+      "webmd.com",
       "cracked.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
-      "columbia.edu",
       "uci.edu",
-      "colourlovers.com"
+      "autodesk.com",
+      "box.com"
     ],
     "mediaforge.com": [
-      "bostonglobe.com",
-      "coursera.org"
+      "nike.com",
+      "shutterstock.com",
+      "bostonglobe.com"
+    ],
+    "medialand.ru": [
+      "rbc.ru"
     ],
     "mediaplex.com": [
-      "economist.com",
       "dell.com",
-      "shutterfly.com"
+      "shutterfly.com",
+      "military.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
+      "lynda.com",
+      "liberation.fr",
       "leparisien.fr"
     ],
     "mediav.com": [
-      "so.com",
       "ctrip.com",
-      "toutiao.com"
+      "2345.com",
+      "so.com"
     ],
     "mediawallahscript.com": [
       "sourceforge.net",
-      "gopro.com"
+      "photobucket.com",
+      "shopko.com"
     ],
-    "mediawiki.org": [
-      "wikimedia.org"
+    "medscape.com": [
+      "medicinenet.com"
     ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
     ],
     "metadsp.co.uk": [
-      "usatoday.com",
-      "mirror.co.uk",
-      "nypost.com"
+      "nypost.com",
+      "standard.co.uk"
     ],
     "mfadsrvr.com": [
-      "nbcsports.com"
+      "jsonline.com"
     ],
     "mg2connext.com": [
+      "mercurynews.com",
       "philly.com",
-      "newsday.com",
-      "ajc.com"
+      "denverpost.com"
     ],
     "mgid.com": [
-      "liveleak.com"
+      "liveleak.com",
+      "radikal.ru"
+    ],
+    "miamiherald.com": [
+      "sacbee.com",
+      "kansascity.com"
     ],
     "miaozhen.com": [
-      "qq.com",
       "sina.com.cn",
-      "pconline.com.cn"
+      "163.com",
+      "dzwww.com",
+      "sohu.com",
+      "autohome.com.cn"
     ],
     "microad.jp": [
+      "rakuten.co.jp",
       "sakura.ne.jp",
-      "hatena.ne.jp"
+      "biglobe.ne.jp"
     ],
     "microsoft.com": [
-      "msn.com",
       "live.com",
       "skype.com",
+      "or.kr",
+      "msn.com",
       "office.com",
       "xbox.com",
-      "complex.com"
+      "complex.com",
+      "encyclopedia.com"
     ],
     "microsoftonline.com": [
       "microsoft.com",
       "office.com"
     ],
+    "mirtesen.ru": [
+      "rbc.ru"
+    ],
     "mktoresp.com": [
       "parallels.com",
+      "prnewswire.com",
       "zend.com",
-      "prweb.com",
-      "proofpoint.com",
+      "nginx.com",
+      "oreilly.com",
       "pingdom.com"
     ],
     "ml314.com": [
       "sourceforge.net",
-      "wsj.com",
+      "forbes.com",
       "bloomberg.com",
-      "space.com",
-      "zerohedge.com"
+      "wsj.com",
+      "zdnet.com",
+      "xda-developers.com"
+    ],
+    "mlb.com": [
+      "nhl.com"
+    ],
+    "mlive.com": [
+      "nola.com"
     ],
     "mmstat.com": [
+      "alibaba.com",
       "youku.com",
-      "sohu.com",
       "taobao.com",
-      "tmall.com"
+      "sohu.com",
+      "51.la"
+    ],
+    "mmtro.com": [
+      "upwork.com"
+    ],
+    "molefefiseranis.ru": [
+      "radikal.ru"
     ],
     "monetate.net": [
       "nationalgeographic.com",
-      "marriott.com"
+      "marriott.com",
+      "ticketmaster.com"
+    ],
+    "monster.com": [
+      "military.com"
     ],
     "mookie1.com": [
-      "businessinsider.com",
-      "photobucket.com",
+      "t-online.de",
+      "nbcnews.com",
       "theglobeandmail.com",
-      "eonline.com"
+      "thetimes.co.uk"
     ],
     "mouseflow.com": [
+      "bbb.org",
       "nintendo.com"
     ],
     "mpnrs.com": [
@@ -6269,6 +5952,7 @@
     ],
     "mrpfd.com": [
       "symantec.com",
+      "gouv.fr",
       "hpe.com"
     ],
     "msgapp.com": [
@@ -6276,63 +5960,108 @@
       "odin.com"
     ],
     "msn.com": [
-      "marketwatch.com"
+      "w3.org",
+      "marketwatch.com",
+      "google.com"
+    ],
+    "mthsense.com": [
+      "alternet.org"
+    ],
+    "mtty.com": [
+      "163.com"
     ],
     "mtvnservices.com": [
       "mtv.com",
       "cc.com"
     ],
+    "multiview.com": [
+      "symantec.com",
+      "nutrition.org"
+    ],
     "musthird.com": [
       "airbnb.com"
+    ],
+    "muumuu-domain.com": [
+      "shop-pro.jp"
+    ],
+    "mybuys.com": [
+      "shopko.com"
+    ],
+    "myhard.com": [
+      "yesky.com"
     ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
+    ],
+    "myregistry.com": [
+      "shopko.com"
     ],
     "myspacecdn.com": [
       "myspace.com"
     ],
     "myvisualiq.net": [
       "soundcloud.com",
-      "paypal.com",
       "surveymonkey.com",
-      "bluehost.com"
+      "spotify.com",
+      "paypal.com",
+      "dell.com"
     ],
     "nanigans.com": [
-      "squareup.com",
       "thinkgeek.com",
-      "yellowpages.com"
+      "overstock.com",
+      "squareup.com",
+      "zappos.com"
     ],
     "narrative.io": [
-      "sourceforge.net",
-      "businessinsider.com"
+      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
     ],
     "nationalgeographic.com": [
-      "foxnews.com"
+      "foxnews.com",
+      "foxbusiness.com",
+      "fox.com"
+    ],
+    "native.ai": [
+      "rollingstone.com"
     ],
     "nativendo.de": [
-      "t-online.de"
+      "t-online.de",
+      "gnu.org",
+      "focus.de"
     ],
     "naver.com": [
-      "unity3d.com"
+      "unity3d.com",
+      "cafe24.com"
     ],
     "naver.jp": [
-      "line.me"
+      "line.me",
+      "livedoor.com"
+    ],
+    "nbcnews.com": [
+      "today.com",
+      "msnbc.com"
     ],
     "nbcuni.com": [
       "cnbc.com",
-      "nbcnews.com",
-      "today.com",
+      "msnbc.com",
       "nbc.com",
-      "syfy.com"
+      "nbcnews.com"
+    ],
+    "netdna-ssl.com": [
+      "alternet.org"
     ],
     "netmng.com": [
-      "businessinsider.com",
-      "lemonde.fr",
-      "colourlovers.com"
+      "lenovo.com",
+      "theknot.com",
+      "shopko.com",
+      "jsonline.com",
+      "xda-developers.com"
+    ],
+    "newatlas.com": [
+      "flipboard.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -6346,25 +6075,26 @@
     ],
     "news.com.au": [
       "theaustralian.com.au",
-      "heraldsun.com.au",
-      "dailytelegraph.com.au"
+      "heraldsun.com.au"
     ],
     "newscdn.com.au": [
-      "heraldsun.com.au",
-      "dailytelegraph.com.au"
+      "heraldsun.com.au"
     ],
     "newscgp.com": [
       "marketwatch.com",
       "nypost.com",
       "thesun.co.uk",
-      "biblegateway.com",
-      "heraldsun.com.au"
+      "wsj.com",
+      "news.com.au",
+      "realtor.com"
     ],
     "newsinc.com": [
       "latimes.com",
-      "hollywoodreporter.com",
-      "thehill.com",
-      "ajc.com"
+      "nydailynews.com",
+      "hollywoodreporter.com"
+    ],
+    "newsmemory.com": [
+      "cleveland.com"
     ],
     "newsvine.com": [
       "nbcnews.com",
@@ -6376,6 +6106,7 @@
     ],
     "newyorker.com": [
       "wired.com",
+      "vanityfair.com",
       "vogue.com",
       "pitchfork.com"
     ],
@@ -6385,33 +6116,84 @@
     "ngpvan.com": [
       "greenpeace.org"
     ],
+    "nih.gov": [
+      "medlineplus.gov",
+      "clinicaltrials.gov"
+    ],
+    "nj.com": [
+      "nola.com"
+    ],
+    "nokia.com": [
+      "bell-labs.com"
+    ],
+    "norton.com": [
+      "namejet.com"
+    ],
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "huffingtonpost.com",
-      "redcross.org",
-      "nbcsports.com"
+      "oracle.com",
+      "washingtonpost.com",
+      "domainmarket.com",
+      "jsonline.com",
+      "helsinki.fi"
+    ],
+    "nsaudience.pl": [
+      "interia.pl"
+    ],
+    "nscontext.eu": [
+      "interia.pl",
+      "home.pl"
     ],
     "nuggad.net": [
-      "t-online.de"
+      "t-online.de",
+      "liberation.fr",
+      "lexpress.fr"
     ],
     "nxtck.com": [
       "nike.com",
-      "bostonglobe.com",
-      "coursera.org",
-      "orange.fr"
+      "shutterstock.com",
+      "bostonglobe.com"
+    ],
+    "nymag.com": [
+      "vulture.com"
+    ],
+    "nzaza.com": [
+      "upwork.com"
     ],
     "o0bg.com": [
       "bostonglobe.com"
     ],
-    "offaces-butional.com": [
-      "pornhub.com"
+    "oath.com": [
+      "tumblr.com",
+      "huffingtonpost.co.uk",
+      "techradar.com"
+    ],
+    "ocdn.eu": [
+      "onet.pl",
+      "brightcove.net"
+    ],
+    "oclc.org": [
+      "worldcat.org"
+    ],
+    "ofapes.com": [
+      "radikal.ru"
+    ],
+    "office.com": [
+      "microsoftonline.com"
+    ],
+    "office365.com": [
+      "microsoftonline.com"
     ],
     "ojrq.net": [
-      "autodesk.com"
+      "office.com"
     ],
     "ok.ru": [
-      "ria.ru"
+      "ria.ru",
+      "mail.ru"
+    ],
+    "olark.com": [
+      "webstarts.com"
     ],
     "olympicchannel.com": [
       "olympic.org"
@@ -6423,30 +6205,36 @@
       "rambler.ru"
     ],
     "omnitagjs.com": [
-      "mirror.co.uk",
-      "variety.com",
-      "skyrock.com",
-      "standard.co.uk"
+      "springer.com",
+      "standard.co.uk",
+      "home.pl",
+      "newatlas.com"
     ],
     "omtrdc.net": [
       "adobe.com",
-      "telegraph.co.uk",
       "amazon.com",
-      "sap.com",
-      "rtve.es"
+      "telegraph.co.uk",
+      "dell.com",
+      "eset.com"
+    ],
+    "onclickmega.com": [
+      "brothersoft.com"
     ],
     "onecount.net": [
       "foreignpolicy.com"
     ],
-    "oneroof.co.nz": [
-      "nzherald.co.nz"
+    "onet.tv": [
+      "onet.pl"
     ],
     "onetrust.com": [
-      "cnn.com",
-      "thesun.co.uk",
       "themeisle.com",
-      "atlassian.com",
+      "bitbucket.org",
+      "namecheap.com",
+      "thesun.co.uk",
       "active.com"
+    ],
+    "onevision.com.tw": [
+      "udn.com"
     ],
     "online-metrix.net": [
       "gotomeeting.com"
@@ -6456,26 +6244,29 @@
     ],
     "onthe.io": [
       "indiatimes.com",
-      "express.co.uk",
-      "rbc.ru"
+      "wn.com",
+      "express.co.uk"
     ],
     "ooyala.com": [
-      "bizjournals.com",
       "accuweather.com",
-      "fedex.com"
+      "technologyreview.com",
+      "bizjournals.com"
     ],
     "openhub.net": [
       "mariadb.org"
     ],
     "openstat.net": [
-      "novostimira.com"
+      "novostimira.com",
+      "kharkov.ua"
     ],
     "openx.net": [
+      "yahoo.com",
+      "amazon.com",
       "nytimes.com",
       "dropbox.com",
-      "telegraph.co.uk",
-      "liveinternet.ru",
-      "colourlovers.com"
+      "theverge.com",
+      "jsonline.com",
+      "active.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -6483,146 +6274,206 @@
     "optaim.com": [
       "sohu.com"
     ],
+    "optimix.asia": [
+      "bshare.cn"
+    ],
     "optimizely.com": [
-      "nytimes.com",
       "cnn.com",
-      "microsoft.com",
+      "creativecommons.org",
+      "webs.com",
       "bbc.com",
-      "hp.com",
+      "live.com",
+      "ibm.com",
       "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
-      "foxnews.com",
-      "change.org",
-      "wikihow.com",
+      "constantcontact.com",
       "imageshack.us",
+      "wikihow.com",
       "newyorker.com",
+      "scientificamerican.com",
+      "evernote.com",
       "box.com",
       "prezi.com",
       "prweb.com",
-      "ign.com",
+      "dictionary.com",
       "bitbucket.org",
-      "gotomeeting.com",
       "accorhotels.com",
+      "uber.com",
+      "xbox.com",
       "history.com",
       "bestbuy.com",
-      "salesforce.com",
-      "www.nhs.uk",
-      "office.com",
+      "jamanetwork.com",
       "imageshack.com",
+      "atlassian.com",
       "dallasnews.com",
       "metmuseum.org",
       "intuit.com",
       "blizzard.com",
-      "foxbusiness.com",
-      "ama-assn.org",
       "squareup.com",
       "starbucks.com",
-      "care2.com",
       "ajc.com",
       "justgiving.com",
-      "bankrate.com",
       "dreamhost.com",
+      "microsoft.com",
       "edx.org",
       "bartleby.com",
+      "malwarebytes.com",
+      "theknot.com",
+      "zenfolio.com",
+      "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
-      "peta.org",
       "fox.com"
+    ],
+    "optimove.events": [
+      "bhphotovideo.com"
     ],
     "ora.tv": [
       "cheezburger.com",
-      "alternet.org",
-      "wnd.com"
+      "alternet.org"
+    ],
+    "oracleimg.com": [
+      "dyn.com"
     ],
     "orangeads.fr": [
       "orange.fr"
+    ],
+    "oreilly.com": [
+      "onlamp.com",
+      "ora.com"
+    ],
+    "otm-r.com": [
+      "tomsk.ru",
+      "radikal.ru",
+      "diary.ru"
     ],
     "otto.de": [
       "t-online.de"
     ],
     "outbrain.com": [
+      "nature.com",
+      "scribd.com",
+      "foxnews.com",
       "cnn.com",
-      "msn.com",
-      "wsj.com",
-      "ew.com",
+      "news.com.au",
       "rfi.fr"
     ],
+    "ovh.com": [
+      "ovh.co.uk"
+    ],
     "owneriq.net": [
+      "lycos.com",
       "lg.com",
-      "acer.com",
+      "washingtontimes.com",
       "walgreens.com"
+    ],
+    "owox.com": [
+      "simplesite.com"
+    ],
+    "paddle.com": [
+      "snapwidget.com"
     ],
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
       "ap.org",
-      "heroku.com",
       "propublica.org"
     ],
     "parsely.com": [
-      "huffingtonpost.com",
-      "bloomberg.com",
       "time.com",
-      "huffingtonpost.co.uk",
-      "syfy.com"
+      "wired.com",
+      "wikia.com",
+      "wsj.com",
+      "fortune.com",
+      "rfi.fr"
     ],
     "paypal.com": [
-      "greenpeace.org",
       "paypal.me"
     ],
     "paypalobjects.com": [
       "paypal.com",
-      "paypal.me",
-      "freetype.org"
+      "freetype.org",
+      "paypal.me"
     ],
     "payroll.com": [
       "intuit.com"
+    ],
+    "pbbl.co": [
+      "zappos.com"
+    ],
+    "pbskids.org": [
+      "pbs.org"
+    ],
+    "pcmag.com": [
+      "macrumors.com",
+      "extremetech.com"
+    ],
+    "pdmp.jp": [
+      "shop-pro.jp"
     ],
     "performgroup.com": [
       "goal.com"
     ],
     "perimeterx.net": [
-      "udemy.com",
-      "zillow.com",
-      "seekingalpha.com",
-      "couchsurfing.com"
+      "bloomberg.com",
+      "pixnet.net",
+      "macrumors.com"
     ],
     "pewresearch.org": [
       "pewinternet.org"
-    ],
-    "photobucket.com": [
-      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
     ],
     "pinterest.com": [
-      "nytimes.com",
       "huffingtonpost.com",
       "dailymail.co.uk",
-      "huffingtonpost.co.uk"
+      "nytimes.com",
+      "themeforest.net",
+      "booking.com",
+      "marthastewart.com"
     ],
     "pitchfork.com": [
       "wired.com",
-      "vogue.com"
+      "newyorker.com",
+      "vanityfair.com",
+      "epicurious.com"
+    ],
+    "pixanalytics.com": [
+      "pixnet.net"
     ],
     "piximedia.com": [
       "orange.fr"
     ],
+    "pixnet.cc": [
+      "pixnet.net"
+    ],
+    "placed.com": [
+      "imdb.com"
+    ],
     "placelocal.com": [
       "gopro.com"
+    ],
+    "playwire.com": [
+      "infoplease.com",
+      "zotero.org"
     ],
     "plista.com": [
       "express.co.uk"
     ],
     "po.st": [
-      "nme.com",
-      "wnd.com"
+      "smithsonianmag.com",
+      "wnd.com",
+      "business2community.com",
+      "nme.com"
+    ],
+    "polymorphicads.jp": [
+      "shinobi.jp"
     ],
     "popin.cc": [
-      "nifty.com"
+      "infoseek.co.jp"
     ],
     "popsugar-assets.com": [
       "popsugar.com"
@@ -6631,29 +6482,36 @@
       "reuters.com",
       "independent.co.uk",
       "chicagotribune.com",
-      "seattletimes.com",
+      "wsj.com",
+      "marketwatch.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
-      "variety.com",
       "lemonde.fr",
-      "howtogeek.com"
+      "livescience.com",
+      "standard.co.uk"
+    ],
+    "pressboard.ca": [
+      "observer.com"
     ],
     "prfct.co": [
-      "smugmug.com"
+      "smugmug.com",
+      "marthastewart.com",
+      "business2community.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
+      "symantec.com",
       "slashdot.org",
-      "thinkgeek.com"
-    ],
-    "prod-cmg-proxy-connext.azurewebsites.net": [
-      "ajc.com"
+      "business2community.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
       "denverpost.com",
       "ocregister.com"
+    ],
+    "proparm.jp": [
+      "biglobe.ne.jp"
     ],
     "provenpixel.com": [
       "shopify.com"
@@ -6661,24 +6519,33 @@
     "providesupport.com": [
       "jigsy.com"
     ],
-    "proximus.be": [
+    "proximustv.be": [
       "skynet.be"
     ],
     "pscp.tv": [
+      "ey.com",
+      "ria.ru",
       "nasa.gov"
     ],
     "pub.network": [
+      "metacafe.com",
       "coindesk.com"
+    ],
+    "publishme.se": [
+      "blogg.se"
     ],
     "pubmatic.com": [
       "dropbox.com",
-      "businessinsider.com",
+      "tinyurl.com",
+      "bloomberg.com",
       "usatoday.com",
-      "space.com",
-      "colourlovers.com"
+      "webmd.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "pubmine.com": [
-      "foreignpolicy.com"
+      "foreignpolicy.com",
+      "onecount.net"
     ],
     "pulpix.com": [
       "variety.com"
@@ -6686,34 +6553,61 @@
     "purch.com": [
       "livescience.com",
       "space.com",
-      "tomshardware.com",
-      "anandtech.com"
+      "tomshardware.com"
     ],
     "purechat.com": [
       "byu.edu"
     ],
-    "pushanert.com": [
-      "4shared.com"
+    "pxf.io": [
+      "namecheap.com",
+      "udemy.com"
     ],
-    "pxi.pub": [
-      "mentalfloss.com"
+    "pxtres.com": [
+      "howstuffworks.com"
+    ],
+    "pxuno.com": [
+      "howstuffworks.com"
+    ],
+    "pxzwei.com": [
+      "howstuffworks.com"
     ],
     "pymx5.com": [
-      "sfgate.com",
       "seattletimes.com",
+      "seattlepi.com",
+      "sfgate.com",
       "cracked.com"
     ],
+    "qnsr.com": [
+      "serverwatch.com"
+    ],
+    "qq.com": [
+      "sina.com.cn",
+      "ctrip.com",
+      "weather.com.cn"
+    ],
+    "qsstats.com": [
+      "serverwatch.com",
+      "eweek.com"
+    ],
+    "qtmojo.com": [
+      "dzwww.com"
+    ],
     "qualtrics.com": [
-      "techrepublic.com",
-      "nintendo.com",
-      "cnet.com"
+      "adidas.com",
+      "cnet.com",
+      "babycenter.com"
     ],
     "quantserve.com": [
-      "vimeo.com",
       "wordpress.org",
+      "vimeo.com",
       "reddit.com",
-      "fool.com",
+      "soundcloud.com",
+      "goodreads.com",
+      "jsonline.com",
       "rfi.fr"
+    ],
+    "quantummetric.com": [
+      "macys.com"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -6725,7 +6619,7 @@
       "weebly.com",
       "bloomberg.com",
       "ning.com",
-      "billboard.com",
+      "nypost.com",
       "eset.com"
     ],
     "rackcdn.com": [
@@ -6734,25 +6628,50 @@
     "radiotime.com": [
       "tunein.com"
     ],
+    "rakuten.co.jp": [
+      "infoseek.co.jp"
+    ],
     "rambler.ru": [
       "livejournal.com",
+      "washingtonpost.com",
       "novostimira.com",
-      "ria.ru"
+      "ria.ru",
+      "kharkov.ua"
     ],
-    "reactful.com": [
-      "thawte.com"
+    "rbnt.org": [
+      "radikal.ru"
+    ],
+    "rcsmetrics.it": [
+      "corriere.it"
+    ],
+    "reachmax.cn": [
+      "sina.com.cn",
+      "autohome.com.cn",
+      "bshare.cn"
     ],
     "reddit.com": [
       "acm.org",
       "perl.com"
     ],
+    "redditmedia.com": [
+      "reddit.com"
+    ],
     "redlink.com": [
-      "jamanetwork.com"
+      "jamanetwork.com",
+      "ccc.de"
+    ],
+    "reference.com": [
+      "thesaurus.com"
     ],
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
+    "relap.io": [
+      "diary.ru"
+    ],
     "republer.com": [
+      "tomsk.ru",
+      "radikal.ru",
       "rambler.ru"
     ],
     "researchintel.com": [
@@ -6769,27 +6688,26 @@
       "reuters.com"
     ],
     "revcontent.com": [
-      "jpost.com",
-      "breitbart.com",
-      "bostonherald.com"
+      "liveuamap.com",
+      "wnd.com",
+      "jpost.com"
     ],
     "revjet.com": [
+      "homedepot.com",
+      "expedia.com",
       "bankrate.com"
     ],
     "rezync.com": [
       "economist.com",
-      "accuweather.com",
-      "investopedia.com"
+      "accuweather.com"
     ],
     "rfihub.com": [
       "dropbox.com",
+      "tinyurl.com",
       "npr.org",
-      "economist.com",
-      "kaspersky.com",
+      "forbes.com",
+      "foursquare.com",
       "gopro.com"
-    ],
-    "rhombusads.com": [
-      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6800,77 +6718,109 @@
       "mlive.com"
     ],
     "richrelevance.com": [
-      "hbr.org"
+      "hbr.org",
+      "kohls.com"
+    ],
+    "rightnowtech.com": [
+      "oracle.com"
     ],
     "rkdms.com": [
-      "dropbox.com",
-      "usatoday.com",
+      "time.com",
       "wired.com",
-      "kotaku.com",
-      "gizmodo.com"
+      "cbsnews.com",
+      "zdnet.com",
+      "pitchfork.com"
     ],
     "rlcdn.com": [
       "adobe.com",
+      "yahoo.com",
       "sourceforge.net",
       "reddit.com",
-      "sap.com",
-      "colourlovers.com"
+      "uci.edu",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "rnengage.com": [
+      "oracle.com",
       "thinkgeek.com"
     ],
     "rockyou.net": [
       "springer.com"
     ],
-    "rqtrk.eu": [
-      "dropbox.com"
+    "roomkey.com": [
+      "hilton.com",
+      "ihg.com"
+    ],
+    "roymorgan.com": [
+      "smh.com.au"
+    ],
+    "rtb.com.ru": [
+      "radikal.ru",
+      "diary.ru"
     ],
     "rtk.io": [
-      "seattletimes.com",
-      "miamiherald.com",
-      "startribune.com"
+      "post-gazette.com",
+      "azcentral.com",
+      "freep.com"
     ],
     "ru4.com": [
-      "dropbox.com"
+      "dropbox.com",
+      "bloomberg.com",
+      "uci.edu"
     ],
     "rubiconproject.com": [
+      "yahoo.com",
+      "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "cnn.com",
-      "techradar.com",
-      "colourlovers.com"
+      "gizmodo.com",
+      "jsonline.com",
+      "xda-developers.com"
     ],
     "rundsp.com": [
-      "hpe.com"
+      "hpe.com",
+      "alternet.org"
+    ],
+    "rutarget.ru": [
+      "rambler.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "bell-labs.com",
-      "hwg.org"
+      "codepen.io",
+      "tvtropes.org"
     ],
     "s3xified.com": [
-      "thehindu.com"
+      "venturebeat.com",
+      "livescience.com",
+      "lycos.com"
+    ],
+    "sabavision.com": [
+      "mihanblog.com"
     ],
     "salesforceliveagent.com": [
+      "constantcontact.com",
       "marriott.com",
-      "teamviewer.com",
       "prweb.com",
       "salesforce.com",
       "eset.com"
     ],
     "salesloft.com": [
-      "wpengine.com",
       "techtarget.com",
-      "upwork.com"
+      "upwork.com",
+      "wpengine.com"
     ],
     "salesmanago.pl": [
       "home.pl"
     ],
     "samba.tv": [
+      "imdb.com",
       "gizmodo.com",
-      "lifehacker.com",
-      "history.com",
-      "tmz.com",
-      "syfy.com"
+      "lifehacker.com"
+    ],
+    "sbal4kp.com": [
+      "dropbox.com"
+    ],
+    "scarabresearch.com": [
+      "tate.org.uk"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -6879,174 +6829,238 @@
       "thelancet.com",
       "cell.com"
     ],
+    "sciencedirectassets.com": [
+      "sciencedirect.com"
+    ],
     "sciverse.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
+    ],
+    "scoop.it": [
+      "investorseurope.technology"
     ],
     "scopus.com": [
-      "thelancet.com",
-      "cell.com"
+      "sciencedirect.com",
+      "cell.com",
+      "thelancet.com"
     ],
     "scorecardresearch.com": [
       "linkedin.com",
       "yahoo.com",
       "tumblr.com",
-      "billboard.com",
-      "syfy.com"
+      "nytimes.com",
+      "goodreads.com",
+      "jsonline.com",
+      "drugs.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
-      "startribune.com"
+      "startribune.com",
+      "ctvnews.ca"
     ],
-    "sdp-campaign.de": [
-      "t-online.de"
+    "sddan.com": [
+      "upwork.com"
+    ],
+    "seadform.net": [
+      "bloomberg.com"
+    ],
+    "searchmarketing.com": [
+      "macys.com"
     ],
     "securedvisit.com": [
-      "cafepress.com"
+      "cafepress.com",
+      "staples.com"
+    ],
+    "seekingalpha.com": [
+      "ytimg.com"
     ],
     "sekindo.com": [
       "allafrica.com"
     ],
     "selectablemedia.com": [
-      "time.com",
       "fortune.com",
       "people.com",
       "ew.com",
-      "travelandleisure.com"
+      "time.com",
+      "marthastewart.com"
     ],
     "self.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "semasio.net": [
-      "space.com"
+      "bloomberg.com"
     ],
     "sendtonews.com": [
+      "canada.com",
       "bostonherald.com"
     ],
     "servebom.com": [
+      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "howtogeek.com",
-      "dailydot.com"
+      "xda-developers.com"
+    ],
+    "servedby-buysellads.com": [
+      "dribbble.com"
     ],
     "serverbid.com": [
-      "sciencedaily.com"
+      "coindesk.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
-      "businessinsider.com",
+      "t-online.de",
+      "nbcnews.com",
       "news.com.au",
-      "redbull.com",
-      "syfy.com"
+      "hgtv.com"
     ],
     "sessioncam.com": [
       "ama-assn.org",
       "fitbit.com"
     ],
+    "shareaholic.com": [
+      "washingtontimes.com",
+      "turnerpublishing.com"
+    ],
     "sharethis.com": [
-      "uk.com",
-      "www.vic.gov.au",
-      "mcafee.com",
-      "findlaw.com",
+      "www.uk.com",
+      "whatsapp.com",
+      "lycos.com",
+      "uci.edu",
       "dailycaller.com"
     ],
     "sharethrough.com": [
-      "springer.com",
-      "samsung.com",
-      "cnbc.com",
-      "squareup.com"
+      "yahoo.com",
+      "cnn.com",
+      "time.com",
+      "cnet.com",
+      "fortune.com"
+    ],
+    "sheego.de": [
+      "t-online.de"
     ],
     "shop.pe": [
-      "dyn.com"
+      "dyn.com",
+      "bluehost.com",
+      "fourseasons.com"
     ],
-    "siftscience.com": [
-      "kickstarter.com",
-      "flickr.com",
-      "shutterstock.com",
-      "patreon.com",
-      "couchsurfing.com"
+    "shopify.com": [
+      "codepen.io",
+      "raspberrypi.org"
+    ],
+    "simplereach.com": [
+      "theatlantic.com"
     ],
     "simpli.fi": [
-      "thinkgeek.com",
-      "tampabay.com"
+      "symantec.com",
+      "washingtontimes.com",
+      "thinkgeek.com"
     ],
     "sina.cn": [
       "sina.com.cn"
     ],
     "sina.com.cn": [
       "weibo.com",
-      "suning.com"
+      "dzwww.com",
+      "sina.com"
+    ],
+    "sinoptik.ua": [
+      "kharkov.ua",
+      "kh.ua"
+    ],
+    "sitehelix.com": [
+      "overstock.com"
     ],
     "siteimprove.com": [
-      "berkeley.edu",
+      "usda.gov",
       "verisign.com",
       "udel.edu",
-      "ethz.ch",
-      "ucsb.edu",
-      "fsu.edu",
-      "buffalo.edu",
-      "unsw.edu.au",
-      "ucsf.edu",
+      "berkeley.edu",
+      "helsinki.fi",
       "case.edu",
       "oclc.org"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
     ],
+    "sitelabweb.com": [
+      "lenovo.com",
+      "upwork.com"
+    ],
     "sitelock.com": [
-      "joomla.org"
+      "joomla.org",
+      "netfirms.com"
     ],
     "sitescout.com": [
       "barnesandnoble.com",
       "tinypic.com",
-      "accuweather.com",
       "seattletimes.com",
-      "travelandleisure.com"
+      "accuweather.com",
+      "newatlas.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
-      "digital.com",
-      "atlasobscura.com"
+      "arstechnica.com",
+      "coindesk.com"
     ],
     "sky.com": [
-      "skygroup.sky"
+      "skygroup.sky",
+      "skysports.com"
     ],
     "slashdotmedia.com": [
       "slashdot.org"
     ],
     "smartadserver.com": [
       "springer.com",
-      "elpais.com",
       "skyrock.com",
-      "home.pl"
+      "sapo.pt"
+    ],
+    "smartclip.net": [
+      "infoplease.com"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
+    ],
+    "smi2.net": [
+      "rbc.ru"
     ],
     "smi2.ru": [
       "rbc.ru"
     ],
     "smithsonian.museum": [
+      "si.edu",
       "smithsonianmag.com"
     ],
+    "smyte.com": [
+      "indiegogo.com",
+      "zendesk.com"
+    ],
     "snapchat.com": [
+      "jimdo.com",
+      "overstock.com",
+      "complex.com",
+      "wsj.com",
       "giphy.com",
-      "walmart.com",
-      "wpengine.com",
-      "motorola.com",
-      "syfy.com"
+      "zappos.com"
+    ],
+    "snapwidget.com": [
+      "udel.edu"
+    ],
+    "snplow.net": [
+      "wetransfer.com"
     ],
     "so.com": [
       "360.cn"
     ],
     "socdm.com": [
-      "goo.ne.jp",
-      "hatena.ne.jp",
-      "ocn.ne.jp"
+      "rakuten.co.jp",
+      "biglobe.ne.jp",
+      "goo.ne.jp"
     ],
     "sociomantic.com": [
       "springer.com",
@@ -7055,34 +7069,68 @@
     "soflopxl.com": [
       "howstuffworks.com"
     ],
+    "softonic-analytics.net": [
+      "softonic.com"
+    ],
+    "sogou.com": [
+      "soso.com"
+    ],
+    "sohu.com": [
+      "ifeng.com",
+      "ctrip.com",
+      "focus.cn"
+    ],
     "sojern.com": [
+      "ihg.com",
+      "hyatt.com",
       "gopro.com"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
+    "soliditet.se": [
+      "jalbum.net"
+    ],
+    "solocpm.com": [
+      "edx.org"
+    ],
     "sonobi.com": [
-      "usatoday.com",
-      "springer.com",
+      "photobucket.com",
       "deviantart.com",
-      "space.com",
-      "goal.com"
+      "springer.com",
+      "forbes.com",
+      "theverge.com",
+      "jsonline.com",
+      "couchsurfing.com"
+    ],
+    "sonyentertainmentnetwork.com": [
+      "playstation.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "tmz.com",
-      "irishtimes.com",
       "mo.gov"
+    ],
+    "sourceforge.net": [
+      "libpng.org"
+    ],
+    "sp.global.ssl.fastly.net": [
+      "theglobeandmail.com"
+    ],
+    "spectate.com": [
+      "emory.edu"
     ],
     "sphereup.com": [
       "jpost.com"
     ],
     "spiceworks.com": [
-      "hp.com",
-      "salesforce.com",
-      "slack.com"
+      "cloudflare.com",
+      "symantec.com",
+      "sophos.com"
+    ],
+    "spineuniverse.com": [
+      "psychcentral.com"
     ],
     "spingo.com": [
       "detroitnews.com"
@@ -7094,14 +7142,17 @@
       "engadget.com",
       "denverpost.com"
     ],
+    "spotify.com": [
+      "oregonstate.edu"
+    ],
     "spots.im": [
       "denverpost.com"
     ],
     "spotxchange.com": [
+      "amazon.com",
       "dropbox.com",
-      "npr.org",
-      "express.co.uk",
-      "jpost.com",
+      "dailymotion.com",
+      "thenextweb.com",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -7110,11 +7161,14 @@
     ],
     "springernature.com": [
       "nature.com",
-      "springer.com",
-      "biomedcentral.com"
+      "biomedcentral.com",
+      "springer.com"
     ],
     "springserve.com": [
-      "tinypic.com"
+      "tinypic.com",
+      "liveuamap.com",
+      "magento.com",
+      "dailydot.com"
     ],
     "sprinklr.com": [
       "autodesk.com"
@@ -7123,40 +7177,72 @@
       "straitstimes.com"
     ],
     "stackadapt.com": [
-      "shopify.com",
-      "farfetch.com"
+      "thehill.com",
+      "farfetch.com",
+      "threadless.com"
+    ],
+    "staples-sparx.com": [
+      "staples.com"
+    ],
+    "staples-static.com": [
+      "staples.com"
+    ],
+    "starfieldtech.com": [
+      "scamnumbers.info"
     ],
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "freepik.com",
+      "man7.org",
+      "cbslocal.com",
       "zerohedge.com"
+    ],
+    "staticimgfarm.com": [
+      "excite.com"
+    ],
+    "staybridge.com": [
+      "ihg.com"
     ],
     "steelhousemedia.com": [
       "prezi.com",
       "wpengine.com",
-      "gettyimages.com",
-      "newegg.com",
+      "istockphoto.com",
       "careerbuilder.com"
+    ],
+    "steepto.com": [
+      "liveleak.com"
     ],
     "stg-sp.global.ssl.fastly.net": [
       "theglobeandmail.com"
     ],
+    "stg8.com": [
+      "sina.com.cn"
+    ],
     "stickyadstv.com": [
-      "pastebin.com",
-      "thinkgeek.com"
+      "bloomberg.com",
+      "dailymotion.com",
+      "feedburner.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
     ],
     "storygize.net": [
       "autodesk.com",
-      "squareup.com"
+      "squareup.com",
+      "dn.ua"
+    ],
+    "streem.com.au": [
+      "smh.com.au",
+      "theage.com.au"
+    ],
+    "streetscout.com": [
+      "azcentral.com"
     ],
     "stripe.com": [
-      "smashballoon.com",
+      "iconfinder.com",
       "presscustomizr.com",
       "themezee.com",
+      "feedly.com",
       "documentcloud.org"
     ],
     "sumo.com": [
@@ -7166,49 +7252,60 @@
       "makezine.com"
     ],
     "sundaysky.com": [
-      "fiverr.com",
-      "jpost.com",
+      "overstock.com",
+      "alternet.org",
+      "infoplease.com",
       "dailydot.com"
-    ],
-    "suning.cn": [
-      "suning.com"
     ],
     "suning.com": [
       "qq.com",
+      "ifeng.com",
       "sohu.com"
     ],
+    "sunrtb.com": [
+      "yesky.com"
+    ],
     "supplyframe.com": [
-      "arduino.cc",
       "ti.com"
     ],
     "survata.com": [
       "tripadvisor.com"
     ],
-    "surveygizmo.com": [
-      "berkeley.edu"
-    ],
     "surveymonkey.com": [
-      "techcrunch.com",
       "cambridge.org",
-      "iop.org",
+      "investopedia.com",
       "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
-      "thehindu.com"
+      "metacafe.com",
+      "indianexpress.com",
+      "springer.com"
     ],
     "symantec.com": [
-      "norton.com"
+      "norton.com",
+      "opinionlab.com"
+    ],
+    "synacor.com": [
+      "att.net"
     ],
     "taboola.com": [
       "weebly.com",
       "dropbox.com",
+      "t-online.de",
       "msn.com",
-      "fool.com",
-      "nbcsports.com"
+      "zdnet.com",
+      "jsonline.com",
+      "edmunds.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
+    ],
+    "tag4arm.com": [
+      "norton.com"
+    ],
+    "tagdelivery.com": [
+      "overstock.com"
     ],
     "tailtarget.com": [
       "uol.com.br"
@@ -7218,57 +7315,84 @@
       "hotels.com"
     ],
     "tanx.com": [
-      "sohu.com",
-      "ifeng.com",
-      "tmall.com",
-      "2345.com"
+      "sina.com.cn",
+      "alibaba.com",
+      "ifeng.com"
     ],
     "taobao.com": [
       "sina.com.cn",
-      "alibaba.com",
+      "1688.com",
       "tmall.com",
-      "1688.com"
+      "51.la"
     ],
     "tapad.com": [
       "adobe.com",
+      "yahoo.com",
       "soundcloud.com",
       "dropbox.com",
-      "rottentomatoes.com"
+      "newyorker.com"
+    ],
+    "targetimg1.com": [
+      "target.com"
     ],
     "tawk.to": [
-      "cba.pl",
-      "affordable-papers.net"
+      "cba.pl"
     ],
-    "taylorandfrancis.com": [
-      "tandfonline.com"
+    "tcell.io": [
+      "sophos.com"
     ],
     "teads.tv": [
-      "walgreens.com"
+      "alternet.org"
     ],
     "tealiumiq.com": [
       "ibm.com",
+      "cbsnews.com",
+      "evernote.com",
       "cnet.com",
-      "samsung.com",
-      "welt.de",
+      "politico.com",
       "usmagazine.com"
+    ],
+    "technolutions.net": [
+      "illinois.edu",
+      "upenn.edu",
+      "uci.edu",
+      "udel.edu",
+      "case.edu"
+    ],
+    "technoratimedia.com": [
+      "accuweather.com"
     ],
     "techweb.com": [
       "informationweek.com"
     ],
     "teenvogue.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
+    ],
+    "telegraph.co.uk": [
+      "wordpress.com"
+    ],
+    "telekom.de": [
+      "t-online.de"
+    ],
+    "tenmax.io": [
+      "biglobe.ne.jp"
     ],
     "theadex.com": [
       "t-online.de",
-      "spiegel.de",
-      "sueddeutsche.de"
+      "gnu.org",
+      "spiegel.de"
+    ],
+    "theatlas.com": [
+      "qz.com"
     ],
     "thebrighttag.com": [
+      "netflix.com",
+      "wufoo.com",
       "playstation.com",
-      "mercurynews.com",
-      "ubisoft.com"
+      "zappos.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -7276,37 +7400,49 @@
     "theguardian.com": [
       "videojs.com"
     ],
-    "thrtle.com": [
-      "sourceforge.net"
+    "thesaurus.com": [
+      "dictionary.com"
     ],
-    "tianqijun.com": [
-      "qianlong.com"
+    "thomsonreuters.com": [
+      "reuters.com"
+    ],
+    "thrtle.com": [
+      "xda-developers.com"
+    ],
+    "tidaltv.com": [
+      "dailymotion.com",
+      "nationalgeographic.com",
+      "xfinity.com"
     ],
     "tidelinedata.io": [
       "deviantart.com"
     ],
     "timecommerce.net": [
-      "time.com",
       "fortune.com",
       "people.com",
       "ew.com",
-      "travelandleisure.com"
+      "time.com",
+      "marthastewart.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
     ],
     "tinypass.com": [
-      "bloomberg.com",
       "businessinsider.com",
       "techcrunch.com",
-      "adage.com",
-      "gizmodo.com"
+      "kickstarter.com",
+      "bloomberg.com",
+      "gizmodo.com",
+      "vancouversun.com"
     ],
     "tiqcdn.com": [
-      "wsj.com",
       "cisco.com",
+      "nbcnews.com",
+      "ibm.com",
+      "wsj.com",
       "marketwatch.com",
-      "here.com"
+      "hpe.com",
+      "orange.fr"
     ],
     "tl813.com": [
       "panasonic.com",
@@ -7315,24 +7451,46 @@
     "tm-awx.com": [
       "mirror.co.uk"
     ],
+    "tmall.com": [
+      "taobao.com"
+    ],
     "tns-counter.ru": [
-      "vk.com",
       "livejournal.com",
+      "vk.com",
       "yandex.ru",
+      "mail.ru",
       "ok.ru",
       "radikal.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
     ],
+    "tracc.it": [
+      "france24.com",
+      "rfi.fr"
+    ],
+    "trackad.cz": [
+      "idnes.cz"
+    ],
     "trackalyzer.com": [
       "squareup.com"
     ],
+    "tradedoubler.com": [
+      "lemonde.fr",
+      "interia.pl"
+    ],
     "tradelab.fr": [
-      "eklablog.com"
+      "eklablog.com",
+      "leparisien.fr"
     ],
     "traffic-media.co": [
       "radikal.ru"
+    ],
+    "trafficgate.net": [
+      "rakuten.co.jp"
+    ],
+    "trafficjam.cn": [
+      "youku.com"
     ],
     "trafficjunky.net": [
       "pornhub.com"
@@ -7343,27 +7501,28 @@
     "trb.com": [
       "latimes.com",
       "chicagotribune.com",
-      "baltimoresun.com"
+      "nydailynews.com"
     ],
     "treasuredata.com": [
-      "exblog.jp",
-      "hatena.ne.jp",
-      "asahi.com"
+      "biglobe.ne.jp",
+      "nintendo.com",
+      "exblog.jp"
     ],
     "tremorhub.com": [
       "usatoday.com",
-      "freep.com",
-      "detroitnews.com"
+      "azcentral.com",
+      "freep.com"
     ],
     "tribalfusion.com": [
+      "dailymotion.com",
       "pastebin.com",
       "liveleak.com",
-      "xe.com",
-      "colourlovers.com"
+      "marriott.com"
     ],
     "tribl.io": [
-      "prnewswire.com",
-      "zimbra.com"
+      "prezi.com",
+      "zimbra.com",
+      "prnewswire.com"
     ],
     "tripadvisor.com": [
       "accorhotels.com"
@@ -7371,70 +7530,107 @@
     "tronc.com": [
       "latimes.com",
       "chicagotribune.com",
-      "baltimoresun.com"
+      "nydailynews.com"
     ],
     "trumba.com": [
-      "ucdavis.edu"
+      "ucdavis.edu",
+      "utah.edu",
+      "emory.edu"
+    ],
+    "truoptik.com": [
+      "slashdot.org",
+      "infoplease.com"
     ],
     "trustarc.com": [
       "skynet.be"
     ],
+    "trustev.com": [
+      "lenovo.com"
+    ],
     "trustpilot.com": [
       "jalbum.net",
+      "avira.com",
       "moonfruit.com"
     ],
     "trvl-px.com": [
-      "hotels.com"
+      "hotels.com",
+      "expedia.com"
+    ],
+    "tumblr.com": [
+      "dailydot.com"
     ],
     "turn.com": [
-      "hp.com",
+      "bloomberg.com",
       "wired.com",
+      "webmd.com",
       "economist.com",
-      "miamiherald.com",
+      "booking.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
     ],
     "tvsquared.com": [
-      "wsj.com",
+      "telegraph.co.uk",
       "jimdo.com",
       "squarespace.com",
-      "aarp.org"
+      "economist.com",
+      "booking.com"
+    ],
+    "twimg.com": [
+      "coe.int",
+      "ey.com",
+      "dol.gov"
     ],
     "twitter.com": [
-      "amazon.com",
       "wordpress.org",
+      "yahoo.com",
+      "chicagotribune.com",
       "nytimes.com",
       "cnn.com",
       "msn.com",
-      "perl.com",
-      "syfy.com"
+      "ca.gov",
+      "parallels.com",
+      "sfgate.com",
+      "marthastewart.com",
+      "helsinki.fi",
+      "edmunds.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
-      "digital.com",
+      "washingtontimes.com",
       "dailycaller.com"
     ],
-    "uc.se": [
-      "jalbum.net"
+    "ubi.com": [
+      "ubisoft.com"
     ],
     "uciservice.com": [
-      "hotels.com"
+      "hotels.com",
+      "expedia.com"
     ],
     "ucoz.net": [
       "narod.ru"
     ],
     "udmserve.net": [
+      "colourlovers.com",
+      "dailydot.com",
       "washingtonexaminer.com"
+    ],
+    "udnfunlife.com": [
+      "udn.com"
+    ],
+    "uefa.com": [
+      "bleacherreport.com"
+    ],
+    "ufpcdn.com": [
+      "brothersoft.com"
     ],
     "ugdturner.com": [
       "cnn.com",
       "nba.com"
     ],
     "undertone.com": [
-      "hpe.com",
       "dallasnews.com",
       "alternet.org"
     ],
@@ -7446,21 +7642,29 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "businessweek.com",
+      "earthlink.net",
       "boingboing.net"
     ],
     "upravel.com": [
-      "rambler.ru"
+      "rambler.ru",
+      "tomsk.ru"
     ],
     "upsellit.com": [
       "samsung.com",
+      "garmin.com",
       "motorola.com"
+    ],
+    "uptolike.com": [
+      "live4fun.ru"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
     ],
     "usa.gov": [
-      "transportation.gov"
+      "transportation.gov",
+      "dhs.gov",
+      "usembassy.gov",
+      "osha.gov"
     ],
     "useproof.com": [
       "iconosquare.com"
@@ -7468,8 +7672,8 @@
     "usergram.info": [
       "ocn.ne.jp"
     ],
-    "uservoice.com": [
-      "scoop.it"
+    "userreport.com": [
+      "scotsman.com"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -7478,88 +7682,120 @@
       "radikal.ru"
     ],
     "utarget.ru": [
-      "radikal.ru"
+      "radikal.ru",
+      "diary.ru"
     ],
     "uuidksinc.net": [
-      "radikal.ru"
+      "radikal.ru",
+      "diary.ru"
     ],
-    "v-biz.com.ua": [
-      "novostimira.com"
+    "v12group.com": [
+      "tinyurl.com",
+      "shopko.com"
     ],
     "vanityfair.com": [
       "wired.com",
+      "newyorker.com",
       "vogue.com",
       "pitchfork.com"
     ],
     "veinteractive.com": [
       "prweb.com",
+      "logitech.com",
       "wnd.com"
     ],
     "velaro.com": [
-      "lg.com"
+      "lg.com",
+      "eff.org"
+    ],
+    "velemh.com": [
+      "liveuamap.com"
+    ],
+    "verticalhealth.net": [
+      "psychcentral.com"
+    ],
+    "veruta.com": [
+      "shopko.com"
     ],
     "viafoura.co": [
       "cbc.ca",
-      "nj.com",
-      "irishtimes.com"
-    ],
-    "viafoura.com": [
-      "irishtimes.com"
+      "columbia.edu",
+      "nj.com"
     ],
     "viafoura.net": [
       "cbc.ca"
     ],
     "videoamp.com": [
-      "alternet.org"
+      "hpe.com"
+    ],
+    "videohub.tv": [
+      "liveuamap.com",
+      "wsj.com",
+      "uci.edu"
     ],
     "vidible.tv": [
       "aol.com",
-      "autoblog.com"
+      "nydailynews.com",
+      "autoblog.com",
+      "huffingtonpost.com"
     ],
     "viglink.com": [
+      "zdnet.com",
+      "softonic.com",
+      "techrepublic.com",
       "cnet.com",
       "thedailybeast.com",
-      "softonic.com",
-      "dailycaller.com"
+      "xda-developers.com"
     ],
     "vilynx.com": [
       "nbcnews.com",
       "olympic.org",
-      "today.com",
-      "cbs.com"
+      "tmz.com"
     ],
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "wufoo.com"
+      "livestream.com",
+      "wufoo.com",
+      "heroku.com",
+      "emarketer.com",
+      "oclc.org"
     ],
     "vindicosuite.com": [
       "myspace.com",
-      "time.com",
       "fortune.com",
-      "ew.com",
-      "travelandleisure.com"
+      "people.com",
+      "time.com",
+      "marthastewart.com",
+      "zappos.com"
     ],
     "virgilio.it": [
       "libero.it"
     ],
-    "visitor-track.com": [
-      "redcross.org"
+    "visualstudio.com": [
+      "microsoft.com"
+    ],
+    "vizury.com": [
+      "dreamstime.com"
     ],
     "vk.com": [
-      "yandex.ru",
       "rt.com",
-      "ria.ru"
+      "templatemonster.com",
+      "ria.ru",
+      "yandex.ru"
     ],
     "vmmpxl.com": [
       "networksolutions.com"
     ],
     "vogue.com": [
       "wired.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "volvelle.tech": [
-      "colourlovers.com"
+      "prweb.com",
+      "logitech.com"
     ],
     "voxmedia.com": [
       "theverge.com",
@@ -7568,22 +7804,31 @@
       "sbnation.com",
       "polygon.com"
     ],
+    "vtracy.de": [
+      "bloomberg.com"
+    ],
     "w55c.net": [
-      "hp.com",
-      "businessinsider.com",
+      "hpe.com",
+      "ebay.com",
+      "sourceforge.net",
       "pbs.org"
     ],
     "wallst.com": [
       "reuters.com"
     ],
+    "waptime.cn": [
+      "tianqi.com"
+    ],
+    "warnerbros.com": [
+      "tmz.com"
+    ],
     "wbtrk.net": [
+      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
     "wcfbc.net": [
-      "repubblica.it",
-      "bild.de",
-      "goethe.de"
+      "bild.de"
     ],
     "weather.com": [
       "wunderground.com"
@@ -7594,8 +7839,9 @@
     ],
     "weborama.fr": [
       "lemonde.fr",
-      "lefigaro.fr",
-      "rbc.ru"
+      "rbc.ru",
+      "lexpress.fr",
+      "leparisien.fr"
     ],
     "webpush.jp": [
       "asahi.com"
@@ -7608,18 +7854,18 @@
       "freewebs.com"
     ],
     "webspectator.com": [
-      "goal.com"
+      "goal.com",
+      "guinnessworldrecords.com"
     ],
     "webtrekk.net": [
       "springer.com",
-      "repubblica.it",
-      "goethe.de"
+      "localiser-ip.com",
+      "welt.de"
     ],
     "webtrendslive.com": [
+      "nature.com",
       "abc.net.au",
       "oup.com",
-      "ethz.ch",
-      "www.nhs.uk",
       "dhl.com"
     ],
     "weibo.com": [
@@ -7637,24 +7883,34 @@
     "wikimedia.org": [
       "wikipedia.org",
       "wiktionary.org",
-      "wikisource.org",
       "mediawiki.org",
+      "wikisource.org",
       "wikibooks.org"
     ],
     "wired.com": [
+      "newyorker.com",
+      "vanityfair.com",
       "vogue.com",
       "pitchfork.com"
+    ],
+    "wise.space": [
+      "purevolume.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
+      "canada.com",
       "globalnews.ca",
       "bostonherald.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
     ],
+    "wishpond.net": [
+      "discovermagazine.com"
+    ],
     "wistia.com": [
+      "zendesk.com",
       "typeform.com",
       "photoshelter.com"
     ],
@@ -7665,15 +7921,19 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "upwork.com"
+      "upwork.com",
+      "zappos.com",
+      "redbubble.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "vogue.com",
+      "newyorker.com",
+      "vanityfair.com",
       "pitchfork.com"
     ],
     "wnyc.org": [
-      "newyorker.com"
+      "newyorker.com",
+      "qq.com"
     ],
     "wolfram.com": [
       "wolframalpha.com"
@@ -7682,41 +7942,50 @@
       "tinypic.com"
     ],
     "woopic.com": [
-      "orange.fr"
+      "orange.fr",
+      "2345.com"
     ],
     "wordpress.com": [
       "time.com",
-      "fortune.com",
-      "akismet.com",
+      "prnewswire.com",
       "cbslocal.com",
+      "fortune.com",
       "nypost.com",
+      "akismet.com",
       "news.com.au",
-      "variety.com",
       "metro.co.uk",
-      "people.com",
-      "woocommerce.com"
-    ],
-    "workandmoney.com": [
-      "nbcsports.com"
+      "variety.com"
     ],
     "wrating.com": [
+      "163.com",
       "jrj.com.cn",
       "weather.com.cn"
     ],
-    "wsj.net": [
-      "wsj.com",
+    "wsj.com": [
       "marketwatch.com"
     ],
+    "wsj.net": [
+      "marketwatch.com",
+      "sfgate.com",
+      "wsj.com"
+    ],
     "wsod.com": [
-      "yahoo.com",
+      "seekingalpha.com",
       "zerohedge.com"
     ],
     "wt-eu02.net": [
-      "libero.it",
-      "virgilio.it"
+      "virgilio.it",
+      "libero.it"
     ],
-    "xe19io.com": [
-      "nme.com"
+    "wurfl.io": [
+      "dw.com",
+      "bartleby.com"
+    ],
+    "wywyuserservice.com": [
+      "vmware.com"
+    ],
+    "xad.com": [
+      "vt.edu"
     ],
     "xg4ken.com": [
       "bluehost.com",
@@ -7727,27 +7996,30 @@
     ],
     "xiti.com": [
       "lemonde.fr",
+      "unblog.fr",
+      "uefa.com",
       "skyrock.com",
-      "faz.net",
       "leparisien.fr"
     ],
     "xlisting.jp": [
-      "goo.ne.jp",
-      "ocn.ne.jp"
+      "rakuten.co.jp",
+      "biglobe.ne.jp",
+      "goo.ne.jp"
     ],
     "xplosion.de": [
+      "t-online.de",
       "spiegel.de",
-      "sueddeutsche.de",
-      "zeit.de"
+      "faz.net"
     ],
     "xs4all.net": [
       "xs4all.nl"
     ],
-    "xtgreat.com": [
-      "qq.com"
+    "xxxlutz.de": [
+      "t-online.de"
     ],
     "yadro.ru": [
       "vk.com",
+      "novostimira.com",
       "mail.ru",
       "rt.com",
       "ok.ru",
@@ -7755,72 +8027,106 @@
     ],
     "yahoo.co.jp": [
       "dropbox.com",
-      "economist.com",
       "exblog.jp",
-      "ocn.ne.jp"
+      "rakuten.co.jp",
+      "economist.com",
+      "biglobe.ne.jp"
     ],
     "yahoo.com": [
+      "amazon.com",
       "vimeo.com",
-      "tumblr.com",
       "flickr.com",
-      "fool.com",
-      "eset.com"
+      "sourceforge.net",
+      "theverge.com",
+      "xda-developers.com"
+    ],
+    "yahoosmallbusiness.com": [
+      "yahoo.com"
     ],
     "yandex.ru": [
-      "opera.com",
       "livejournal.com",
+      "opera.com",
+      "stanford.edu",
       "ning.com",
       "rt.com",
-      "liveinternet.ru",
-      "sputniknews.com",
-      "radikal.ru"
+      "fourseasons.com",
+      "radikal.ru",
+      "yandex.com",
+      "kharkov.ua",
+      "rambler.ru"
+    ],
+    "yandex.ua": [
+      "kharkov.ua",
+      "kh.ua"
     ],
     "yastatic.net": [
-      "sputniknews.com",
-      "ria.ru",
-      "yandex.ru"
+      "qip.ru",
+      "tass.ru",
+      "radikal.ru",
+      "yandex.com"
+    ],
+    "yieldify.com": [
+      "logitech.com"
     ],
     "yieldlab.net": [
-      "t-online.de",
-      "springer.com",
       "spiegel.de",
-      "heise.de"
+      "heise.de",
+      "faz.net",
+      "statista.com"
     ],
     "yieldoptimizer.com": [
-      "groupon.com"
+      "ihg.com",
+      "hyatt.com",
+      "philly.com"
     ],
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
       "nytimes.com",
-      "qualtrics.com"
+      "dropbox.com",
+      "aol.com",
+      "qualtrics.com",
+      "eset.com"
     ],
     "yldbt.com": [
-      "usatoday.com",
-      "pcworld.com",
-      "computerworld.com",
-      "biography.com"
+      "wired.com",
+      "arstechnica.com",
+      "newyorker.com",
+      "pcworld.com"
+    ],
+    "ymetrica1.com": [
+      "kharkov.ua",
+      "kh.ua",
+      "ucoz.ru"
+    ],
+    "yoox.it": [
+      "net-a-porter.com"
     ],
     "yotpo.com": [
       "gopro.com"
     ],
     "youtube-nocookie.com": [
+      "epa.gov",
       "moodle.org",
       "popsci.com",
       "uscourts.gov"
     ],
     "youtube.com": [
+      "vimeo.com",
       "google.com",
-      "mozilla.org",
+      "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
-      "boutell.com",
-      "uh.edu",
-      "dezeen.com",
-      "honeywell.com"
+      "redhat.com",
+      "skyrock.com",
+      "caltech.edu",
+      "dailykos.com",
+      "honeywell.com",
+      "amazon.com"
     ],
     "youvisit.com": [
       "osu.edu",
+      "oregonstate.edu",
       "fsu.edu"
     ],
     "ypcdn.com": [
@@ -7829,50 +8135,68 @@
     "yudu.co.nz": [
       "nzherald.co.nz"
     ],
-    "zassets.com": [
-      "zappos.com"
-    ],
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
       "ign.com",
-      "speedtest.net",
       "everydayhealth.com"
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com"
+      "thehindu.com",
+      "infoplease.com"
     ],
     "zemanta.com": [
-      "paypal.com",
-      "usatoday.com",
-      "mirror.co.uk",
+      "independent.co.uk",
+      "thehill.com",
       "farfetch.com",
-      "colourlovers.com"
+      "paypal.com",
+      "lemonde.fr",
+      "infoplease.com"
+    ],
+    "zendesk.com": [
+      "jugem.jp",
+      "in.gov",
+      "hobbyking.com"
     ],
     "zergnet.com": [
       "imdb.com",
-      "marketwatch.com",
-      "weather.com",
-      "tmz.com"
+      "pcmag.com",
+      "rollingstone.com",
+      "marketwatch.com"
+    ],
+    "zhaopin.cn": [
+      "zhaopin.com"
+    ],
+    "zhiziyun.com": [
+      "ctrip.com"
     ],
     "zidtech.com": [
       "coindesk.com"
     ],
     "ziffdavis.com": [
+      "ign.com",
       "extremetech.com"
     ],
+    "zoho.com": [
+      "zoho.in"
+    ],
+    "zohopublic.com": [
+      "zoho.com"
+    ],
     "zoomph.com": [
+      "udel.edu",
+      "biglobe.ne.jp",
       "uga.edu"
+    ],
+    "zopim.com": [
+      "lulu.com"
     ],
     "zprk.io": [
       "news.com.au",
       "theaustralian.com.au",
       "heraldsun.com.au"
-    ],
-    "zynbit.com": [
-      "parallels.com"
     ]
   },
-  "version": "2018.9.19"
+  "version": "2018.8.22"
 }

--- a/results.json
+++ b/results.json
@@ -3,7 +3,13 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535574366154,
+      "nextUpdateTime": 1538180650544,
+      "userAction": ""
+    },
+    "112-tzm-766.mktoresp.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538394933849,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -18,49 +24,79 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "126.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "140cc.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "194-vvc-221.mktoresp.com": {
+    "15gifts.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535940577860,
-      "userAction": ""
-    },
-    "1dmp.io": {
-      "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "20798148p.rfihub.com": {
+    "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535651482302,
+      "nextUpdateTime": 1538483514256,
+      "userAction": ""
+    },
+    "247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "254a.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535556135314,
+      "nextUpdateTime": 1538368660302,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695702688,
-      "userAction": ""
-    },
-    "2ecd5.v.fwmrm.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535927532754,
+      "nextUpdateTime": 1538256664930,
       "userAction": ""
     },
     "2o7.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "33across.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "360yield.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "3gl.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -72,160 +108,220 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "4139589.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538385347766,
+      "userAction": ""
+    },
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535895120778,
+      "nextUpdateTime": 1538095276395,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535610484977,
-      "userAction": ""
-    },
-    "4303900.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535857837364,
-      "userAction": ""
-    },
-    "4351288.fls.doubleclick.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535596840473,
+      "nextUpdateTime": 1538443166948,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535803262487,
+      "nextUpdateTime": 1538206007436,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560640124,
+      "nextUpdateTime": 1538083902504,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535564507606,
+      "nextUpdateTime": 1538456849026,
       "userAction": ""
     },
-    "516-dgm-318.mktoresp.com": {
+    "50bang.org": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535612912168,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535672353106,
+      "nextUpdateTime": 1538323409082,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535922487903,
+      "nextUpdateTime": 1538531334136,
       "userAction": ""
     },
-    "5779616.fls.doubleclick.net": {
+    "58.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "58cdn.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "5p4rk13.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "6126321.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535748710087,
+      "nextUpdateTime": 1538145560460,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535720157703,
+      "nextUpdateTime": 1538338401506,
       "userAction": ""
     },
-    "6954342.fls.doubleclick.net": {
+    "6sc.co": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535922263721,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535558701365,
+      "nextUpdateTime": 1538334719410,
+      "userAction": ""
+    },
+    "8136595.fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538150124402,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535705793636,
+      "nextUpdateTime": 1538132491651,
       "userAction": ""
     },
-    "8758559.fls.doubleclick.net": {
+    "8329645.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535729644705,
+      "nextUpdateTime": 1538200870446,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535817179790,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538500225994,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535695345166,
+      "nextUpdateTime": 1538059890436,
+      "userAction": ""
+    },
+    "a.quora.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538122796132,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535690460813,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538294298158,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535515726416,
+      "nextUpdateTime": 1538194589363,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535681555823,
+      "nextUpdateTime": 1538427938823,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535644294827,
+      "nextUpdateTime": 1538404954879,
+      "userAction": ""
+    },
+    "a6264210458.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538338901088,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535738145329,
+      "nextUpdateTime": 1538508807697,
+      "userAction": ""
+    },
+    "a8298190319.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538384086156,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535467395021,
+      "nextUpdateTime": 1538142584062,
+      "userAction": ""
+    },
+    "aamsitecertifier.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598814522,
+      "nextUpdateTime": 1538049200350,
       "userAction": ""
     },
-    "aax.amazon-adsystem.com": {
+    "aaxads.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535901789257,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "abmr.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "acast.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "accessatlanta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -234,16 +330,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "accounts.us1.gigya.com": {
+    "accounts.pinterest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535736262835,
+      "nextUpdateTime": 1538249417948,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535895412521,
+      "nextUpdateTime": 1538062628696,
       "userAction": ""
     },
     "acpm.fr": {
@@ -252,51 +348,105 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "action.media6degrees.com": {
+    "acquia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535510347212,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535451360532,
+      "nextUpdateTime": 1538535925079,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535546516924,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538355264350,
       "userAction": ""
     },
-    "ad-score.com": {
+    "acuityplatform.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "acxiomapac.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-stir.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad-survey.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ad.adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538277008771,
+      "userAction": ""
+    },
     "ad.doubleclick.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535755342766,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538242542788,
       "userAction": ""
     },
-    "ad.mail.ru": {
+    "ad.wsod.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535793253863,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538425057023,
       "userAction": ""
     },
-    "ad.yieldlab.net": {
+    "adapf.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535951806065,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adc-srv.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adclear.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "addthis.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adentifi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -306,9 +456,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adhigh.net": {
+    "adfox.ru": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adhigh.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adingo.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adition.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adjust-net.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -318,15 +492,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adlmerge.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535497530432,
-      "userAction": ""
-    },
     "adm.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "admiral.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538420953790,
+      "userAction": ""
+    },
+    "admission.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -336,10 +516,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ado.pro-market.net": {
+    "adobe.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535748637442,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adotmob.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adriver.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adroll.com": {
@@ -348,46 +546,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "adrta.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ads.investingchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538447339353,
+      "userAction": ""
+    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535458586592,
+      "nextUpdateTime": 1538496601089,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535871108745,
+      "nextUpdateTime": 1538445794602,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535471847357,
-      "userAction": ""
-    },
-    "ads.twitter.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535837937648,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538373205501,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535522038868,
+      "nextUpdateTime": 1538418132951,
+      "userAction": ""
+    },
+    "adsafety.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adscale.de": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535535646707,
+      "nextUpdateTime": 1538488159302,
+      "userAction": ""
+    },
+    "adserver.intentiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538557381542,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535549205489,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538153556785,
       "userAction": ""
     },
     "adsnative.com": {
@@ -396,13 +618,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsniper.ru": {
+    "adsrvr.org": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adsrvr.org": {
+    "adswizz.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -414,7 +636,7 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "adtags.pro": {
+    "adtng.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -428,8 +650,26 @@
     },
     "adx.com.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535858535725,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "adzerk.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aetnd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "afkp.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "agkn.com": {
@@ -438,16 +678,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aidata.io": {
+    "akamaihd.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "akamaized.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "albacross.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alibaba.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "aimfar.solution.weborama.fr": {
+    "alicdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535679293961,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "alipay.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aliyun.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "allure.com": {
@@ -462,40 +732,124 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazon.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "amazon.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "amazoncustomerservice.d2.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "amazonwebservices.d2.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538516307010,
+      "userAction": ""
+    },
+    "amazonwebservicesinc.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538414598582,
+      "userAction": ""
+    },
+    "ameba.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535852651670,
+      "nextUpdateTime": 1538212864175,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535756031250,
+      "nextUpdateTime": 1538500466583,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535739670165,
+      "nextUpdateTime": 1538293517643,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535489431737,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538328395538,
       "userAction": ""
     },
-    "analytics.twitter.com": {
+    "ancestry.ca": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535497570934,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.mx": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ancestry.se": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "and.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "answcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -504,64 +858,70 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "aol.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "ap.lijit.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535545407977,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538225149247,
+      "userAction": ""
+    },
+    "apester.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535734725089,
-      "userAction": ""
-    },
-    "api-iam.intercom.io": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535646885704,
-      "userAction": ""
-    },
-    "api-v3.tinypass.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535496392864,
+      "nextUpdateTime": 1538364760079,
       "userAction": ""
     },
     "api.adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535610556073,
+      "nextUpdateTime": 1538168277917,
       "userAction": ""
     },
-    "api.bounceexchange.com": {
+    "api.adsymptotic.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538545671107,
+      "userAction": ""
+    },
+    "api.circularhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535667795032,
+      "nextUpdateTime": 1538545915720,
+      "userAction": ""
+    },
+    "api.company-target.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538204919804,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535799853232,
-      "userAction": ""
-    },
-    "api.nanigans.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535573272097,
+      "nextUpdateTime": 1538343500501,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535526188562,
+      "nextUpdateTime": 1538328923918,
       "userAction": ""
     },
-    "api.viglink.com": {
+    "api.sabavision.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535837253495,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538058807775,
       "userAction": ""
     },
     "apis.google.com": {
@@ -570,10 +930,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "apn.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535705741301,
+      "nextUpdateTime": 1538267380235,
+      "userAction": ""
+    },
+    "app.vssps.visualstudio.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538349547779,
+      "userAction": ""
+    },
+    "apple.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "aps.hearstnp.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538071048301,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -582,10 +966,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "arcpublishing.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "art19.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535778737155,
+      "nextUpdateTime": 1538321865785,
+      "userAction": ""
+    },
+    "as.casalemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538094506065,
+      "userAction": ""
+    },
+    "assets-gulfnews.sportz.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538268936081,
+      "userAction": ""
+    },
+    "assets.adobedtm.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538518662620,
+      "userAction": ""
+    },
+    "assets.pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538397145272,
+      "userAction": ""
+    },
+    "atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atemda.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ati-host.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "atlasobscura-travel.t.domdex.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538333342983,
+      "userAction": ""
+    },
+    "att.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -594,52 +1044,106 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "au.audience.newscgp.com": {
+    "au.tags.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535493275684,
+      "nextUpdateTime": 1538525497075,
       "userAction": ""
     },
-    "au.pixel.newscgp.com": {
+    "audtd.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535533997563,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "auth.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "autopilothq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535486459205,
+      "nextUpdateTime": 1538297140111,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535826163427,
+      "nextUpdateTime": 1538294619765,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538132077041,
+      "userAction": ""
+    },
+    "baidu.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535850919219,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bam-x.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535503086090,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538443530778,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535857829768,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538247008130,
       "userAction": ""
     },
-    "beacon.krxd.net": {
+    "baur.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbbpromos.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bbc.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bdimg.share.baidu.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535588620683,
+      "nextUpdateTime": 1538404525556,
+      "userAction": ""
+    },
+    "beemray.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bfmio.com": {
@@ -650,20 +1154,38 @@
     },
     "bh.contextweb.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535918584905,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538421717180,
+      "userAction": ""
+    },
+    "bid.contextweb.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538470282368,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535462855319,
+      "nextUpdateTime": 1538243655658,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535847717423,
+      "nextUpdateTime": 1538449269932,
+      "userAction": ""
+    },
+    "biddingx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bidr.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -681,6 +1203,60 @@
     "bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bizrate.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "block.lp1block.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538176389447,
+      "userAction": ""
+    },
+    "bluecava.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluemix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bluetoad.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bnidx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bobo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -702,16 +1278,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "boston.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bostonglobemedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "boxinc.sc.omtrdc.net": {
+    "brandcdn.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535788486927,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "brides.com": {
@@ -720,76 +1308,112 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "bs.serving-sys.com": {
+    "brightcove.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535882683488,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "btlr.sharethrough.com": {
+    "brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535742566208,
+      "nextUpdateTime": 1538238980390,
+      "userAction": ""
+    },
+    "bshare.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "bshare.optimix.asia": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538143370691,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535714537026,
+      "nextUpdateTime": 1538135297080,
+      "userAction": ""
+    },
+    "btttag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c-ctrip.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535499348118,
+      "nextUpdateTime": 1538456439921,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535593788843,
-      "userAction": ""
-    },
-    "c.datpix.net": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535929878835,
+      "nextUpdateTime": 1538109343951,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535843909307,
+      "nextUpdateTime": 1538317787251,
       "userAction": ""
     },
-    "c.liadm.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535745741276,
-      "userAction": ""
-    },
-    "c.statcounter.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535633412069,
-      "userAction": ""
-    },
-    "c1.adform.net": {
+    "c.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535883830729,
+      "nextUpdateTime": 1538549605036,
+      "userAction": ""
+    },
+    "c.pub.network": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538231054008,
+      "userAction": ""
+    },
+    "c1.neweggimages.com": {
+      "dnt": true,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538193299183,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694406005,
+      "nextUpdateTime": 1538552135048,
       "userAction": ""
     },
-    "cache.vindicosuite.com": {
+    "c212.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535646678212,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "c3tag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cadreon.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -798,22 +1422,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "canwestglobal.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535936828607,
-      "userAction": ""
-    },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585773243,
+      "nextUpdateTime": 1538149772927,
+      "userAction": ""
+    },
+    "carambo.la": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -822,76 +1440,136 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cbsi.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cbsistatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ccgateway.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535478492051,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538505275561,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535678194329,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538183210921,
+      "userAction": ""
+    },
+    "cdn.blueconic.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538409772024,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535878784206,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538464924771,
       "userAction": ""
     },
-    "cdn.inquisitr.com": {
+    "cdn.districtm.io": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535620914588,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538502123391,
       "userAction": ""
     },
-    "cdn.justuno.com": {
+    "cdn.dynamicyield.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535489425202,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538054972489,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535640903944,
+      "nextUpdateTime": 1538056897091,
       "userAction": ""
     },
     "cdn.native.ai": {
       "dnt": true,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1529084908284,
+      "nextUpdateTime": 1538112716764,
       "userAction": ""
     },
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535916357377,
+      "nextUpdateTime": 1538491657369,
+      "userAction": ""
+    },
+    "cdn.selectablemedia.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538325259903,
+      "userAction": ""
+    },
+    "cdn.siftscience.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538255124011,
+      "userAction": ""
+    },
+    "cdn.static.zdbb.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538423691203,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535647079432,
+      "nextUpdateTime": 1538052152256,
       "userAction": ""
     },
-    "cdn.tt.omtrdc.net": {
+    "cdn.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535754928056,
+      "nextUpdateTime": 1538350048168,
+      "userAction": ""
+    },
+    "cdn.tynt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538121563634,
+      "userAction": ""
+    },
+    "cdn.viglink.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538552819503,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598133851,
+      "nextUpdateTime": 1538331283935,
       "userAction": ""
     },
-    "cdns.gigya.com": {
+    "cdnwidget.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535604636517,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cern.ch": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -903,7 +1581,61 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535912957647,
+      "nextUpdateTime": 1538056961121,
+      "userAction": ""
+    },
+    "chei.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "chinaso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "choozle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "circularhub.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "civicscience.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ck.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538079083152,
+      "userAction": ""
+    },
+    "ckies.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538290612775,
+      "userAction": ""
+    },
+    "clickability.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "clicktripz.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -918,16 +1650,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "clmbtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cloudflare.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535545995328,
+      "nextUpdateTime": 1538084946321,
+      "userAction": ""
+    },
+    "cms.tanx.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538314445492,
+      "userAction": ""
+    },
+    "cnet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535500216943,
+      "nextUpdateTime": 1538212613316,
+      "userAction": ""
+    },
+    "cnn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -936,10 +1698,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "cobaltgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "cohesionapps.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535914813920,
+      "nextUpdateTime": 1538216572940,
+      "userAction": ""
+    },
+    "collector-963.tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538075212407,
+      "userAction": ""
+    },
+    "collector-pxbecn7fqx.perimeterx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538178626553,
+      "userAction": ""
+    },
+    "collegenet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "commander1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "company-target.com": {
@@ -948,13 +1746,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "condenast.demdex.net": {
+    "condenastdigital.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535961983554,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "condenastdigital.com": {
+    "config.lrcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538224661599,
+      "userAction": ""
+    },
+    "connatix.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -963,7 +1767,13 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535610657582,
+      "nextUpdateTime": 1538044706175,
+      "userAction": ""
+    },
+    "connexity.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "consensu.org": {
@@ -972,22 +1782,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "consent-pref.trustarc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538382256612,
+      "userAction": ""
+    },
     "consent.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "consumer.krxd.net": {
+    "content.ad": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535644691945,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535769653005,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538123517033,
       "userAction": ""
     },
     "contextweb.com": {
@@ -996,15 +1812,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "convertro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "core.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538077162990,
+      "userAction": ""
+    },
+    "cornell.edu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "counter.yadro.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535484862572,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538315953930,
+      "userAction": ""
+    },
+    "coxmediagroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creativecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1014,16 +1860,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "crsspxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "cse.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "cstatic.weborama.fr": {
+    "cssrvsync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ct.pinterest.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535817088302,
+      "nextUpdateTime": 1538334484197,
+      "userAction": ""
+    },
+    "cx.atdmt.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538107799509,
       "userAction": ""
     },
     "cxense.com": {
@@ -1032,100 +1896,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "d.adroll.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535892452597,
-      "userAction": ""
-    },
-    "d.agkn.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535636389666,
-      "userAction": ""
-    },
     "d.company-target.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535557003597,
-      "userAction": ""
-    },
-    "d.df-srv.de": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535942927369,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538510704544,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535683801735,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538196982209,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535759989893,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538294378750,
       "userAction": ""
     },
-    "d3kkw-y716t.ads.tremorhub.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535711046845,
-      "userAction": ""
-    },
-    "data.ad-score.com": {
+    "d1af033869koo7.cloudfront.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535770730900,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "data.dianomi.com": {
+    "d1rv23qj5kas56.cloudfront.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535762735169,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datacloud-us-east-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535857345882,
-      "userAction": ""
-    },
-    "datacloud.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535789663952,
-      "userAction": ""
-    },
-    "datamind.ru": {
+    "d41.co": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "datpix.net": {
+    "da-ads.com": {
       "dnt": false,
       "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dailymail.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "data.dianomi.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538215972432,
+      "userAction": ""
+    },
+    "datamind.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dc-storm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535873979413,
+      "nextUpdateTime": 1538143536390,
       "userAction": ""
     },
-    "de.ioam.de": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535466422250,
-      "userAction": ""
-    },
-    "deepintent.com": {
+    "decajo.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1538503040838,
+      "userAction": ""
+    },
+    "delivery.zidtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538180066266,
       "userAction": ""
     },
     "demdex.net": {
@@ -1146,7 +1998,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "df-srv.de": {
+    "dezeenjobs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "di-dtaectolog-us-prod-1.appspot.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1158,15 +2016,9 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "digitaladsystems.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "digitaltarget.ru": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1176,16 +2028,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dis.us.criteo.com": {
+    "display.apester.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535670042661,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538272371129,
       "userAction": ""
     },
-    "display.bfmio.com": {
+    "disqus.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535720094693,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "distiltag.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "districtm.io": {
@@ -1194,33 +2052,33 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dm-us.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535589581939,
-      "userAction": ""
-    },
-    "dm.hybrid.ai": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535689555708,
-      "userAction": ""
-    },
-    "dmg.digitaltarget.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535852281239,
-      "userAction": ""
-    },
     "dmx.districtm.io": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535595988233,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538077158657,
+      "userAction": ""
+    },
+    "dmxleo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "docs.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "dol.gov": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "domdex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1230,16 +2088,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "dotsub.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "doublepimpssl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535607931755,
+      "nextUpdateTime": 1538127110451,
+      "userAction": ""
+    },
+    "dpmsrv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1248,10 +2124,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "dsum-sec.casalemedia.com": {
+    "dt.admission.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538348346597,
+      "userAction": ""
+    },
+    "dt.cobaltgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538296791629,
+      "userAction": ""
+    },
+    "dx.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535938750810,
+      "nextUpdateTime": 1538412044496,
+      "userAction": ""
+    },
+    "dynad.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1260,10 +2154,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eb2.3lift.com": {
+    "dyntrk.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535826511101,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "e-2072.adzerk.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538325723457,
+      "userAction": ""
+    },
+    "ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1272,10 +2178,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ebis.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "echo.intergient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538161191136,
+      "userAction": ""
+    },
+    "eclick.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538421526521,
+      "userAction": ""
+    },
+    "edge-cdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535881020504,
+      "nextUpdateTime": 1538303768684,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1290,34 +2220,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "elsevier.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "elsevierhealth.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "embed.sendtonews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538199320008,
+      "userAction": ""
+    },
+    "emlgrid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "engage.commander1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538534356108,
+      "userAction": ""
+    },
+    "engine.addroplet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538467483460,
+      "userAction": ""
+    },
     "epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eset.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535674741536,
-      "userAction": ""
-    },
-    "eu.track.digitaladsystems.com": {
+    "equalstyle.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535871670836,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "eus.rubiconproject.com": {
+    "eset.marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538430898085,
+      "userAction": ""
+    },
+    "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535957567699,
+      "nextUpdateTime": 1538356537340,
+      "userAction": ""
+    },
+    "estat.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535542299351,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538345920195,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1329,7 +2301,37 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535624124109,
+      "nextUpdateTime": 1538552306958,
+      "userAction": ""
+    },
+    "evise.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "evvnt-api.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538336434789,
+      "userAction": ""
+    },
+    "ewscripps.hb.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538506157825,
+      "userAction": ""
+    },
+    "exactag.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "excite.co.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "exelator.com": {
@@ -1340,8 +2342,8 @@
     },
     "experience.tinypass.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535598114496,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538171166728,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1350,9 +2352,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "eyereturn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ezoic.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1362,22 +2376,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "faggrim.com": {
+    "fastapi.net": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535612994323,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535463240415,
+      "nextUpdateTime": 1538455076395,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535905176352,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538277861999,
+      "userAction": ""
+    },
+    "fdlstatic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "feathr.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1392,22 +2418,88 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "filepicker.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "firstimpression.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flashtalking.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flickr.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "flipboard.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fls.doubleclick.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538174863248,
+      "userAction": ""
+    },
     "flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "foxnet.demdex.net": {
+    "force.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535788047904,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "freestar-d.openx.net": {
+    "foresee.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "forms.hubspot.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535744855557,
+      "nextUpdateTime": 1538138908700,
+      "userAction": ""
+    },
+    "formstack.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "fout.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "foxycart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "freshdesk.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1422,64 +2514,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "g.cn.miaozhen.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535694446011,
-      "userAction": ""
-    },
-    "g2.gumgum.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535682782409,
-      "userAction": ""
-    },
-    "gads.pubmatic.com": {
+    "g.3gl.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535628645321,
+      "nextUpdateTime": 1538410704427,
       "userAction": ""
     },
-    "gakogedifoda.ru": {
+    "g.ign.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535579017912,
-      "userAction": ""
-    },
-    "gannett-d.openx.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535532577705,
-      "userAction": ""
-    },
-    "gannett.demdex.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535738506516,
-      "userAction": ""
-    },
-    "gannett.hb.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535558203644,
+      "nextUpdateTime": 1538148864057,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535485170416,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538395883518,
+      "userAction": ""
+    },
+    "gemius.pl": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "geocoding.internetbrands.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538536149847,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535563893270,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538218189361,
       "userAction": ""
     },
-    "geosync.solution.weborama.fr": {
+    "getclicky.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535926178244,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gigya.com": {
@@ -1488,7 +2562,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "giphy.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "glamour.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "globalwebindex.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1506,6 +2592,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "goo.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "google.com": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1515,7 +2607,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598569331,
+      "nextUpdateTime": 1538370377555,
       "userAction": ""
     },
     "gq.com": {
@@ -1527,7 +2619,19 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711236388,
+      "nextUpdateTime": 1538295132337,
+      "userAction": ""
+    },
+    "gridsumdissector.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "groupondata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1536,22 +2640,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "gscounters.us1.gigya.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535770595777,
-      "userAction": ""
-    },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535871768873,
+      "nextUpdateTime": 1538471693280,
       "userAction": ""
     },
-    "gum.criteo.com": {
+    "gtags.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535579223748,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1566,76 +2664,214 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "gwiqcdn.globalwebindex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538329164909,
+      "userAction": ""
+    },
+    "hatena.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hatena.ne.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585198153,
+      "nextUpdateTime": 1538228306081,
       "userAction": ""
     },
-    "hgbn.rocks": {
+    "healte.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535863358694,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "hgbnr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535728786580,
-      "userAction": ""
-    },
-    "hpr.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535497040220,
-      "userAction": ""
-    },
-    "hybrid.ai": {
+    "hearstnp.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "i.liadm.com": {
+    "help.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535739388610,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "i.po.st": {
+    "hitslink.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hive.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hm.baidu.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538383968817,
+      "userAction": ""
+    },
+    "horyzon-media.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hubspot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535735230278,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ib.3lift.com": {
+    "hugedata.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "huihui.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hwcdn.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "hybrid.ai": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "i.connatix.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535579900537,
+      "nextUpdateTime": 1538433396017,
+      "userAction": ""
+    },
+    "i.tianqi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538262509948,
+      "userAction": ""
+    },
+    "iasds01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535879292043,
+      "nextUpdateTime": 1538182536434,
       "userAction": ""
     },
-    "ic.tynt.com": {
+    "ibclick.stream": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ibillboard.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535551583447,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ibt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535730891780,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538459618997,
       "userAction": ""
     },
-    "images.taboola.com": {
+    "id5-sync.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "idealmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "identityssl.newscdn.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538550188509,
+      "userAction": ""
+    },
+    "idsync.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535479823214,
+      "nextUpdateTime": 1538467403404,
+      "userAction": ""
+    },
+    "ign.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "igodigital.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "iheart.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "im-apps.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "img.purch.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "imgur.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "impact-ad.jp": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1644,13 +2880,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "infinityid.condenastdigital.com": {
+    "in.getclicky.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535542941029,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538484989853,
       "userAction": ""
     },
-    "inquisitr.com": {
+    "infinity-tracking.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "infinityid.condenastdigital.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538163838777,
+      "userAction": ""
+    },
+    "inq.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1659,19 +2907,43 @@
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535576906508,
+      "nextUpdateTime": 1538092323704,
       "userAction": ""
     },
     "insightexpressai.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "instagram.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535916640573,
+      "nextUpdateTime": 1538177453642,
+      "userAction": ""
+    },
+    "instinctiveads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "intentmedia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "intercom.io": {
@@ -1680,10 +2952,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "intergient.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "internetbrands.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535958592894,
+      "nextUpdateTime": 1538398006786,
+      "userAction": ""
+    },
+    "investingchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "invoc.us": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "ioam.de": {
@@ -1692,7 +2988,19 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "iperceptions.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ipredictive.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1700,26 +3008,62 @@
     },
     "ips-invite.iperceptions.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535746109483,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538513891249,
+      "userAction": ""
+    },
+    "irs01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "italiaonline01.wt-eu02.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538262101357,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538426276329,
+      "userAction": ""
+    },
+    "janrainsso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jquery.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "jrs5.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535501210103,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "js.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535523156086,
+      "nextUpdateTime": 1538190129186,
       "userAction": ""
     },
     "js.matheranalytics.com": {
       "dnt": true,
       "heuristicAction": "",
-      "nextUpdateTime": 1529472262192,
+      "nextUpdateTime": 1538279062905,
       "userAction": ""
     },
     "jsrdn.com": {
@@ -1730,7 +3074,13 @@
     },
     "justuno.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kameleoon.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1776,6 +3126,24 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "kinja.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "kiwiirc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "knet.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
@@ -1788,7 +3156,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "leadintel.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538046595757,
+      "userAction": ""
+    },
+    "leadlander.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "legocdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "liadm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "licasd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ligadx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -1806,15 +3204,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "link-page.info": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "linksynergy.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "listrakbi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "live.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "live.sekindo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538332400243,
+      "userAction": ""
+    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "livejournal.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1824,52 +3258,94 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "load77.exelator.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535541362768,
-      "userAction": ""
-    },
-    "loadm.exelator.com": {
+    "load.sumo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535938747750,
+      "nextUpdateTime": 1538194386904,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535583123603,
+      "nextUpdateTime": 1538189709302,
       "userAction": ""
     },
-    "log.outbrain.com": {
+    "loc.gov": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535577619677,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "login-ds.dotomi.com": {
+    "lockerdome.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538146284566,
+      "userAction": ""
+    },
+    "log.mmstat.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535487720538,
+      "nextUpdateTime": 1538355091856,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535602940193,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538513913912,
       "userAction": ""
     },
-    "logp2.xiti.com": {
+    "logly.co.jp": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535800795531,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "m.addthis.com": {
+    "logs11.xiti.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538403190845,
+      "userAction": ""
+    },
+    "logs1136.xiti.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538251719016,
+      "userAction": ""
+    },
+    "lp1block.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lptag.liveperson.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538533427768,
+      "userAction": ""
+    },
+    "lqm.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lrcontent.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "lytics.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535797170899,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "m6r.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mail.ru": {
@@ -1896,46 +3372,46 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "marinsm.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketlinc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "marketo.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "match.adsrvr.org": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538200836706,
+      "userAction": ""
+    },
+    "match.prod.bidr.io": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538339384874,
+      "userAction": ""
+    },
+    "matheranalytics.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535858739536,
-      "userAction": ""
-    },
-    "match.deepintent.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535770736865,
-      "userAction": ""
-    },
-    "match.sharethrough.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535669407198,
-      "userAction": ""
-    },
-    "matching.adtags.pro": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535931796491,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
-      "userAction": ""
-    },
-    "mc.webvisor.org": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535584418815,
-      "userAction": ""
-    },
-    "mc.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535737532185,
       "userAction": ""
     },
     "media.net": {
@@ -1953,16 +3429,76 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535842898170,
+      "nextUpdateTime": 1538439252020,
       "userAction": ""
     },
-    "mediarithmics.com": {
+    "mediaforge.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mediaplex.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediarithmics.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediav.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mediawallahscript.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "medtargetsystem.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mendeley.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "messenger.live.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "metadsp.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mfadsrvr.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mg2connext.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mgid.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -1974,10 +3510,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "microad.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoft.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "microsoftonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "mid.rkdms.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535865290211,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538247909740,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1989,7 +3543,61 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535541848986,
+      "nextUpdateTime": 1538394141616,
+      "userAction": ""
+    },
+    "mmstat.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "monetate.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mookie1.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mouseflow.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mpnrs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mrpfd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msgapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "msn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "mssl.fwmrm.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538487358307,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -2004,6 +3612,12 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "mtrx.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538555902065,
+      "userAction": ""
+    },
     "mts0.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -2016,7 +3630,13 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "multiview.com": {
+    "mtvnservices.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "musthird.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2034,16 +3654,118 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nanigans.com": {
+    "mynativeplatform.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myspacecdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "myvisualiq.net": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nanigans.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nasdaq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nationalgeographic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "native.ai": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560186363,
+      "nextUpdateTime": 1538320667027,
+      "userAction": ""
+    },
+    "nativendo.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "naver.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nbcu.demdex.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538463121539,
+      "userAction": ""
+    },
+    "nbcuni.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "neweggimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "news.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newscdn.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newscgp.com": {
@@ -2055,7 +3777,25 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535858989061,
+      "nextUpdateTime": 1538421923960,
+      "userAction": ""
+    },
+    "newsinc.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsvine.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "newsweekgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newyorker.com": {
@@ -2064,16 +3804,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-a.intercom.io": {
+    "nexac.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535683012789,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "nexus-websocket-b.intercom.io": {
+    "ngpvan.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535610146889,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nokia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "nr-data.net": {
@@ -2082,10 +3828,82 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "oclc.112.2o7.net": {
+    "nuggad.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535501585551,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "nxtck.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "o0bg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oasc10.247realmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538268830533,
+      "userAction": ""
+    },
+    "office.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "office365.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ojrq.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ok.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olark.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "olympicchannel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omkt.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnidsp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "omnitagjs.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -2094,9 +3912,39 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "onecount.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "oneroof.co.nz": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onetag.mgr.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538426323108,
+      "userAction": ""
+    },
     "onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "online-metrix.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "onsugar.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2106,21 +3954,75 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ooyala.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openhub.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "openstat.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "openx.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "optimize-stats.voxmedia.com": {
+    "ophan.theguardian.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535895613989,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538371630281,
+      "userAction": ""
+    },
+    "opinionstage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optaim.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "optimix.asia": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ora.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "orangeads.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "otto.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2130,52 +4032,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ovh.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "p.adsymptotic.com": {
+    "owox.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535495458906,
-      "userAction": ""
-    },
-    "p.cpx.to": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535875406126,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535716223948,
+      "nextUpdateTime": 1538076392629,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535555301108,
-      "userAction": ""
-    },
-    "p.skimresources.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535760257854,
-      "userAction": ""
-    },
-    "p.yieldlab.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535783323409,
+      "nextUpdateTime": 1538159006482,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535815373509,
+      "nextUpdateTime": 1538075969602,
       "userAction": ""
     },
     "pardot.com": {
@@ -2190,27 +4080,81 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pbid.pro-market.net": {
+    "paypal.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535792440906,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "paypalobjects.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "payroll.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538125278981,
+      "userAction": ""
+    },
+    "performgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "perimeterx.net": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535797919846,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "phonograph2.voxmedia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538254593492,
+      "userAction": ""
+    },
+    "photobucket.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535582597532,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538374590064,
+      "userAction": ""
+    },
+    "pic.fastapi.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538255329652,
       "userAction": ""
     },
     "picasaweb.google.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pingan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pinterest.com": {
+      "dnt": false,
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2222,74 +4166,62 @@
     },
     "pitchfork.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535876656131,
-      "userAction": ""
-    },
-    "pixel-geo.prfct.co": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535836609372,
-      "userAction": ""
-    },
-    "pixel.advertising.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535531983715,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535859784800,
+      "nextUpdateTime": 1538133315883,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535459106331,
-      "userAction": ""
-    },
-    "pixel.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535748451871,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538133366404,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535639969032,
-      "userAction": ""
-    },
-    "pixel.rubiconproject.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535645678163,
+      "nextUpdateTime": 1538522752196,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535635208019,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538192671832,
       "userAction": ""
     },
-    "pixel.tapad.com": {
+    "pixel.zprk.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535610784392,
+      "nextUpdateTime": 1538486726252,
       "userAction": ""
     },
-    "pixeltrack.eyeviewads.com": {
+    "piximedia.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535897272070,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "placelocal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "platform-api.sharethis.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538056097475,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535554574334,
+      "nextUpdateTime": 1538260131857,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2304,16 +4236,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "player.performgroup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538214631976,
+      "userAction": ""
+    },
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535916234173,
+      "nextUpdateTime": 1538362569129,
+      "userAction": ""
+    },
+    "players.brightcove.net": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535930452354,
+      "nextUpdateTime": 1538319307097,
+      "userAction": ""
+    },
+    "plista.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2324,14 +4274,26 @@
     },
     "po.st": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535756748496,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538187345852,
       "userAction": ""
     },
-    "postmedia.demdex.net": {
+    "popsugar-assets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pos.baidu.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535710477120,
+      "nextUpdateTime": 1538418412765,
+      "userAction": ""
+    },
+    "postmedia.us.janrainsso.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538174985349,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2340,15 +4302,21 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "pr-bh.ybp.yahoo.com": {
+    "powerlinks.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535914334685,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pressboard.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "prfct.co": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2358,28 +4326,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "profile.ssp.rambler.ru": {
+    "prod-cmg-proxy-connext.azurewebsites.net": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535789715456,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "prod-mng-proxy-connext.azurewebsites.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "provenpixel.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "providesupport.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "proximus.be": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "proximus.demdex.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535737146713,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538427583405,
       "userAction": ""
     },
-    "ps.eyeota.net": {
+    "pub.network": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535788753573,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535909696148,
+      "nextUpdateTime": 1538202489440,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2388,63 +4380,93 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "purch-match.dotomi.com": {
+    "pubmine.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535842539658,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "px.adhigh.net": {
+    "pulpix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535700996611,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "purechat.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "pushanert.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535686118831,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538206203762,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535707783947,
+      "nextUpdateTime": 1538460515426,
       "userAction": ""
     },
-    "px.owneriq.net": {
+    "pxi.pub": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535951971781,
-      "userAction": ""
-    },
-    "px.steelhousemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535887595495,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535801751541,
+      "nextUpdateTime": 1538200483882,
       "userAction": ""
     },
-    "q.quora.com": {
+    "qq.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535857711077,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "qcx.quantserve.com": {
+    "qualtrics.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535884922283,
+      "nextUpdateTime": 1538327762416,
       "userAction": ""
     },
     "quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooks.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "quickbooksonline.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2454,10 +4476,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "r.skimresources.com": {
+    "r.turn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535790117318,
+      "nextUpdateTime": 1538114432566,
+      "userAction": ""
+    },
+    "rackcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "radiotime.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2466,51 +4500,105 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "rand.d1.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535724135338,
-      "userAction": ""
-    },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535943279957,
+      "nextUpdateTime": 1538208445032,
       "userAction": ""
     },
-    "reachms.bfmio.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535922335285,
-      "userAction": ""
-    },
-    "registercom.sc.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535959894691,
-      "userAction": ""
-    },
-    "registercom.tt.omtrdc.net": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535760317951,
-      "userAction": ""
-    },
-    "relap.io": {
+    "reachmax.cn": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535610652702,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "republer-sync.rutarget.ru": {
+    "reddit.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535696676261,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "redlink.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "regmedia.co.uk": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "republer.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reson8.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "responsetap.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "reutersmedia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "revjet.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rezync.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rhombusads.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ria.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richmetrics.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "richrelevance.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2526,34 +4614,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "rnengage.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rockyou.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535789708558,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538294745257,
+      "userAction": ""
+    },
+    "rqtrk.eu": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535574550900,
+      "nextUpdateTime": 1538129421105,
       "userAction": ""
     },
-    "rtb.districtm.io": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535878658398,
-      "userAction": ""
-    },
-    "rtb.mfadsrvr.com": {
+    "rss.art19.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535602308341,
+      "nextUpdateTime": 1538167421505,
+      "userAction": ""
+    },
+    "rtb.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538352452690,
+      "userAction": ""
+    },
+    "rtk.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rtve.d1.sc.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538202862196,
+      "userAction": ""
+    },
+    "ru4.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "rudy.adsnative.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538152569067,
       "userAction": ""
     },
     "rutarget.ru": {
@@ -2571,79 +4701,85 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535635426495,
+      "nextUpdateTime": 1538369224004,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535692857867,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538062771361,
       "userAction": ""
     },
-    "s.cpx.to": {
+    "s.clickability.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535952869756,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538478226394,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535783451713,
-      "userAction": ""
-    },
-    "s.jsrdn.com": {
-      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535498662982,
+      "nextUpdateTime": 1538149322611,
       "userAction": ""
     },
-    "s.po.st": {
+    "s.nexac.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535560094637,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538515216122,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535860326137,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538221863124,
+      "userAction": ""
+    },
+    "s.spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538331458176,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535818293290,
-      "userAction": ""
-    },
-    "s.yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535622978260,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538183045497,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535617312775,
+      "nextUpdateTime": 1538180635780,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535723340329,
+      "nextUpdateTime": 1538367243127,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535575485409,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538366295174,
+      "userAction": ""
+    },
+    "s3-us-west-2.amazonaws.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535580484432,
+      "nextUpdateTime": 1538491765915,
+      "userAction": ""
+    },
+    "sabavision.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2652,7 +4788,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sape.ru": {
+    "salesloft.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "salesmanago.pl": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "samba.tv": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "samplicio.us": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -2661,25 +4815,55 @@
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535700559367,
+      "nextUpdateTime": 1538303818062,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535725608507,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538237980451,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535951923078,
+      "nextUpdateTime": 1538343887161,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535728176589,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538475610945,
+      "userAction": ""
+    },
+    "scholarlyiq.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirect.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciencedirectassets.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sciverse.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scopus.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2688,10 +4872,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "scribblelive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "scribd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535742086735,
+      "nextUpdateTime": 1538500013668,
+      "userAction": ""
+    },
+    "scripps.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538350668625,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -2700,10 +4902,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sdc-qczj.pingan.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538490872689,
+      "userAction": ""
+    },
+    "sdp-campaign.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "search.spotxchange.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535520532074,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538422064517,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2715,90 +4929,108 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535677815299,
-      "userAction": ""
-    },
-    "secfld.vmmpxl.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535800058823,
+      "nextUpdateTime": 1538546208242,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465743467,
+      "nextUpdateTime": 1538187034130,
+      "userAction": ""
+    },
+    "secure-dcr.imrworldwide.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538214152681,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535785998221,
+      "nextUpdateTime": 1538262143169,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535914435468,
+      "nextUpdateTime": 1538371117898,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535948798377,
+      "nextUpdateTime": 1538367254534,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535877945891,
+      "nextUpdateTime": 1538062926851,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535597555162,
-      "userAction": ""
-    },
-    "secure.insightexpressai.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535791667902,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538515294111,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535639340469,
+      "nextUpdateTime": 1538269531819,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535564812848,
+      "nextUpdateTime": 1538219869201,
+      "userAction": ""
+    },
+    "secure.statcounter.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538453154129,
+      "userAction": ""
+    },
+    "securedvisit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535650108629,
+      "nextUpdateTime": 1538165745281,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535464387320,
+      "nextUpdateTime": 1538077819865,
       "userAction": ""
     },
-    "segments.company-target.com": {
+    "sekindo.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535734903711,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "selectablemedia.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "self.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sendtonews.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2808,9 +5040,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "servedby.flashtalking.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538477934971,
+      "userAction": ""
+    },
+    "serverbid.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "session.timecommerce.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538421892505,
+      "userAction": ""
+    },
+    "sessioncam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sf14g.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "shareaholic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2826,15 +5094,51 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "simage2.pubmatic.com": {
+    "shop.pe": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "siftscience.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535730445037,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "simpli.fi": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sina.com.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "siteimproveanalytics.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sitelock.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2850,7 +5154,31 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "sjs.bizographics.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538374333246,
+      "userAction": ""
+    },
     "skimresources.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sky.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "slashdotmedia.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smartadserver.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -2859,13 +5187,79 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535498866607,
+      "nextUpdateTime": 1538354484555,
+      "userAction": ""
+    },
+    "smashing-delivery.herokuapp.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smi2.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "smithsonian.museum": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "so.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "socdm.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sociomantic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "soflopxl.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sogou.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sohu.irs01.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538175757124,
+      "userAction": ""
+    },
+    "sokrati.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "solarwinds.tt.omtrdc.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538167927210,
       "userAction": ""
     },
     "sonobi.com": {
@@ -2882,13 +5276,49 @@
     },
     "sp.analytics.yahoo.com": {
       "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538339922746,
+      "userAction": ""
+    },
+    "sphereup.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spiceworks.com": {
+      "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535555922438,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "sportz.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spot.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spots.im": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "spoutable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -2898,64 +5328,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-27-09.config.parsely.com": {
+    "springernature.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606591829,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-27-09.pixel.parsely.com": {
+    "springserve.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535775011168,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-27-10.config.parsely.com": {
+    "springserve.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "srv-2018-09-26-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535756373485,
+      "nextUpdateTime": 1538359586941,
+      "userAction": ""
+    },
+    "srv-2018-09-26-09.pixel.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538445425688,
+      "userAction": ""
+    },
+    "srv-2018-09-26-10.config.parsely.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538474458903,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535710872574,
+      "nextUpdateTime": 1538460842793,
       "userAction": ""
     },
-    "ssl.siteimprove.com": {
+    "srx.com.sg": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535689859677,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535454314181,
-      "userAction": ""
-    },
-    "sso.caltat.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535761951625,
-      "userAction": ""
-    },
-    "ssp-rtb.sape.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535766755060,
-      "userAction": ""
-    },
-    "ssum-sec.casalemedia.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535761311673,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538250386292,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535924056645,
+      "nextUpdateTime": 1538512151649,
+      "userAction": ""
+    },
+    "stackadapt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stanza-d.openx.net": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538238071781,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2964,34 +5406,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "static.addtoany.com": {
-      "dnt": true,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1529315030088,
-      "userAction": ""
-    },
-    "static.datamind.ru": {
+    "static.bshare.cn": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535845316114,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538407047481,
       "userAction": ""
     },
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535639204569,
+      "nextUpdateTime": 1538438476744,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535592093085,
-      "userAction": ""
-    },
-    "static.quantcast.mgr.consensu.org": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535861273600,
+      "nextUpdateTime": 1538374661983,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -3003,18 +5433,42 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535757740002,
+      "nextUpdateTime": 1538123969054,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535490242831,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538383272999,
       "userAction": ""
     },
     "steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stg-sp.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "stickyadstv.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storage.googleapis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "storygize.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3027,7 +5481,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535936086555,
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -3036,94 +5490,76 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "suning.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "supplyframe.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "survata.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535543303368,
+      "nextUpdateTime": 1538409550581,
+      "userAction": ""
+    },
+    "surveymonkey.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "svcs.ebay.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538325865068,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535878443632,
+      "nextUpdateTime": 1538045911214,
       "userAction": ""
     },
-    "sync-tm.everesttech.net": {
+    "switchadhub.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535753717531,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "sync.1dmp.io": {
+    "symantec.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535866711433,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535474216425,
+      "nextUpdateTime": 1538159389370,
       "userAction": ""
     },
-    "sync.adkernel.com": {
+    "sync.graph.bluecava.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535616105586,
-      "userAction": ""
-    },
-    "sync.bfmio.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535792114790,
-      "userAction": ""
-    },
-    "sync.datamind.ru": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535757781917,
-      "userAction": ""
-    },
-    "sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535699991298,
-      "userAction": ""
-    },
-    "sync.mathtag.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535939733228,
-      "userAction": ""
-    },
-    "sync.multiview.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535809892152,
+      "nextUpdateTime": 1538100879756,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465474316,
-      "userAction": ""
-    },
-    "sync.teads.tv": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535793050783,
-      "userAction": ""
-    },
-    "sync.upravel.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535705180457,
-      "userAction": ""
-    },
-    "sync3.adsniper.ru": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535672244398,
+      "nextUpdateTime": 1538407016386,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -3138,10 +5574,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tacdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535701257955,
+      "nextUpdateTime": 1538489495789,
+      "userAction": ""
+    },
+    "tag.mtrcs.samba.tv": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538210741846,
+      "userAction": ""
+    },
+    "tag.placelocal.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538095525832,
+      "userAction": ""
+    },
+    "tags.news.com.au": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538246007029,
+      "userAction": ""
+    },
+    "tailtarget.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -3150,10 +5616,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tamgrt.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tanx.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "taobao.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535764731289,
+      "nextUpdateTime": 1538492207266,
       "userAction": ""
     },
     "tapad.com": {
@@ -3162,7 +5646,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "teads.tv": {
+    "tapestry.tapad.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538235641061,
+      "userAction": ""
+    },
+    "target.smi2.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538428202945,
+      "userAction": ""
+    },
+    "tawk.to": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "taylorandfrancis.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
@@ -3171,6 +5673,12 @@
     "tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "techweb.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3192,16 +5700,64 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "theglobeandmail.ca": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "theguardian.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "thrtle.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535484616929,
+      "nextUpdateTime": 1538123580474,
       "userAction": ""
     },
-    "timeuk.demdex.net": {
+    "tianqi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tidaltv.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tidelinedata.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "timecommerce.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "timeinc.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535590619071,
+      "nextUpdateTime": 1538072239103,
+      "userAction": ""
+    },
+    "timewarnercable.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tinypass.com": {
@@ -3210,10 +5766,28 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "tiqcdn.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tlx.3lift.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535694887621,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538202979002,
+      "userAction": ""
+    },
+    "tm-awx.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tmall.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3222,28 +5796,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "top100.rambler.ru": {
+    "toutapp.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535891887087,
-      "userAction": ""
-    },
-    "tr.outbrain.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535664544534,
-      "userAction": ""
-    },
-    "tr.snapchat.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535741046224,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535674993267,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538111155067,
+      "userAction": ""
+    },
+    "track.hubspot.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538073273875,
+      "userAction": ""
+    },
+    "tradelab.fr": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trafficjunky.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3252,13 +5832,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "trc.taboola.com": {
+    "travelsmarter.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535758029438,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "tremorhub.com": {
+    "travelzoo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trb.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "treasuredata.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3270,15 +5862,99 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "trends.revcontent.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538067659492,
+      "userAction": ""
+    },
+    "tribalfusion.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tribl.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "triblive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tripadvisor.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trk.connatix.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538056981974,
+      "userAction": ""
+    },
+    "tronc.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trumba.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "truoptik.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustarc.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "trustpilot.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535677023679,
+      "nextUpdateTime": 1538407164376,
       "userAction": ""
     },
     "turn.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tutorialize.me": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tvsquared.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "twimg.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3294,51 +5970,177 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "u.openx.net": {
+    "uc.se": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535606318085,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "upravel.com": {
+    "uciservice.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "uconnect.tealiumiq.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538086919054,
+      "userAction": ""
+    },
+    "ucoz.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "udmserve.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538457145899,
+      "userAction": ""
+    },
+    "ugdturner.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unagi-eu.amazon.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1538257470790,
+      "userAction": ""
+    },
+    "undertone.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unicc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unity.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "unrulymedia.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "ups.xplosion.de": {
+    "upsellit.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535897007154,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "urbandictionary.store": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535697248099,
+      "nextUpdateTime": 1538339771741,
       "userAction": ""
     },
-    "us4.siteimprove.com": {
+    "usa.gov": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535464144110,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "us5.siteimprove.com": {
+    "usergram.info": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535699974981,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
-    "va.v.liveperson.net": {
+    "uservoice.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535466934945,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ustream.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "utarget.pro": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538409562664,
+      "userAction": ""
+    },
+    "utarget.ru": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538382140645,
+      "userAction": ""
+    },
+    "uuidksinc.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538344768057,
+      "userAction": ""
+    },
+    "v-biz.com.ua": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "veinteractive.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "velaro.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vendorlist.consensu.org": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538143303737,
+      "userAction": ""
+    },
+    "viafoura.co": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "viafoura.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3348,7 +6150,25 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "videohub.tv": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vidible.tv": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "viglink.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vilynx.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3366,34 +6186,34 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "visitor-service-us-east-1.tealiumiq.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535733808496,
-      "userAction": ""
-    },
-    "vmmpxl.com": {
+    "virgilio.it": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "vmss.boldchat.com": {
+    "visualstudio.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535601239497,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "vk.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535498479361,
+      "nextUpdateTime": 1538418284544,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3405,28 +6225,100 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535636170372,
+      "nextUpdateTime": 1538264689912,
       "userAction": ""
     },
-    "wam-yahoo.solution.weborama.fr": {
+    "w55c.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535796722948,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wal.co": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wal.wolfram.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538507015629,
+      "userAction": ""
+    },
+    "wallst.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535855791363,
+      "nextUpdateTime": 1538404424123,
       "userAction": ""
     },
-    "web.hb.ad.cpe.dotomi.com": {
+    "wbtrk.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535923593881,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wcfbc.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "weather.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webmd.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "weborama.fr": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webpush.jp": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webservices.webspectator.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538420584854,
+      "userAction": ""
+    },
+    "websimages.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webspectator.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "webtrekk.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3438,21 +6330,45 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "webvisor.org": {
+    "weibo.com": {
       "dnt": false,
       "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "widgets.outbrain.com": {
+    "welt.de": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "whistleout.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "widget.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535670143608,
+      "nextUpdateTime": 1538468993614,
+      "userAction": ""
+    },
+    "wikia-services.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wikimedia.org": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "wired.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3462,34 +6378,130 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wishpond.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wistia.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wix.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wkxppshj-qx.global.ssl.fastly.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "wms-na.amazon-adsystem.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538561096392,
+      "userAction": ""
+    },
+    "wnyc.org": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wolfram.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woobi.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "woopic.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wordpress.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wrating.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ws.sessioncam.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538093572796,
+      "userAction": ""
+    },
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535840821698,
+      "nextUpdateTime": 1538495803032,
       "userAction": ""
     },
-    "ww.steelhousemedia.com": {
+    "wsj.net": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535813179789,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wsod.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "wt-eu02.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535765401859,
+      "nextUpdateTime": 1538510946198,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535489564334,
+      "nextUpdateTime": 1538087322367,
+      "userAction": ""
+    },
+    "www.beian.gov.cn": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538073326388,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3501,25 +6513,31 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535595495451,
+      "nextUpdateTime": 1538446372221,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535586988900,
+      "nextUpdateTime": 1538493655891,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535930397006,
+      "nextUpdateTime": 1538123690650,
+      "userAction": ""
+    },
+    "www.dezeenjobs.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538195644309,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535509674049,
+      "nextUpdateTime": 1538168960663,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -3531,13 +6549,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535739774613,
+      "nextUpdateTime": 1538116834884,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535560046524,
+      "nextUpdateTime": 1538157891279,
       "userAction": ""
     },
     "www.google.com": {
@@ -3549,97 +6567,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535756312610,
+      "nextUpdateTime": 1538093232146,
+      "userAction": ""
+    },
+    "www.iolam.it": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538193507860,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535879616929,
-      "userAction": ""
-    },
-    "www.linkedin.com": {
-      "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535800042571,
+      "nextUpdateTime": 1538121151651,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535800256120,
+      "nextUpdateTime": 1538278936690,
       "userAction": ""
     },
-    "www.pitchfork.com": {
+    "www.proximus.be": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535749245992,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538480707132,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535728733870,
+      "nextUpdateTime": 1538341119642,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535468979631,
+      "nextUpdateTime": 1538191505978,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535776576351,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538165597564,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535467088529,
+      "nextUpdateTime": 1538511390052,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535653525547,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538445532831,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535873679290,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1538290704894,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535804763970,
-      "userAction": ""
-    },
-    "www.yandex.ru": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535541713916,
+      "nextUpdateTime": 1538343058111,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535773470002,
+      "nextUpdateTime": 1538182668807,
+      "userAction": ""
+    },
+    "wwwimages.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535481472835,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538550095595,
       "userAction": ""
     },
-    "x01.aidata.io": {
+    "xad.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535957511051,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "xiti.com": {
@@ -3648,15 +6666,27 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "xpl.theadex.com": {
+    "xlisting.jp": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535914264605,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xs4all.net": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "xsdownload.adobe.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -3667,6 +6697,12 @@
       "userAction": ""
     },
     "yadro.ru": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yahoo.co.jp": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
@@ -3684,13 +6720,37 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yastatic.net": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1538421382254,
+      "userAction": ""
+    },
     "yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "yieldoptimizer.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "yimg.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "yldbt.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "youtube-nocookie.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
       "nextUpdateTime": 0,
@@ -3702,22 +6762,40 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "youvisit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ypcdn.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535571133437,
+      "nextUpdateTime": 1538367319132,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535964428669,
+      "heuristicAction": "",
+      "nextUpdateTime": 1538234483947,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535649235764,
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zedo.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3725,55 +6803,62 @@
       "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
+    },
+    "zergnet.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zidtech.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "ziffdavis.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zoomph.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zprk.io": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "zynbit.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
     }
   },
   "snitch_map": {
     "126.net": [
-      "163.com",
-      "fotki.com"
-    ],
-    "127.net": [
       "163.com"
     ],
     "15gifts.com": [
       "thetimes.co.uk"
     ],
-    "1dmp.io": [
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
-    ],
-    "1rx.io": [
-      "tinyurl.com",
-      "lycos.com",
-      "photobucket.com"
-    ],
-    "23video.com": [
-      "bandcamp.com"
-    ],
-    "247-inc.net": [
-      "marriott.com"
-    ],
     "247realmedia.com": [
       "bmj.com",
-      "aappublications.org",
       "americanbar.org"
     ],
     "254a.com": [
-      "thehindu.com"
-    ],
-    "2mdnsys.com": [
-      "liveuamap.com"
+      "tinyurl.com"
     ],
     "2o7.net": [
-      "mysql.com",
       "cdc.gov",
-      "theatlantic.com",
       "prnewswire.com",
-      "fastcompany.com",
-      "earthlink.net",
-      "qz.com",
-      "oclc.org"
+      "fastcompany.com"
     ],
     "33across.com": [
       "accuweather.com"
@@ -3781,29 +6866,19 @@
     "360.cn": [
       "so.com"
     ],
-    "360buyimg.com": [
-      "jd.com"
-    ],
     "360yield.com": [
       "springer.com",
-      "home.pl",
-      "allafrica.com"
+      "home.pl"
     ],
     "3gl.net": [
-      "istockphoto.com",
-      "gettyimages.com",
-      "economist.com"
+      "go.com",
+      "economist.com",
+      "sfgate.com"
     ],
     "3lift.com": [
-      "nature.com",
-      "springer.com",
-      "theverge.com",
+      "msn.com",
       "usatoday.com",
-      "infoworld.com",
-      "focus.de"
-    ],
-    "4dsply.com": [
-      "wnd.com"
+      "springer.com"
     ],
     "50bang.org": [
       "2345.com"
@@ -3815,50 +6890,33 @@
       "ganji.com"
     ],
     "5p4rk13.com": [
-      "sfu.ca",
-      "cdbaby.com"
+      "sfu.ca"
     ],
     "6sc.co": [
-      "zendesk.com",
-      "gotomeeting.com",
-      "rsa.com"
-    ],
-    "7eer.net": [
-      "lenovo.com",
-      "adidas.com"
-    ],
-    "7grid.com": [
-      "mihanblog.com"
+      "brightcove.com"
     ],
     "aamsitecertifier.com": [
-      "smh.com.au",
       "theglobeandmail.com",
-      "bostonglobe.com"
+      "bostonglobe.com",
+      "post-gazette.com"
     ],
     "aaxads.com": [
-      "forbes.com"
+      "forbes.com",
+      "speedtest.net"
     ],
     "abmr.net": [
-      "paypal.com",
-      "nike.com"
+      "nike.com",
+      "freetype.org"
+    ],
+    "acast.com": [
+      "cam.ac.uk"
     ],
     "accessatlanta.com": [
       "ajc.com"
     ],
-    "accuweather.com": [
-      "miamiherald.com",
-      "sacbee.com",
-      "kansascity.com"
-    ],
-    "acint.net": [
-      "tomsk.ru",
-      "radikal.ru",
-      "diary.ru"
-    ],
     "acpm.fr": [
       "lemonde.fr",
       "lefigaro.fr",
-      "liberation.fr",
       "leparisien.fr"
     ],
     "acquia.com": [
@@ -3866,35 +6924,25 @@
       "osu.edu",
       "amd.com"
     ],
-    "actionnetwork.org": [
-      "dailykos.com"
-    ],
     "acuityplatform.com": [
       "medscape.com"
     ],
     "acxiomapac.com": [
-      "bartleby.com"
+      "businessinsider.com",
+      "npr.org"
     ],
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-score.com": [
-      "infoplease.com"
-    ],
     "ad-stir.com": [
       "sakura.ne.jp",
-      "biglobe.ne.jp",
       "seesaa.jp"
     ],
     "ad-survey.com": [
-      "huanqiu.com",
-      "yesky.com"
+      "huanqiu.com"
     ],
     "adapf.com": [
       "sakura.ne.jp"
-    ],
-    "adaraanalytics.com": [
-      "hyatt.com"
     ],
     "adc-srv.net": [
       "autodesk.com"
@@ -3903,58 +6951,36 @@
       "t-online.de"
     ],
     "addroplet.com": [
-      "wallinside.com",
-      "wnd.com",
+      "tinypic.com",
       "washingtonexaminer.com"
     ],
     "addthis.com": [
       "nasa.gov",
-      "jimdo.com",
-      "yahoo.com",
       "who.int",
-      "unenvironment.org",
-      "gulfnews.com"
-    ],
-    "addtoany.com": [
-      "irs.gov"
+      "npr.org"
     ],
     "adentifi.com": [
-      "metmuseum.org",
-      "infoplease.com"
+      "metmuseum.org"
     ],
     "adform.net": [
-      "t-online.de",
-      "bloomberg.com",
-      "springer.com",
-      "sciencemag.org",
-      "thehindu.com",
-      "helsinki.fi"
+      "forbes.com",
+      "imdb.com",
+      "t-online.de"
     ],
     "adfox.ru": [
       "livejournal.com",
       "liveinternet.ru",
-      "rambler.ru",
-      "ria.ru"
-    ],
-    "adfront.org": [
-      "joomla.org"
+      "sputniknews.com"
     ],
     "adhigh.net": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
-    ],
-    "adidas.fi": [
-      "adidas.com"
+      "rambler.ru"
     ],
     "adingo.jp": [
-      "biglobe.ne.jp"
+      "seesaa.jp"
     ],
     "adition.com": [
-      "bloomberg.com",
+      "t-online.de",
       "dailymotion.com",
-      "spiegel.de",
       "lemonde.fr"
     ],
     "adjust-net.jp": [
@@ -3962,133 +6988,83 @@
       "ocn.ne.jp"
     ],
     "adkernel.com": [
-      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "xda-developers.com",
-      "dailydot.com"
-    ],
-    "adlmerge.com": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "admaster.com.cn": [
-      "autohome.com.cn",
-      "bshare.cn"
+      "howtogeek.com"
     ],
     "admission.net": [
       "edmunds.com"
     ],
-    "admixer.net": [
-      "space.com"
-    ],
     "adnxs.com": [
-      "yahoo.com",
-      "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "thehindu.com",
-      "rfi.fr"
+      "forbes.com"
     ],
     "adobe.com": [
-      "wikipedia.org",
       "behance.net",
       "history.com",
-      "fotolia.com"
+      "nbc.com"
     ],
     "adobedtm.com": [
       "newyorker.com",
-      "bbb.org",
-      "bizjournals.com",
+      "symantec.com",
       "worldbank.org"
     ],
     "adotmob.com": [
-      "standard.co.uk",
-      "upwork.com",
-      "variety.com"
+      "variety.com",
+      "standard.co.uk"
     ],
     "adriver.ru": [
-      "ria.ru",
-      "rambler.ru",
-      "tomsk.ru",
-      "home.pl"
+      "liveinternet.ru",
+      "sputniknews.com",
+      "rambler.ru"
     ],
     "adroll.com": [
-      "stumbleupon.com",
-      "nature.com",
-      "nginx.org",
+      "photobucket.com",
       "cloudflare.com",
-      "sitepoint.com",
-      "case.edu"
+      "ning.com"
+    ],
+    "adrta.com": [
+      "seesaa.jp"
+    ],
+    "adsafety.net": [
+      "npr.org"
     ],
     "adscale.de": [
       "t-online.de",
-      "bloomberg.com",
       "springer.com",
-      "statista.com",
       "home.pl"
     ],
     "adsnative.com": [
-      "autodesk.com",
-      "thehill.com",
+      "squareup.com",
       "informationweek.com",
       "bostonherald.com"
     ],
-    "adsniper.ru": [
-      "rambler.ru",
-      "radikal.ru"
-    ],
     "adsrvr.org": [
-      "adobe.com",
-      "yahoo.com",
-      "googletagmanager.com",
       "sourceforge.net",
-      "thehindu.com",
-      "hgtv.com"
+      "nytimes.com",
+      "forbes.com"
     ],
     "adswizz.com": [
+      "variety.com",
       "iheart.com",
-      "tunein.com",
-      "variety.com"
+      "tunein.com"
     ],
     "adsymptotic.com": [
-      "tinyurl.com",
-      "etsy.com",
-      "tripadvisor.com",
-      "usatoday.com",
-      "thehindu.com",
-      "realtor.com"
+      "forbes.com",
+      "wsj.com",
+      "etsy.com"
     ],
-    "adtags.pro": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "adtdp.com": [
-      "biglobe.ne.jp"
+    "adtng.com": [
+      "pornhub.com"
     ],
     "advertising.com": [
-      "amazon.com",
-      "sourceforge.net",
-      "dropbox.com",
-      "wsj.com",
-      "home.pl",
-      "walgreens.com"
-    ],
-    "advertur.ru": [
-      "radikal.ru"
-    ],
-    "adwstats.com": [
-      "cisco.com"
+      "yahoo.com",
+      "nytimes.com",
+      "msn.com"
     ],
     "adx.com.ru": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "adx1.com": [
-      "venturebeat.com",
-      "livescience.com",
-      "space.com"
+      "rambler.ru"
     ],
     "adzerk.net": [
       "asp.net"
@@ -4096,103 +7072,88 @@
     "aetnd.com": [
       "history.com"
     ],
-    "afilio.com.br": [
-      "mcafee.com"
+    "afkp.net": [
+      "autodesk.com"
     ],
     "agkn.com": [
-      "amazon.com",
-      "t-online.de",
+      "imdb.com",
       "bloomberg.com",
-      "cnet.com",
-      "bankrate.com",
-      "gizmodo.com"
-    ],
-    "aid-ad.jp": [
-      "shinobi.jp"
-    ],
-    "aidata.io": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
-    ],
-    "aili.com": [
-      "sina.com.cn"
-    ],
-    "ajx130.online": [
-      "radikal.ru"
+      "cnet.com"
     ],
     "akamaihd.net": [
-      "voanews.com",
-      "repubblica.it",
-      "iyfubh.com",
-      "forbes.com"
+      "forbes.com",
+      "voanews.com"
     ],
     "akamaized.net": [
       "tamu.edu",
       "microsoft.com",
-      "nbc.com"
+      "xbox.com"
     ],
     "albacross.com": [
       "rebelmouse.com"
     ],
     "alibaba.com": [
-      "youku.com",
-      "taobao.com",
+      "tmall.com",
       "aliexpress.com",
-      "tmall.com"
+      "alibabacloud.com"
     ],
     "alicdn.com": [
       "sina.com.cn",
-      "alibaba.com",
       "youku.com",
-      "aliexpress.com",
-      "1688.com",
-      "2345.com"
+      "sohu.com"
     ],
     "alipay.com": [
-      "alibaba.com",
       "youku.com"
     ],
     "aliyun.com": [
-      "alibabacloud.com"
+      "alibabacloud.com",
+      "gmw.cn"
     ],
     "allure.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
-    "am15.net": [
-      "radikal.ru"
-    ],
-    "amap.com": [
-      "zhaopin.com"
-    ],
     "amazon-adsystem.com": [
-      "amazon.com",
-      "nytimes.com",
-      "reddit.com",
-      "cnn.com",
-      "mentalfloss.com",
-      "bostonherald.com"
+      "forbes.com",
+      "imdb.com",
+      "washingtonpost.com"
     ],
     "amazon.co.uk": [
       "amazon.de"
     ],
     "amazon.com": [
-      "qq.com",
       "imdb.com",
       "amazon.co.uk",
       "amazon.de",
-      "amazon.co.jp"
+      "amazon.es"
     ],
     "ameba.jp": [
       "ameblo.jp"
     ],
-    "analytics-egain.com": [
-      "virginmedia.com"
+    "ancestry.ca": [
+      "ancestry.com"
+    ],
+    "ancestry.co.uk": [
+      "ancestry.com"
+    ],
+    "ancestry.com.au": [
+      "ancestry.com"
+    ],
+    "ancestry.de": [
+      "ancestry.com"
+    ],
+    "ancestry.fr": [
+      "ancestry.com"
+    ],
+    "ancestry.it": [
+      "ancestry.com"
+    ],
+    "ancestry.mx": [
+      "ancestry.com"
+    ],
+    "ancestry.se": [
+      "ancestry.com"
     ],
     "and.co.uk": [
       "dailymail.co.uk"
@@ -4201,136 +7162,72 @@
       "answers.com"
     ],
     "answerscloud.com": [
-      "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "nintendo.com",
-      "realtor.com"
-    ],
-    "antdsp.com": [
-      "hc360.com"
+      "uscourts.gov"
     ],
     "aol.co.uk": [
       "huffingtonpost.co.uk"
     ],
-    "aol.com": [
-      "engadget.com",
-      "indiatimes.com",
-      "autoblog.com",
-      "techcrunch.com"
-    ],
-    "ap.org": [
-      "post-gazette.com"
-    ],
     "apester.com": [
-      "deadline.com",
-      "searchenginewatch.com",
       "nme.com"
     ],
     "apn.co.nz": [
       "nzherald.co.nz"
     ],
     "app.link": [
-      "foursquare.com",
-      "history.com",
-      "nbc.com",
-      "allrecipes.com",
-      "strava.com"
-    ],
-    "appdynamics.com": [
-      "nfl.com"
+      "medium.com",
+      "buzzfeed.com",
+      "foursquare.com"
     ],
     "apple.com": [
       "digitaltrends.com",
       "icloud.com",
-      "softpedia.com",
       "thinkgeek.com"
-    ],
-    "aqtracker.com": [
-      "nikkei.com"
-    ],
-    "arcgis.com": [
-      "chron.com"
     ],
     "architecturaldigest.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "arcpublishing.com": [
       "washingtonpost.com"
     ],
-    "areyouahuman.com": [
-      "reuters.com",
-      "merriam-webster.com",
-      "accuweather.com"
-    ],
-    "arrivalist.com": [
-      "philly.com"
-    ],
     "art19.com": [
       "coindesk.com"
     ],
-    "asos-media.com": [
-      "asos.com"
-    ],
     "atdmt.com": [
       "facebook.com",
-      "yahoo.com",
-      "msn.com",
-      "upwork.com"
+      "shutterfly.com",
+      "xbox.com"
     ],
     "atemda.com": [
       "springer.com",
       "home.pl"
     ],
-    "atgsvcs.com": [
-      "oracle.com",
-      "xerox.com"
-    ],
     "ati-host.net": [
+      "bbc.com",
       "straitstimes.com"
     ],
     "att.com": [
       "att.net"
     ],
     "audtd.com": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
-    ],
-    "autoimg.cn": [
-      "autohome.com.cn"
+      "rambler.ru"
     ],
     "autopilothq.com": [
-      "bitbucket.org",
-      "rfc-editor.org",
       "typeform.com"
-    ],
-    "b1img.com": [
-      "threadless.com"
     ],
     "baidu.com": [
       "sina.com.cn",
       "163.com",
-      "ifeng.com",
-      "sohu.com",
-      "2345.com"
+      "sohu.com"
     ],
     "bam-x.com": [
       "gq.com"
     ],
-    "bazaarvoice.com": [
-      "target.com",
-      "lenovo.com",
-      "motorola.com"
-    ],
-    "bbb.org": [
-      "penders.com",
-      "afternic.com",
-      "sedo.com"
+    "baur.de": [
+      "t-online.de"
     ],
     "bbbpromos.org": [
       "bbb.org"
@@ -4338,115 +7235,61 @@
     "bbc.co.uk": [
       "bbc.com"
     ],
-    "bbelements.com": [
-      "idnes.cz"
-    ],
-    "beatport.com": [
-      "tmall.com"
-    ],
     "beemray.com": [
       "telegraph.co.uk",
       "mirror.co.uk"
     ],
     "beian.gov.cn": [
       "dzwww.com",
-      "ku6.com"
-    ],
-    "benchtag2.co": [
-      "sbs.com.au"
-    ],
-    "betweendigital.com": [
-      "tomsk.ru",
-      "radikal.ru"
+      "qianlong.com"
     ],
     "bfmio.com": [
-      "symantec.com",
       "tinypic.com",
-      "venturebeat.com",
       "livescience.com",
-      "dailydot.com"
-    ],
-    "bfmtv.com": [
-      "liberation.fr",
-      "lexpress.fr"
+      "space.com"
     ],
     "biddingx.com": [
       "sina.com.cn"
     ],
     "bidr.io": [
       "adobe.com",
-      "dailymotion.com",
-      "hootsuite.com",
       "hp.com",
-      "upwork.com"
+      "dailymotion.com"
     ],
     "bidswitch.net": [
-      "yahoo.com",
-      "google.com",
-      "amazon.com",
-      "dropbox.com",
-      "thehindu.com",
-      "radikal.ru"
-    ],
-    "bigmining.com": [
-      "hatena.ne.jp"
-    ],
-    "bigmir.net": [
-      "kharkov.ua",
-      "kh.ua"
+      "forbes.com",
+      "tinyurl.com",
+      "imdb.com"
     ],
     "bing.com": [
       "vimeo.com",
       "cnn.com",
-      "weebly.com",
-      "msn.com",
-      "motorola.com",
-      "microsoft.com",
-      "pingdom.com"
-    ],
-    "bitbucket.org": [
-      "atlassian.com"
+      "weebly.com"
     ],
     "bizible.com": [
-      "eventbrite.com",
       "cloudflare.com",
-      "zendesk.com",
       "ibm.com",
-      "here.com",
-      "gitlab.com"
-    ],
-    "bizibly.com": [
-      "eventbrite.com",
-      "cloudflare.com"
+      "shutterstock.com"
     ],
     "bizographics.com": [
-      "zend.com",
-      "nginx.com",
-      "oreilly.com",
-      "jimdo.com"
+      "jimdo.com",
+      "surveymonkey.com",
+      "economist.com"
     ],
     "bizrate.com": [
+      "time.com",
       "fortune.com",
-      "people.com",
-      "ew.com",
-      "time.com"
-    ],
-    "blogos.com": [
-      "livedoor.com"
-    ],
-    "bloomberg.com": [
-      "macrumors.com"
+      "people.com"
     ],
     "bluecava.com": [
-      "history.com",
-      "biography.com"
+      "wsj.com",
+      "giphy.com",
+      "active.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
-      "theatlantic.com",
       "sfgate.com",
-      "chron.com",
-      "ajc.com"
+      "chron.com"
     ],
     "bluemix.net": [
       "ibm.com"
@@ -4455,20 +7298,20 @@
       "variety.com"
     ],
     "bnidx.com": [
-      "jigsy.com",
-      "bravenet.com"
+      "bravenet.com",
+      "jigsy.com"
+    ],
+    "bobo.com": [
+      "163.com"
     ],
     "boldchat.com": [
       "buydomains.com",
       "gotomeeting.com",
-      "cancer.org",
-      "networksolutions.com"
+      "cancer.org"
     ],
     "bonappetit.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "boston.com": [
@@ -4477,62 +7320,43 @@
     "bostonglobemedia.com": [
       "boston.com"
     ],
-    "botradar.tech": [
-      "radikal.ru"
-    ],
-    "boudja.com": [
-      "4shared.com"
-    ],
     "bounceexchange.com": [
       "cnn.com",
       "time.com",
-      "wired.com",
-      "usatoday.com",
-      "allrecipes.com",
-      "pitchfork.com"
+      "usatoday.com"
     ],
     "brandcdn.com": [
       "ncsu.edu"
     ],
     "brides.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "brightcove.com": [
-      "scholastic.com",
-      "si.com",
-      "federalreserve.gov",
+      "aarp.org",
       "theaustralian.com.au",
-      "informationweek.com",
-      "straitstimes.com"
+      "informationweek.com"
     ],
     "brightcove.net": [
-      "lefigaro.fr",
-      "politico.com",
-      "bostonglobe.com",
-      "aljazeera.com"
+      "lonelyplanet.com",
+      "thetimes.co.uk",
+      "thenational.ae"
+    ],
+    "bshare.cn": [
+      "qianlong.com"
     ],
     "bttrack.com": [
-      "yahoo.com",
-      "independent.co.uk",
-      "zendesk.com",
-      "nypost.com",
-      "dailydot.com"
+      "livescience.com",
+      "variety.com",
+      "hpe.com"
     ],
     "btttag.com": [
       "samsung.com",
-      "marriott.com",
-      "ihg.com"
-    ],
-    "bumlam.com": [
-      "rambler.ru"
+      "marriott.com"
     ],
     "c-ctrip.com": [
-      "ctrip.com",
-      "qunar.com"
+      "ctrip.com"
     ],
     "c212.net": [
       "prnewswire.com"
@@ -4543,36 +7367,18 @@
     "cadreon.com": [
       "economist.com"
     ],
-    "caltat.com": [
-      "live4fun.ru",
-      "radikal.ru"
-    ],
-    "candlewoodsuites.com": [
-      "ihg.com"
-    ],
-    "capturehighered.net": [
-      "ku.edu",
-      "unm.edu"
-    ],
     "carambo.la": [
-      "accuweather.com",
-      "salon.com"
+      "accuweather.com"
     ],
     "casalemedia.com": [
-      "amazon.com",
-      "dropbox.com",
-      "myspace.com",
+      "imdb.com",
       "washingtonpost.com",
-      "thehindu.com",
-      "pitchfork.com"
+      "bloomberg.com"
     ],
     "cbsi.com": [
-      "zdnet.com",
-      "last.fm",
-      "gamespot.com",
       "cnet.com",
       "cbsnews.com",
-      "cbssports.com"
+      "zdnet.com"
     ],
     "cbsistatic.com": [
       "cbsnews.com"
@@ -4581,72 +7387,37 @@
       "softonic.com",
       "biography.com"
     ],
-    "cdn-apple.com": [
-      "icloud.com"
-    ],
-    "cdn-hotels.com": [
-      "hotels.com"
-    ],
-    "cdn-net.com": [
-      "hotels.com",
-      "americanexpress.com"
-    ],
     "cdnwidget.com": [
       "photoshelter.com"
-    ],
-    "cedexis-test.com": [
-      "tumblr.com"
     ],
     "cern.ch": [
       "home.cern"
     ],
-    "changeagain.me": [
-      "iconosquare.com"
-    ],
-    "charitynavigator.org": [
-      "heart.org"
-    ],
     "chei.com.cn": [
       "chsi.com.cn"
     ],
-    "chicagotribune.com": [
-      "wikipedia.org"
-    ],
-    "chinajob.com": [
-      "china.org.cn"
-    ],
     "chinaso.com": [
-      "weather.com.cn"
-    ],
-    "chinavivaki.com": [
-      "bshare.cn"
+      "weather.com.cn",
+      "chinanews.com"
     ],
     "choozle.com": [
-      "denverpost.com",
-      "photobucket.com"
+      "photobucket.com",
+      "denverpost.com"
     ],
     "circularhub.com": [
       "suntimes.com",
       "tampabay.com",
-      "bostonherald.com"
+      "stltoday.com"
     ],
     "civicscience.com": [
-      "post-gazette.com",
-      "knowyourmeme.com",
-      "ebaumsworld.com"
+      "post-gazette.com"
     ],
     "ckies.net": [
       "abril.com.br"
     ],
     "clickability.com": [
-      "prnewswire.com",
       "philly.com",
       "proquest.com"
-    ],
-    "clicktale.net": [
-      "xbox.com",
-      "office.com",
-      "microsoft.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
@@ -4656,11 +7427,9 @@
       "indiatimes.com"
     ],
     "cloudflare.com": [
-      "uci.edu",
-      "nbcnews.com",
+      "redhat.com",
       "sciencemag.org",
-      "nginx.com",
-      "allaboutcookies.org"
+      "uci.edu"
     ],
     "cnet.com": [
       "zdnet.com"
@@ -4670,65 +7439,35 @@
     ],
     "cntraveler.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
-    ],
-    "cnzz.com": [
-      "zol.com.cn"
     ],
     "cobaltgroup.com": [
       "edmunds.com"
     ],
-    "coherentpath.com": [
-      "staples.com"
-    ],
     "cohesionapps.com": [
-      "americanexpress.com",
-      "admin.ch",
       "bankrate.com"
     ],
     "collegenet.com": [
-      "gmu.edu",
-      "ku.edu"
-    ],
-    "comm100.com": [
-      "hobbyking.com"
+      "gmu.edu"
     ],
     "commander1.com": [
       "ovh.com",
-      "ubisoft.com",
-      "arte.tv"
+      "ovh.co.uk",
+      "ubisoft.com"
     ],
     "company-target.com": [
       "adobe.com",
       "ibm.com",
-      "redhat.com",
-      "hp.com",
-      "upwork.com",
-      "box.com"
-    ],
-    "complex.com": [
-      "knowyourmeme.com",
-      "dailydot.com",
-      "ebaumsworld.com"
-    ],
-    "conative.de": [
-      "focus.de"
+      "hp.com"
     ],
     "condenastdigital.com": [
       "wired.com",
-      "arstechnica.com",
-      "nj.com",
       "newyorker.com",
-      "nola.com",
-      "pitchfork.com"
-    ],
-    "conductrics.com": [
-      "nginx.com"
+      "arstechnica.com"
     ],
     "connatix.com": [
+      "jpost.com",
       "alternet.org",
       "dailydot.com"
     ],
@@ -4736,114 +7475,52 @@
       "sourceforge.net"
     ],
     "consensu.org": [
-      "rollingstone.com",
-      "variety.com",
-      "adweek.com",
-      "independent.co.uk",
-      "nme.com"
+      "pcworld.com",
+      "us.org",
+      "rollingstone.com"
     ],
-    "consumable.com": [
-      "xfinity.com"
-    ],
-    "contentabc.com": [
-      "pornhub.com"
+    "content.ad": [
+      "tinypic.com"
     ],
     "contextweb.com": [
       "sourceforge.net",
-      "myspace.com",
-      "bloomberg.com",
       "forbes.com",
-      "thehindu.com",
-      "coindesk.com"
-    ],
-    "convertful.com": [
-      "lifehack.org"
+      "imdb.com"
     ],
     "convertro.com": [
-      "ibm.com",
-      "logitech.com",
       "slack.com"
-    ],
-    "convio.net": [
-      "diabetes.org"
     ],
     "cornell.edu": [
       "arxiv.org"
     ],
-    "cox.net": [
-      "cox.com"
-    ],
-    "coxbusiness.com": [
-      "cox.com"
-    ],
     "coxmediagroup.com": [
       "ajc.com"
     ],
-    "cpex.cz": [
-      "idnes.cz"
-    ],
     "cpx.to": [
-      "express.co.uk",
-      "digitaltrends.com",
-      "techradar.com",
       "independent.co.uk",
-      "allmusic.com",
-      "rfi.fr"
-    ],
-    "cquotient.com": [
-      "gopro.com"
-    ],
-    "cr-nielsen.com": [
-      "youku.com"
+      "mirror.co.uk",
+      "express.co.uk"
     ],
     "creativecdn.com": [
-      "ria.ru",
-      "udn.com"
-    ],
-    "creativecommons.org": [
-      "perl.com"
+      "ria.ru"
     ],
     "criteo.com": [
-      "tinyurl.com",
-      "washingtonpost.com",
-      "dailymail.co.uk",
       "dropbox.com",
-      "newegg.com",
-      "sedo.com"
-    ],
-    "croissed.info": [
-      "4shared.com"
-    ],
-    "crowneplaza.com": [
-      "ihg.com"
+      "forbes.com",
+      "reuters.com"
     ],
     "crsspxl.com": [
       "sourceforge.net",
-      "slashdot.org",
-      "bartleby.com"
-    ],
-    "crwdcntrl.net": [
-      "wunderground.com"
+      "slashdot.org"
     ],
     "cssrvsync.com": [
       "springer.com",
       "home.pl"
     ],
-    "ctv.ca": [
-      "ctvnews.ca"
-    ],
-    "curse.com": [
-      "wowdb.com"
-    ],
-    "custhelp.com": [
-      "oracle.com"
-    ],
     "cxense.com": [
-      "opera.com",
-      "talktalk.co.uk",
-      "gizmodo.com",
       "wsj.com",
-      "allafrica.com"
+      "opera.com",
+      "talktalk.co.uk"
     ],
     "d1af033869koo7.cloudfront.net": [
       "marriott.com"
@@ -4851,14 +7528,10 @@
     "d1rv23qj5kas56.cloudfront.net": [
       "webnode.com"
     ],
-    "d2-apps.net": [
-      "rakuten.co.jp",
-      "yahoo.co.jp"
-    ],
     "d41.co": [
+      "hp.com",
       "intel.com",
-      "hpe.com",
-      "hp.com"
+      "hpe.com"
     ],
     "da-ads.com": [
       "deviantart.com"
@@ -4866,76 +7539,30 @@
     "dailymail.co.uk": [
       "metro.co.uk"
     ],
-    "dailymotion.com": [
-      "google.com"
-    ],
     "datamind.ru": [
-      "novostimira.com",
       "rambler.ru",
-      "kharkov.ua",
-      "radikal.ru"
-    ],
-    "datasteam.io": [
-      "ama-assn.org"
-    ],
-    "datpix.net": [
-      "radikal.ru"
-    ],
-    "daum.net": [
-      "shutterstock.com",
-      "tistory.com"
-    ],
-    "daumcdn.net": [
-      "daum.net"
-    ],
-    "daumdn.com": [
-      "shutterstock.com"
+      "novostimira.com"
     ],
     "dc-storm.com": [
       "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com"
+      "alibabacloud.com",
+      "coursera.org"
     ],
-    "deep.bi": [
-      "hrw.org"
-    ],
-    "deepintent.com": [
-      "infoplease.com"
-    ],
-    "dell.com": [
-      "rsa.com"
+    "decajo.ru": [
+      "radikal.ru"
     ],
     "demdex.net": [
       "adobe.com",
       "yahoo.com",
-      "amazon.com",
-      "soundcloud.com",
-      "thehindu.com",
-      "skynet.be"
-    ],
-    "departapp.com": [
-      "liveuamap.com"
+      "soundcloud.com"
     ],
     "deployads.com": [
       "tinyurl.com",
-      "lycos.com",
       "sciencedaily.com",
       "zerohedge.com"
     ],
-    "deqwas.net": [
-      "rakuten.co.jp"
-    ],
-    "developermedia.com": [
-      "codeproject.com"
-    ],
     "dezeenjobs.com": [
       "dezeen.com"
-    ],
-    "df-srv.de": [
-      "focus.de"
-    ],
-    "dhs.gov": [
-      "fema.gov"
     ],
     "di-dtaectolog-us-prod-1.appspot.com": [
       "disney.com",
@@ -4944,58 +7571,33 @@
     "dianomi.com": [
       "businessinsider.com",
       "marketwatch.com",
-      "entrepreneur.com",
       "zerohedge.com"
     ],
-    "dictionary.com": [
-      "thesaurus.com"
-    ],
-    "digitaladsystems.com": [
-      "tomsk.ru",
-      "radikal.ru"
-    ],
     "digitaltarget.ru": [
-      "liveinternet.ru",
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
+      "rambler.ru"
     ],
     "digitru.st": [
       "britannica.com",
       "lifehacker.com",
-      "express.co.uk",
-      "gizmodo.com",
-      "bostonherald.com"
-    ],
-    "disney.com": [
-      "starwars.com"
+      "express.co.uk"
     ],
     "disqus.com": [
-      "pnas.org",
+      "rollingstone.com",
       "dyn.com",
-      "mercurynews.com",
-      "rollingstone.com"
+      "mercurynews.com"
     ],
     "distiltag.com": [
       "reuters.com",
-      "merriam-webster.com"
+      "merriam-webster.com",
+      "washingtontimes.com"
     ],
     "districtm.io": [
+      "forbes.com",
       "barnesandnoble.com",
-      "urbandictionary.com",
-      "axs.com",
-      "thehindu.com",
-      "newatlas.com"
-    ],
-    "djv99sxoqpv11.cloudfront.net": [
-      "4shared.com"
+      "timeanddate.com"
     ],
     "dmxleo.com": [
       "dailymotion.com"
-    ],
-    "dnnapi.com": [
-      "zenfolio.com",
-      "gob.es"
     ],
     "dol.gov": [
       "osha.gov"
@@ -5003,16 +7605,12 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com",
-      "slashdot.org"
+      "wsj.com"
     ],
     "dotomi.com": [
-      "tinyurl.com",
-      "samsung.com",
-      "webmd.com",
       "forbes.com",
-      "thehindu.com",
-      "walgreens.com"
+      "samsung.com",
+      "economist.com"
     ],
     "dotsub.com": [
       "aarp.org"
@@ -5020,52 +7618,26 @@
     "doubleclick.net": [
       "youtube.com",
       "twitter.com",
-      "linkedin.com",
-      "sourceforge.net",
-      "haaretz.com",
-      "focus.de"
-    ],
-    "doublemax.net": [
-      "udn.com"
+      "linkedin.com"
     ],
     "doublepimpssl.com": [
       "pornhub.com"
     ],
-    "doubleverify.com": [
-      "military.com",
-      "allafrica.com"
-    ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
-      "techtarget.com",
       "adweek.com"
-    ],
-    "dxpmedia.com": [
-      "sina.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
     ],
     "dynamicyield.com": [
-      "t-online.de",
       "cnbc.com",
-      "nbcnews.com",
+      "norton.com",
       "washingtonexaminer.com"
     ],
-    "dynatrace-managed.com": [
-      "delta.com"
-    ],
     "dyntrk.com": [
-      "dailymotion.com",
-      "infoplease.com"
-    ],
-    "ebay-us.com": [
-      "ebay.com.au",
-      "ebay.com"
-    ],
-    "ebay.co.uk": [
-      "synacor.com"
+      "dailymotion.com"
     ],
     "ebay.com": [
       "ebay.co.uk",
@@ -5075,44 +7647,25 @@
     "ebayrtm.com": [
       "ebay.co.uk",
       "ebay.de",
-      "ebay.com",
       "ebay.com.au"
     ],
-    "ebdr3.com": [
-      "springer.com"
-    ],
     "ebis.ne.jp": [
-      "exblog.jp",
-      "xrea.com"
-    ],
-    "econda-monitor.de": [
-      "expedia.com"
-    ],
-    "ecustomeropinions.com": [
-      "skysports.com"
+      "exblog.jp"
     ],
     "edge-cdn.net": [
       "biomedcentral.com"
     ],
-    "edmunds.com": [
-      "unenvironment.org"
-    ],
     "effectivemeasure.net": [
       "bbc.com",
       "dailymotion.com",
-      "gulfnews.com",
-      "goal.com"
+      "gulfnews.com"
     ],
     "eloqua.com": [
       "intel.com",
-      "cisco.com",
-      "prnewswire.com",
-      "redhat.com",
-      "infoworld.com",
-      "eset.com"
+      "siemens.com",
+      "redhat.com"
     ],
     "elsevier.com": [
-      "sciencedirect.com",
       "thelancet.com",
       "cell.com"
     ],
@@ -5120,80 +7673,33 @@
       "thelancet.com",
       "cell.com"
     ],
-    "emc.com": [
-      "rsa.com"
-    ],
     "emlgrid.com": [
       "home.pl"
     ],
-    "emxdgt.com": [
-      "springer.com",
-      "home.pl"
-    ],
-    "envato.com": [
-      "codecanyon.net"
-    ],
     "epicurious.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
-    ],
-    "epital.gdn": [
-      "4shared.com"
     ],
     "equalstyle.com": [
       "hubpages.com"
     ],
-    "espn.com": [
-      "fivethirtyeight.com"
-    ],
-    "estara.com": [
-      "xerox.com"
-    ],
     "estat.com": [
       "over-blog.com",
       "canalblog.com",
-      "lefigaro.fr",
       "tomshardware.com"
-    ],
-    "etracker.de": [
-      "sedo.com"
-    ],
-    "etsystudio.com": [
-      "etsy.com"
-    ],
-    "evenhotels.com": [
-      "ihg.com"
-    ],
-    "eventsabout.com": [
-      "sacbee.com"
     ],
     "everesttech.net": [
       "adobe.com",
-      "yahoo.com",
       "sourceforge.net",
-      "dropbox.com",
-      "thehindu.com",
-      "newatlas.com"
-    ],
-    "everyaction.com": [
-      "greenpeace.org"
+      "nytimes.com"
     ],
     "evise.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
-    "evolok.net": [
-      "scotsman.com"
-    ],
-    "evyy.net": [
-      "office.com"
-    ],
-    "ew3.io": [
-      "liberation.fr"
+    "evvnt-api.global.ssl.fastly.net": [
+      "seattlepi.com"
     ],
     "exactag.com": [
       "t-online.de"
@@ -5201,38 +7707,21 @@
     "excite.co.jp": [
       "exblog.jp"
     ],
-    "exe.bid": [
-      "rambler.ru"
-    ],
     "exelator.com": [
       "soundcloud.com",
       "forbes.com",
-      "bloomberg.com",
-      "businessinsider.com",
-      "genius.com",
-      "gizmodo.com"
-    ],
-    "exosrv.com": [
-      "pornhub.com"
-    ],
-    "expedia.com": [
-      "excite.com"
+      "businessinsider.com"
     ],
     "eyeota.net": [
       "sourceforge.net",
-      "forbes.com",
-      "bloomberg.com",
-      "gizmodo.com",
-      "heraldsun.com.au"
+      "wsj.com",
+      "npr.org"
     ],
     "eyereturn.com": [
-      "thestar.com",
-      "queensu.ca"
+      "thestar.com"
     ],
     "eyeviewads.com": [
-      "staples.com",
-      "nypost.com",
-      "walgreens.com"
+      "boingboing.net"
     ],
     "ezoic.net": [
       "tinyurl.com",
@@ -5240,40 +7729,17 @@
     ],
     "facebook.com": [
       "instagram.com",
-      "wordpress.org",
       "adobe.com",
-      "nytimes.com",
-      "haaretz.com",
-      "focus.de"
+      "apple.com"
     ],
-    "facetz.net": [
-      "novostimira.com",
-      "rambler.ru",
-      "kharkov.ua"
-    ],
-    "faggrim.com": [
-      "radikal.ru"
-    ],
-    "fairfax.com.au": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "fastcompany.com": [
-      "fastcodesign.com"
+    "fastapi.net": [
+      "sohu.com"
     ],
     "fdlstatic.com": [
       "cnet.com"
     ],
     "feathr.co": [
-      "informationweek.com",
-      "eurogamer.net"
-    ],
-    "ffx.io": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "fidelity-media.com": [
-      "home.pl"
+      "informationweek.com"
     ],
     "filepicker.io": [
       "enlightenment.org",
@@ -5281,245 +7747,123 @@
     ],
     "firstimpression.io": [
       "jpost.com",
-      "serverwatch.com",
       "haaretz.com"
     ],
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu"
+      "monster.com"
     ],
     "flickr.com": [
-      "state.gov",
       "oecd.org",
-      "enable-javascript.com"
+      "enable-javascript.com",
+      "cia.gov"
     ],
     "flipboard.com": [
       "venturebeat.com",
-      "autoblog.com",
-      "popsugar.com"
-    ],
-    "flyercity.ca": [
-      "canada.com"
+      "popsugar.com",
+      "autoblog.com"
     ],
     "flyertown.ca": [
-      "canada.com",
-      "globalnews.ca",
       "nationalpost.com",
+      "globalnews.ca",
       "vancouversun.com"
     ],
-    "fontawesome.com": [
-      "socarrao.com.br",
-      "clinicaltrials.gov",
-      "moonfruit.com",
-      "webex.com",
-      "ucsc.edu",
-      "sitepoint.com"
+    "force.com": [
+      "constantcontact.com",
+      "salesforce.com"
     ],
     "foresee.com": [
       "epa.gov",
-      "si.edu",
-      "theglobeandmail.com",
-      "sec.gov",
-      "worldcat.org"
+      "ieee.org",
+      "theglobeandmail.com"
     ],
     "formstack.com": [
       "in.gov"
     ],
     "fout.jp": [
       "economist.com",
-      "hatena.ne.jp"
-    ],
-    "fox.com": [
-      "nationalgeographic.com",
-      "foxnews.com",
-      "foxbusiness.com"
-    ],
-    "foxbusiness.com": [
-      "fox.com"
-    ],
-    "foxnews.com": [
-      "foxbusiness.com",
-      "fox.com"
-    ],
-    "foxsports.com": [
-      "fox.com"
+      "exblog.jp",
+      "biglobe.ne.jp"
     ],
     "foxycart.com": [
       "brookings.edu"
     ],
-    "freeskreen.com": [
-      "nationalpost.com",
-      "wattpad.com"
-    ],
     "freshdesk.com": [
       "podbean.com"
     ],
-    "friendbuy.com": [
-      "lulu.com"
-    ],
-    "funcaptcha.com": [
-      "axs.com"
-    ],
-    "funnyordie.com": [
-      "deadline.com",
-      "videojs.com"
-    ],
     "fwmrm.net": [
-      "yahoo.com",
-      "mlb.com",
-      "xfinity.com",
+      "go.com",
       "discovery.com",
-      "hgtv.com"
-    ],
-    "g2crowd.com": [
-      "prezi.com",
-      "teamviewer.us",
-      "wpengine.com"
-    ],
-    "gakogedifoda.ru": [
-      "radikal.ru"
-    ],
-    "gamer-network.net": [
-      "eurogamer.net"
+      "foodnetwork.com"
     ],
     "gemius.pl": [
       "sapo.pt",
-      "interia.pl",
       "ria.ru"
     ],
-    "gentags.net": [
-      "sina.com.cn"
-    ],
     "getclicky.com": [
-      "icio.us",
       "newatlas.com",
       "cyberchimps.com"
-    ],
-    "getdrip.com": [
-      "dreamhost.com"
-    ],
-    "getpocket.com": [
-      "cronolog.org"
-    ],
-    "getsmartcontent.com": [
-      "pcworld.com",
-      "computerworld.com",
-      "hpe.com",
-      "networkworld.com"
-    ],
-    "gfycat.com": [
-      "reddit.com"
     ],
     "gigya.com": [
       "cnn.com",
       "independent.co.uk",
-      "abc.net.au",
-      "cbslocal.com",
-      "abc.es",
-      "hgtv.com"
+      "abc.net.au"
     ],
     "giphy.com": [
-      "urbandictionary.com",
-      "liberation.fr",
-      "webshots.com"
-    ],
-    "github.com": [
-      "wsj.com"
+      "urbandictionary.com"
     ],
     "glamour.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "globalwebindex.net": [
       "reuters.com",
       "time.com",
-      "fortune.com",
-      "si.com"
-    ],
-    "gmossp-sp.jp": [
-      "shinobi.jp",
-      "shop-pro.jp"
+      "fortune.com"
     ],
     "go.com": [
       "disney.com",
-      "espn.com",
       "starwars.com",
       "fivethirtyeight.com"
     ],
     "golfdigest.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "goo.ne.jp": [
       "ocn.ne.jp"
     ],
-    "google.co.jp": [
-      "forumotion.com"
-    ],
     "google.com": [
       "youtube.com",
-      "linkedin.com",
-      "google.de",
-      "sourceforge.net",
-      "scmp.com",
-      "sendspace.com",
-      "chromium.org",
-      "focus.de"
+      "vimeo.com",
+      "goo.gl"
     ],
     "gq.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "gridsumdissector.com": [
-      "qq.com",
-      "www.gov.cn",
-      "autohome.com.cn"
+      "www.gov.cn"
     ],
     "groupondata.com": [
       "groupon.com"
     ],
-    "gsimedia.net": [
-      "acehardware.com"
-    ],
-    "gssprt.jp": [
-      "dropbox.com",
-      "biglobe.ne.jp"
-    ],
     "gtags.net": [
-      "sina.com.cn",
       "ctrip.com"
     ],
     "gumgum.com": [
-      "liveuamap.com",
-      "colourlovers.com",
-      "infoplease.com",
+      "snopes.com",
       "thehindu.com",
-      "coindesk.com"
-    ],
-    "guoshipartners.com": [
-      "udn.com"
+      "home.pl"
     ],
     "gwallet.com": [
-      "adobe.com",
-      "ox.ac.uk",
-      "ihg.com",
       "economist.com",
-      "business2community.com"
-    ],
-    "gwmtracking.com": [
-      "proofpoint.com"
-    ],
-    "hadcs.de": [
-      "t-online.de"
+      "ox.ac.uk",
+      "smithsonianmag.com"
     ],
     "hatena.com": [
       "hatena.ne.jp"
@@ -5529,7 +7873,6 @@
       "cronolog.org"
     ],
     "healte.de": [
-      "spiegel.de",
       "reuters.com"
     ],
     "hearstnp.com": [
@@ -5538,20 +7881,7 @@
       "seattlepi.com"
     ],
     "help.com": [
-      "comodo.com",
-      "couchsurfing.com"
-    ],
-    "hgbn.rocks": [
-      "radikal.ru"
-    ],
-    "hgbnr.com": [
-      "radikal.ru"
-    ],
-    "hiexpress.com": [
-      "ihg.com"
-    ],
-    "highwire.org": [
-      "pnas.org"
+      "comodo.com"
     ],
     "hitslink.com": [
       "webstarts.com"
@@ -5559,40 +7889,16 @@
     "hive.co": [
       "complex.com"
     ],
-    "hlserve.com": [
-      "bestbuy.com",
-      "macys.com",
-      "kohls.com"
-    ],
-    "holidayinn.com": [
-      "ihg.com"
-    ],
-    "holidayinnresorts.com": [
-      "ihg.com"
-    ],
     "horyzon-media.com": [
       "skyrock.com"
     ],
-    "hotelindigo.com": [
-      "ihg.com"
-    ],
-    "hotelsapi.io": [
-      "ovh.net"
-    ],
-    "htmedia.in": [
-      "hindustantimes.com"
-    ],
     "hubspot.com": [
-      "wpengine.com",
-      "shopify.com",
-      "technologyreview.com",
-      "scoop.it"
+      "scoop.it",
+      "500px.com",
+      "thelancet.com"
     ],
-    "huffingtonpost.co.uk": [
-      "oath.com"
-    ],
-    "huffingtonpost.com": [
-      "huffingtonpost.co.uk"
+    "hugedata.com.cn": [
+      "miit.gov.cn"
     ],
     "huihui.cn": [
       "youdao.com"
@@ -5601,57 +7907,35 @@
       "boingboing.net"
     ],
     "hybrid.ai": [
-      "rambler.ru",
-      "tomsk.ru",
-      "diary.ru",
-      "radikal.ru"
+      "rambler.ru"
     ],
-    "hypemarks.com": [
-      "uchicago.edu",
-      "purdue.edu",
-      "brown.edu"
-    ],
-    "i.ua": [
-      "kharkov.ua",
-      "kh.ua"
-    ],
-    "i1img.com": [
-      "excite.com"
-    ],
-    "ib-ibi.com": [
-      "globo.com"
+    "iasds01.com": [
+      "discovery.com"
     ],
     "ibclick.stream": [
-      "webmd.com",
-      "wikitravel.org",
-      "inhabitat.com"
+      "webmd.com"
     ],
     "ibillboard.com": [
+      "t-online.de",
       "springer.com",
-      "home.pl",
-      "idnes.cz"
+      "home.pl"
     ],
     "ibt.com": [
       "newsweek.com",
       "ibtimes.com"
     ],
     "id5-sync.com": [
-      "bloomberg.com",
-      "venturebeat.com",
       "dailymotion.com",
       "livescience.com",
-      "xda-developers.com"
+      "skyrock.com"
     ],
     "idealmedia.com": [
-      "alternet.org",
       "thehill.com"
     ],
     "ign.com": [
       "videojs.com"
     ],
     "igodigital.com": [
-      "apa.org",
-      "adidas.com",
       "motorola.com",
       "nintendo.com"
     ],
@@ -5660,109 +7944,63 @@
     ],
     "im-apps.net": [
       "exblog.jp",
-      "rakuten.co.jp",
       "biglobe.ne.jp",
-      "economist.com"
-    ],
-    "imagetopng.club": [
-      "4shared.com"
-    ],
-    "imedia.cz": [
-      "idnes.cz"
-    ],
-    "imgfarm.com": [
-      "excite.com"
+      "goo.ne.jp"
     ],
     "imgur.com": [
       "stackoverflow.com",
-      "stackexchange.com",
-      "unm.edu"
+      "stackexchange.com"
     ],
     "impact-ad.jp": [
-      "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp",
-      "economist.com",
-      "ocn.ne.jp"
+      "hatena.ne.jp",
+      "goo.ne.jp"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
-      "bbc.com",
-      "wsj.com",
-      "popsugar.com",
-      "gizmodo.com"
+      "wsj.com"
     ],
     "infinity-tracking.net": [
       "telegraph.co.uk",
       "gartner.com"
     ],
-    "infolinks.com": [
-      "infoplease.com"
-    ],
-    "innovid.com": [
-      "nationalreview.com"
-    ],
     "inq.com": [
-      "att.com",
-      "shutterstock.com",
       "ups.com"
-    ],
-    "inquisitr.com": [
-      "www.poznan.pl",
-      "flipboard.com"
-    ],
-    "inside-graph.com": [
-      "staples.com"
     ],
     "insightexpressai.com": [
       "unsplash.com",
-      "standard.co.uk",
-      "motorola.com",
-      "giphy.com",
-      "gopro.com"
+      "philly.com"
     ],
     "instagram.com": [
-      "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
       "arizona.edu"
     ],
     "instinctiveads.com": [
-      "variety.com",
-      "dp.ua",
-      "blackberry.com",
-      "rollingstone.com"
+      "rollingstone.com",
+      "variety.com"
     ],
     "intentiq.com": [
-      "sourceforge.net",
-      "symantec.com",
-      "slashdot.org"
+      "thinkgeek.com",
+      "active.com"
     ],
     "intentmedia.net": [
-      "hotels.com",
-      "tripadvisor.com",
-      "expedia.com"
+      "tripadvisor.com"
     ],
     "intercom.io": [
-      "themeforest.net",
-      "ft.com",
-      "elegantthemes.com",
-      "codecanyon.net",
-      "iconfinder.com"
+      "themegrill.com",
+      "emarketer.com",
+      "diabetes.org"
     ],
     "intergient.com": [
       "infoplease.com"
     ],
     "internetbrands.com": [
-      "wikitravel.org",
-      "inhabitat.com"
+      "wikitravel.org"
     ],
     "investingchannel.com": [
       "zerohedge.com"
-    ],
-    "investis.com": [
-      "ge.com"
     ],
     "invoc.us": [
       "prweb.com"
@@ -5770,86 +8008,57 @@
     "ioam.de": [
       "t-online.de",
       "spiegel.de",
-      "xing.com",
-      "focus.de"
+      "xing.com"
     ],
     "iolam.it": [
       "virgilio.it"
     ],
     "iperceptions.com": [
-      "ford.com",
-      "seagate.com",
-      "honeywell.com",
       "boeing.com"
     ],
-    "ipinyou.com": [
-      "autohome.com.cn"
-    ],
     "ipredictive.com": [
+      "imdb.com",
       "myspace.com",
       "dailymotion.com"
     ],
     "irs01.com": [
-      "youku.com"
-    ],
-    "izooto.com": [
-      "indianexpress.com"
+      "youku.com",
+      "sohu.com"
     ],
     "janrainsso.com": [
       "vancouversun.com"
     ],
     "jd.com": [
       "163.com",
-      "ifeng.com",
       "sohu.com"
     ],
     "jquery.com": [
-      "dyn.com",
-      "fujitsu.com",
-      "liveleak.com",
-      "lemonde.fr"
+      "opensource.org",
+      "lemonde.fr",
+      "businessinsider.com"
     ],
     "jrs5.com": [
       "nike.com",
-      "shutterstock.com",
+      "coursera.org",
       "bostonglobe.com"
     ],
     "jsrdn.com": [
       "thestar.com",
       "boingboing.net",
-      "dallasnews.com",
-      "vancouversun.com"
-    ],
-    "justpremium.com": [
-      "tvtropes.org"
+      "dallasnews.com"
     ],
     "justuno.com": [
       "gartner.com",
-      "searchengineland.com",
-      "zenfolio.com",
-      "gopro.com"
-    ],
-    "jword.jp": [
-      "excite.co.jp"
-    ],
-    "jyxo.com": [
-      "blog.cz"
-    ],
-    "kakao.com": [
-      "tistory.com",
-      "daum.net"
+      "searchengineland.com"
     ],
     "kameleoon.eu": [
       "welt.de",
       "orange.fr"
     ],
     "keywee.co": [
-      "latimes.com",
-      "nationalgeographic.com",
-      "chicagotribune.com",
       "nytimes.com",
-      "complex.com",
-      "zappos.com"
+      "latimes.com",
+      "nationalgeographic.com"
     ],
     "kinja.com": [
       "gizmodo.com",
@@ -5859,105 +8068,66 @@
     "kiwiirc.com": [
       "enlightenment.org"
     ],
-    "krxd.net": [
-      "inhabitat.com",
-      "bgr.com",
-      "jalopnik.com",
-      "cnn.com",
-      "allrecipes.com",
-      "gizmodo.com"
+    "knet.cn": [
+      "dzwww.com"
     ],
-    "ladsp.com": [
-      "exblog.jp",
-      "biglobe.ne.jp",
-      "shop-pro.jp"
+    "krxd.net": [
+      "cnn.com",
+      "theguardian.com",
+      "usatoday.com"
     ],
     "leadintel.io": [
       "nme.com"
     ],
-    "leaf.io": [
-      "ehow.com",
-      "livestrong.com"
+    "leadlander.com": [
+      "panasonic.com"
     ],
     "legocdn.com": [
       "lego.com"
     ],
-    "lejwaengv.com": [
-      "rd.com"
-    ],
     "liadm.com": [
-      "webmd.com",
-      "nj.com",
-      "patch.com",
       "bloomberg.com",
-      "cbssports.com",
-      "washingtonexaminer.com"
-    ],
-    "libero.it": [
-      "virgilio.it"
+      "time.com",
+      "economist.com"
     ],
     "licasd.com": [
-      "nj.com",
-      "cbssports.com"
-    ],
-    "licdn.com": [
-      "linkedin.com"
+      "time.com"
     ],
     "ligadx.com": [
       "springer.com",
       "lemonde.fr",
-      "home.pl",
-      "orange.fr"
+      "lefigaro.fr"
     ],
     "lightboxcdn.com": [
+      "gizmodo.com",
       "zdnet.com",
-      "fastcompany.com",
-      "adweek.com",
-      "mashable.com",
-      "dailycaller.com"
+      "fastcompany.com"
     ],
     "lijit.com": [
       "sourceforge.net",
-      "bloomberg.com",
-      "deviantart.com",
-      "uci.edu",
-      "zimbio.com",
-      "infoplease.com"
-    ],
-    "lincoln.com": [
-      "ford.com"
+      "wsj.com",
+      "bloomberg.com"
     ],
     "link-page.info": [
-      "netvibes.com",
-      "icq.com"
+      "netvibes.com"
     ],
     "linkedin.com": [
-      "adobe.com",
       "vimeo.com",
-      "sourceforge.net",
-      "dropbox.com",
-      "mentalfloss.com",
-      "lexisnexis.com"
+      "adobe.com",
+      "sourceforge.net"
     ],
     "linksynergy.com": [
-      "rakuten.co.jp",
-      "pcworld.com",
       "nike.com",
-      "infoworld.com"
-    ],
-    "list-manage.com": [
-      "boingboing.net"
+      "alibabacloud.com",
+      "coursera.org"
     ],
     "listrakbi.com": [
       "denverpost.com"
     ],
     "live.com": [
-      "paypal.com",
-      "skype.com",
-      "msn.com",
       "microsoft.com",
-      "bing.com",
-      "office.com"
+      "msn.com",
+      "bing.com"
     ],
     "livechatinc.com": [
       "ning.com",
@@ -5965,34 +8135,27 @@
       "sophos.com",
       "nazwa.pl"
     ],
-    "livedoor.jp": [
-      "livedoor.com"
-    ],
     "livejournal.net": [
       "livejournal.com"
     ],
     "liveperson.net": [
-      "apache.org",
-      "prnewswire.com",
-      "ibm.com",
-      "thetimes.co.uk",
-      "lexisnexis.com"
-    ],
-    "lkqd.net": [
-      "allafrica.com"
+      "talktalk.co.uk",
+      "earthlink.net",
+      "trendmicro.com"
     ],
     "loc.gov": [
-      "congress.gov",
       "copyright.gov"
     ],
     "lockerdome.com": [
-      "infoplease.com",
-      "coindesk.com",
-      "edmunds.com"
+      "jpost.com",
+      "infoplease.com"
     ],
     "logly.co.jp": [
       "goo.ne.jp",
       "nifty.com"
+    ],
+    "lp1block.com": [
+      "radikal.ru"
     ],
     "lqm.io": [
       "lefigaro.fr"
@@ -6001,229 +8164,141 @@
       "cbc.ca",
       "arte.tv"
     ],
-    "lucklayed.info": [
-      "4shared.com"
-    ],
-    "lwcal.com": [
-      "sfu.ca"
-    ],
     "lytics.io": [
-      "adweek.com",
+      "economist.com",
       "digitaltrends.com",
-      "fool.com",
-      "economist.com"
+      "adweek.com"
     ],
     "m6r.eu": [
       "t-online.de",
       "statista.com"
     ],
-    "madeleine.de": [
-      "t-online.de"
-    ],
     "mail.ru": [
       "vk.com",
-      "novostimira.com",
-      "google.com",
       "yandex.ru",
-      "ria.ru",
-      "ok.ru",
-      "radikal.ru"
-    ],
-    "mailchimp.com": [
-      "colorlib.com",
-      "fas.org",
-      "tias.com",
-      "nap.edu"
-    ],
-    "mantisadnetwork.com": [
-      "tvtropes.org"
+      "icq.com"
     ],
     "marinsm.com": [
-      "eventbrite.com",
       "webs.com",
-      "hootsuite.com",
-      "smugmug.com"
+      "smugmug.com",
+      "wufoo.com"
     ],
     "marketlinc.com": [
-      "kaspersky.com",
+      "teamviewer.us",
       "norton.com",
-      "eset.com",
-      "teamviewer.us"
+      "eset.com"
     ],
     "marketo.com": [
       "nokia.com",
       "panasonic.com",
-      "dyn.com",
-      "searchengineland.com",
-      "domaintools.com"
+      "dyn.com"
     ],
     "matheranalytics.com": [
       "theglobeandmail.com",
       "thestar.com",
-      "seattletimes.com",
-      "ajc.com"
+      "mercurynews.com"
     ],
     "mathtag.com": [
-      "adobe.com",
-      "vimeo.com",
       "sourceforge.net",
-      "forbes.com",
-      "thehindu.com",
-      "walgreens.com"
+      "nytimes.com",
+      "forbes.com"
     ],
     "media.net": [
       "nytimes.com",
-      "dropbox.com",
       "forbes.com",
-      "reuters.com",
-      "medicinenet.com",
-      "cracked.com"
+      "reuters.com"
     ],
     "media6degrees.com": [
       "bloomberg.com",
       "uci.edu",
-      "autodesk.com",
-      "box.com"
+      "autodesk.com"
     ],
     "mediaforge.com": [
       "nike.com",
-      "shutterstock.com",
+      "coursera.org",
       "bostonglobe.com"
     ],
-    "medialand.ru": [
-      "rbc.ru"
-    ],
     "mediaplex.com": [
-      "dell.com",
-      "shutterfly.com",
-      "military.com"
+      "t-online.de",
+      "economist.com",
+      "dell.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
-      "lynda.com",
-      "liberation.fr",
       "leparisien.fr"
     ],
     "mediav.com": [
+      "so.com",
       "ctrip.com",
-      "2345.com",
-      "so.com"
+      "toutiao.com"
     ],
     "mediawallahscript.com": [
-      "sourceforge.net",
-      "photobucket.com",
-      "shopko.com"
-    ],
-    "medscape.com": [
-      "medicinenet.com"
+      "sourceforge.net"
     ],
     "medtargetsystem.com": [
       "medscape.com"
     ],
     "mendeley.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
     "metadsp.co.uk": [
-      "nypost.com",
-      "standard.co.uk",
-      "variety.com"
+      "boingboing.net",
+      "standard.co.uk"
     ],
     "mfadsrvr.com": [
-      "infoplease.com"
+      "forbes.com"
     ],
     "mg2connext.com": [
-      "mercurynews.com",
       "philly.com",
-      "denverpost.com",
       "ajc.com"
     ],
     "mgid.com": [
-      "liveleak.com",
-      "radikal.ru"
-    ],
-    "miamiherald.com": [
-      "sacbee.com",
-      "kansascity.com"
+      "liveleak.com"
     ],
     "miaozhen.com": [
       "sina.com.cn",
-      "163.com",
-      "dzwww.com",
-      "autohome.com.cn"
+      "pconline.com.cn",
+      "qq.com"
     ],
     "microad.jp": [
-      "rakuten.co.jp",
       "sakura.ne.jp",
-      "biglobe.ne.jp"
+      "hatena.ne.jp"
     ],
     "microsoft.com": [
       "live.com",
       "skype.com",
-      "or.kr",
-      "msn.com",
-      "office.com",
-      "xbox.com",
-      "complex.com"
-    ],
-    "microsoftonline.com": [
-      "microsoft.com",
       "office.com"
     ],
-    "mirtesen.ru": [
-      "rbc.ru"
+    "microsoftonline.com": [
+      "office.com",
+      "microsoft.com"
     ],
     "mktoresp.com": [
       "parallels.com",
-      "prnewswire.com",
       "zend.com",
-      "oreilly.com",
-      "ebsco.com",
-      "pingdom.com"
+      "prweb.com"
     ],
     "ml314.com": [
       "sourceforge.net",
-      "forbes.com",
-      "bloomberg.com",
       "wsj.com",
-      "networkworld.com",
-      "zerohedge.com"
-    ],
-    "mlb.com": [
-      "nhl.com"
-    ],
-    "mlive.com": [
-      "nola.com"
+      "bloomberg.com"
     ],
     "mmstat.com": [
-      "alibaba.com",
       "youku.com",
-      "taobao.com",
-      "aliexpress.com"
-    ],
-    "mmtro.com": [
-      "upwork.com"
-    ],
-    "molefefiseranis.ru": [
-      "radikal.ru"
+      "sohu.com",
+      "taobao.com"
     ],
     "monetate.net": [
       "nationalgeographic.com",
-      "marriott.com",
-      "ticketmaster.com"
-    ],
-    "monster.com": [
-      "military.com"
+      "marriott.com"
     ],
     "mookie1.com": [
       "t-online.de",
-      "nbcnews.com",
-      "theglobeandmail.com",
-      "businessinsider.com"
+      "businessinsider.com",
+      "npr.org"
     ],
     "mouseflow.com": [
-      "bbb.org",
       "nintendo.com"
     ],
     "mpnrs.com": [
@@ -6232,118 +8307,63 @@
     ],
     "mrpfd.com": [
       "symantec.com",
-      "gouv.fr",
       "hpe.com"
     ],
     "msgapp.com": [
-      "post-gazette.com",
-      "odin.com"
+      "post-gazette.com"
     ],
     "msn.com": [
       "w3.org",
-      "marketwatch.com",
-      "google.com"
-    ],
-    "mthsense.com": [
-      "alternet.org"
-    ],
-    "mtty.com": [
-      "163.com"
+      "marketwatch.com"
     ],
     "mtvnservices.com": [
       "mtv.com",
       "cc.com"
     ],
-    "multiview.com": [
-      "symantec.com",
-      "nutrition.org"
-    ],
     "musthird.com": [
       "airbnb.com"
-    ],
-    "muumuu-domain.com": [
-      "shop-pro.jp"
-    ],
-    "mybuys.com": [
-      "shopko.com"
-    ],
-    "myhard.com": [
-      "yesky.com"
     ],
     "mynativeplatform.com": [
       "springer.com",
       "home.pl"
-    ],
-    "myregistry.com": [
-      "shopko.com"
     ],
     "myspacecdn.com": [
       "myspace.com"
     ],
     "myvisualiq.net": [
       "soundcloud.com",
-      "surveymonkey.com",
-      "spotify.com",
       "paypal.com",
-      "redbubble.com"
+      "surveymonkey.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
-      "overstock.com",
-      "squareup.com",
-      "zappos.com"
+      "yellowpages.com"
     ],
     "narrative.io": [
-      "sourceforge.net",
-      "gizmodo.com"
+      "sourceforge.net"
     ],
     "nasdaq.com": [
       "globenewswire.com"
     ],
     "nationalgeographic.com": [
-      "foxnews.com",
-      "foxbusiness.com",
-      "fox.com"
+      "foxnews.com"
     ],
     "native.ai": [
-      "rollingstone.com"
+      "cbslocal.com"
     ],
     "nativendo.de": [
-      "t-online.de",
-      "gnu.org",
-      "focus.de"
+      "t-online.de"
     ],
     "naver.com": [
-      "unity3d.com",
-      "cafe24.com",
-      "yonhapnews.co.kr"
+      "unity3d.com"
     ],
     "naver.jp": [
-      "line.me",
-      "livedoor.com"
-    ],
-    "nbcnews.com": [
-      "today.com",
-      "msnbc.com"
+      "line.me"
     ],
     "nbcuni.com": [
       "cnbc.com",
-      "msnbc.com",
-      "nbc.com",
-      "nbcnews.com"
-    ],
-    "netdna-ssl.com": [
-      "alternet.org"
-    ],
-    "netmng.com": [
-      "lenovo.com",
-      "theknot.com",
-      "shopko.com",
-      "usatoday.com",
-      "thehindu.com"
-    ],
-    "newatlas.com": [
-      "flipboard.com"
+      "nbcnews.com",
+      "today.com"
     ],
     "neweggimages.com": [
       "newegg.com"
@@ -6363,20 +8383,14 @@
       "heraldsun.com.au"
     ],
     "newscgp.com": [
-      "marketwatch.com",
-      "nypost.com",
-      "thesun.co.uk",
       "wsj.com",
-      "heraldsun.com.au"
+      "marketwatch.com",
+      "nypost.com"
     ],
     "newsinc.com": [
       "latimes.com",
-      "nydailynews.com",
       "hollywoodreporter.com",
-      "ajc.com"
-    ],
-    "newsmemory.com": [
-      "cleveland.com"
+      "thehill.com"
     ],
     "newsvine.com": [
       "nbcnews.com",
@@ -6388,9 +8402,7 @@
     ],
     "newyorker.com": [
       "wired.com",
-      "vanityfair.com",
       "vogue.com",
-      "gq.com",
       "pitchfork.com"
     ],
     "nexac.com": [
@@ -6399,66 +8411,24 @@
     "ngpvan.com": [
       "greenpeace.org"
     ],
-    "nih.gov": [
-      "medlineplus.gov",
-      "clinicaltrials.gov"
-    ],
     "nokia.com": [
       "bell-labs.com"
-    ],
-    "norton.com": [
-      "namejet.com"
     ],
     "nr-data.net": [
       "sourceforge.net",
       "wsj.com",
-      "oracle.com",
-      "huffingtonpost.com",
-      "allrecipes.com",
-      "helsinki.fi"
-    ],
-    "nsaudience.pl": [
-      "interia.pl"
-    ],
-    "nscontext.eu": [
-      "interia.pl",
-      "home.pl"
+      "huffingtonpost.com"
     ],
     "nuggad.net": [
-      "t-online.de",
-      "liberation.fr",
-      "lexpress.fr"
+      "t-online.de"
     ],
     "nxtck.com": [
       "nike.com",
-      "shutterstock.com",
-      "bostonglobe.com",
-      "orange.fr"
-    ],
-    "nymag.com": [
-      "vulture.com"
-    ],
-    "nzaza.com": [
-      "upwork.com"
+      "coursera.org",
+      "bostonglobe.com"
     ],
     "o0bg.com": [
       "bostonglobe.com"
-    ],
-    "oath.com": [
-      "tumblr.com",
-      "huffingtonpost.co.uk",
-      "techradar.com",
-      "autoblog.com"
-    ],
-    "ocdn.eu": [
-      "onet.pl",
-      "brightcove.net"
-    ],
-    "oclc.org": [
-      "worldcat.org"
-    ],
-    "ofapes.com": [
-      "radikal.ru"
     ],
     "office.com": [
       "microsoftonline.com"
@@ -6467,13 +8437,13 @@
       "microsoftonline.com"
     ],
     "ojrq.net": [
-      "office.com"
+      "autodesk.com"
     ],
     "ok.ru": [
-      "ria.ru",
-      "mail.ru"
+      "ria.ru"
     ],
     "olark.com": [
+      "texas.gov",
       "webstarts.com"
     ],
     "olympicchannel.com": [
@@ -6486,38 +8456,25 @@
       "rambler.ru"
     ],
     "omnitagjs.com": [
-      "springer.com",
+      "variety.com",
       "standard.co.uk",
-      "home.pl",
-      "variety.com"
+      "home.pl"
     ],
     "omtrdc.net": [
       "adobe.com",
-      "amazon.com",
       "telegraph.co.uk",
-      "marriott.com",
-      "ancestry.com",
-      "eset.com"
-    ],
-    "onclickmega.com": [
-      "brothersoft.com"
+      "amazon.com"
     ],
     "onecount.net": [
       "foreignpolicy.com"
     ],
-    "onet.tv": [
-      "onet.pl"
+    "oneroof.co.nz": [
+      "nzherald.co.nz"
     ],
     "onetrust.com": [
-      "themeisle.com",
-      "bitbucket.org",
-      "namecheap.com",
       "cnn.com",
-      "haaretz.com",
-      "active.com"
-    ],
-    "onevision.com.tw": [
-      "udn.com"
+      "thesun.co.uk",
+      "themeisle.com"
     ],
     "online-metrix.net": [
       "gotomeeting.com"
@@ -6527,29 +8484,23 @@
     ],
     "onthe.io": [
       "indiatimes.com",
-      "wn.com",
       "express.co.uk",
       "rbc.ru"
     ],
     "ooyala.com": [
       "accuweather.com",
-      "technologyreview.com",
-      "bizjournals.com"
+      "fedex.com"
     ],
     "openhub.net": [
       "mariadb.org"
     ],
     "openstat.net": [
-      "novostimira.com",
-      "kharkov.ua"
+      "novostimira.com"
     ],
     "openx.net": [
       "yahoo.com",
-      "amazon.com",
       "nytimes.com",
-      "dropbox.com",
-      "thehindu.com",
-      "active.com"
+      "forbes.com"
     ],
     "opinionstage.com": [
       "nobelprize.org"
@@ -6558,244 +8509,133 @@
       "sohu.com"
     ],
     "optimix.asia": [
-      "bshare.cn"
+      "bshare.cn",
+      "qianlong.com"
     ],
     "optimizely.com": [
-      "cnn.com",
+      "nytimes.com",
       "creativecommons.org",
       "webs.com",
-      "bbc.com",
-      "live.com",
-      "ibm.com",
-      "hp.com",
-      "wiley.com",
-      "npr.org",
-      "springer.com",
-      "cbsnews.com",
-      "foxnews.com",
-      "imageshack.us",
-      "wikihow.com",
-      "newyorker.com",
-      "evernote.com",
-      "box.com",
-      "prezi.com",
-      "prweb.com",
-      "dictionary.com",
-      "ehow.com",
-      "bitbucket.org",
-      "gotomeeting.com",
-      "accorhotels.com",
-      "uber.com",
-      "xbox.com",
-      "history.com",
-      "bestbuy.com",
-      "jamanetwork.com",
-      "imageshack.com",
-      "dallasnews.com",
-      "metmuseum.org",
-      "blizzard.com",
-      "intuit.com",
-      "starbucks.com",
-      "squareup.com",
-      "justgiving.com",
-      "dreamhost.com",
-      "edx.org",
-      "microsoft.com",
-      "cbssports.com",
-      "bartleby.com",
-      "theknot.com",
-      "zenfolio.com",
-      "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
+      "imageshack.com",
+      "box.com",
       "fox.com"
-    ],
-    "optimove.events": [
-      "bhphotovideo.com"
     ],
     "ora.tv": [
       "cheezburger.com",
       "alternet.org"
     ],
-    "oracleimg.com": [
-      "dyn.com"
-    ],
     "orangeads.fr": [
       "orange.fr"
-    ],
-    "oreilly.com": [
-      "onlamp.com",
-      "ora.com"
-    ],
-    "otm-r.com": [
-      "tomsk.ru",
-      "radikal.ru",
-      "diary.ru"
     ],
     "otto.de": [
       "t-online.de"
     ],
     "outbrain.com": [
-      "nature.com",
-      "scribd.com",
-      "foxnews.com",
       "cnn.com",
-      "globalnews.ca",
-      "focus.de"
+      "msn.com",
+      "wsj.com"
     ],
     "ovh.com": [
       "ovh.co.uk"
     ],
     "owneriq.net": [
-      "lycos.com",
       "lg.com",
       "washingtontimes.com",
-      "thehindu.com",
-      "pitchfork.com"
+      "acer.com"
     ],
     "owox.com": [
-      "simplesite.com"
-    ],
-    "paddle.com": [
-      "snapwidget.com"
+      "boredpanda.com"
     ],
     "pardot.com": [
       "tandfonline.com",
       "prezi.com",
-      "ap.org",
-      "propublica.org"
+      "ap.org"
     ],
     "parsely.com": [
-      "time.com",
-      "wired.com",
-      "wikia.com",
       "wsj.com",
-      "nola.com",
-      "dezeen.com"
+      "huffingtonpost.com",
+      "bloomberg.com"
     ],
     "paypal.com": [
       "paypal.me"
     ],
     "paypalobjects.com": [
       "paypal.com",
-      "freetype.org",
-      "paypal.me"
+      "paypal.me",
+      "freetype.org"
     ],
     "payroll.com": [
       "intuit.com"
-    ],
-    "pbskids.org": [
-      "pbs.org"
-    ],
-    "pcmag.com": [
-      "macrumors.com",
-      "extremetech.com"
-    ],
-    "pdmp.jp": [
-      "shop-pro.jp"
     ],
     "performgroup.com": [
       "goal.com"
     ],
     "perimeterx.net": [
-      "bloomberg.com",
-      "pixnet.net",
-      "macrumors.com",
-      "upwork.com"
+      "udemy.com",
+      "zillow.com",
+      "vogue.com"
     ],
-    "pewresearch.org": [
-      "pewinternet.org"
+    "photobucket.com": [
+      "tinypic.com"
     ],
     "pingan.com": [
       "autohome.com.cn"
     ],
     "pinterest.com": [
-      "huffingtonpost.com",
-      "dailymail.co.uk",
       "nytimes.com",
-      "themeforest.net",
-      "popsugar.com"
+      "huffingtonpost.com",
+      "dailymail.co.uk"
     ],
     "pitchfork.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
-      "epicurious.com"
-    ],
-    "pixanalytics.com": [
-      "pixnet.net"
+      "vogue.com"
     ],
     "piximedia.com": [
       "orange.fr"
     ],
-    "pixnet.cc": [
-      "pixnet.net"
-    ],
-    "placed.com": [
-      "imdb.com"
-    ],
     "placelocal.com": [
       "gopro.com"
-    ],
-    "playwire.com": [
-      "infoplease.com",
-      "zotero.org"
     ],
     "plista.com": [
       "express.co.uk"
     ],
     "po.st": [
       "smithsonianmag.com",
-      "wnd.com",
-      "business2community.com",
       "nme.com"
-    ],
-    "polymorphicads.jp": [
-      "shinobi.jp"
-    ],
-    "popin.cc": [
-      "infoseek.co.jp"
     ],
     "popsugar-assets.com": [
       "popsugar.com"
     ],
     "postrelease.com": [
-      "reuters.com",
-      "independent.co.uk",
-      "chicagotribune.com",
       "wsj.com",
-      "ajc.com",
-      "bostonherald.com"
+      "reuters.com",
+      "independent.co.uk"
     ],
     "powerlinks.com": [
-      "lemonde.fr",
-      "livescience.com",
-      "standard.co.uk",
       "variety.com",
-      "orange.fr"
+      "lemonde.fr",
+      "howtogeek.com"
     ],
     "pressboard.ca": [
-      "observer.com"
+      "thestar.com"
     ],
     "prfct.co": [
-      "smugmug.com",
-      "marthastewart.com",
-      "business2community.com"
+      "smugmug.com"
     ],
     "pro-market.net": [
       "sourceforge.net",
-      "symantec.com",
       "slashdot.org",
-      "business2community.com"
+      "thinkgeek.com"
+    ],
+    "prod-cmg-proxy-connext.azurewebsites.net": [
+      "ajc.com"
     ],
     "prod-mng-proxy-connext.azurewebsites.net": [
       "mercurynews.com",
       "denverpost.com",
       "ocregister.com"
-    ],
-    "proparm.jp": [
-      "biglobe.ne.jp"
     ],
     "provenpixel.com": [
       "shopify.com"
@@ -6803,32 +8643,19 @@
     "providesupport.com": [
       "jigsy.com"
     ],
-    "proximustv.be": [
+    "proximus.be": [
       "skynet.be"
     ],
-    "pscp.tv": [
-      "ey.com",
-      "ria.ru",
-      "nasa.gov"
-    ],
     "pub.network": [
-      "metacafe.com",
       "coindesk.com"
     ],
-    "publishme.se": [
-      "blogg.se"
-    ],
     "pubmatic.com": [
-      "dropbox.com",
-      "tinyurl.com",
+      "forbes.com",
       "bloomberg.com",
-      "usatoday.com",
-      "thehindu.com",
-      "walgreens.com"
+      "usatoday.com"
     ],
     "pubmine.com": [
-      "foreignpolicy.com",
-      "onecount.net"
+      "foreignpolicy.com"
     ],
     "pulpix.com": [
       "variety.com"
@@ -6841,58 +8668,29 @@
     "purechat.com": [
       "byu.edu"
     ],
-    "pxf.io": [
-      "namecheap.com",
-      "udemy.com"
+    "pushanert.com": [
+      "4shared.com"
     ],
-    "pxtres.com": [
-      "howstuffworks.com"
-    ],
-    "pxuno.com": [
-      "howstuffworks.com"
-    ],
-    "pxzwei.com": [
-      "howstuffworks.com"
+    "pxi.pub": [
+      "mentalfloss.com"
     ],
     "pymx5.com": [
-      "seattletimes.com",
-      "seattlepi.com",
       "sfgate.com",
-      "cracked.com"
-    ],
-    "qnsr.com": [
-      "serverwatch.com"
+      "seattletimes.com",
+      "seattlepi.com"
     ],
     "qq.com": [
-      "sina.com.cn",
-      "ctrip.com",
-      "weather.com.cn",
       "tencent.com"
     ],
-    "qsstats.com": [
-      "serverwatch.com",
-      "eweek.com"
-    ],
-    "qtmojo.com": [
-      "dzwww.com"
-    ],
     "qualtrics.com": [
-      "adidas.com",
+      "nintendo.com",
       "cnet.com",
-      "babycenter.com",
-      "cbssports.com",
       "mayoclinic.org"
     ],
     "quantserve.com": [
       "wordpress.org",
-      "vimeo.com",
       "reddit.com",
-      "soundcloud.com",
-      "thehindu.com",
-      "gizmodo.com"
-    ],
-    "quantummetric.com": [
-      "macys.com"
+      "soundcloud.com"
     ],
     "quickbooks.com": [
       "intuit.com"
@@ -6903,10 +8701,7 @@
     "quora.com": [
       "weebly.com",
       "bloomberg.com",
-      "ning.com",
-      "nypost.com",
-      "thehindu.com",
-      "eset.com"
+      "ning.com"
     ],
     "rackcdn.com": [
       "frontiersin.org"
@@ -6914,56 +8709,26 @@
     "radiotime.com": [
       "tunein.com"
     ],
-    "rakuten.co.jp": [
-      "infoseek.co.jp"
-    ],
     "rambler.ru": [
       "livejournal.com",
-      "washingtonpost.com",
       "novostimira.com",
-      "ria.ru",
-      "radikal.ru",
-      "kharkov.ua"
-    ],
-    "rbnt.org": [
-      "radikal.ru"
-    ],
-    "rcsmetrics.it": [
-      "corriere.it"
+      "ria.ru"
     ],
     "reachmax.cn": [
-      "sina.com.cn",
-      "autohome.com.cn",
-      "bshare.cn"
+      "qq.com"
     ],
     "reddit.com": [
       "acm.org",
       "perl.com"
     ],
-    "redditmedia.com": [
-      "reddit.com"
-    ],
     "redlink.com": [
-      "jamanetwork.com",
-      "ccc.de"
-    ],
-    "reference.com": [
-      "thesaurus.com"
+      "jamanetwork.com"
     ],
     "regmedia.co.uk": [
       "theregister.co.uk"
     ],
-    "relap.io": [
-      "diary.ru",
-      "radikal.ru"
-    ],
     "republer.com": [
-      "tomsk.ru",
-      "radikal.ru",
       "rambler.ru"
-    ],
-    "researchintel.com": [
-      "intel.com"
     ],
     "reson8.com": [
       "startribune.com",
@@ -6976,13 +8741,11 @@
       "reuters.com"
     ],
     "revcontent.com": [
-      "liveuamap.com",
-      "wnd.com",
-      "jpost.com"
+      "jpost.com",
+      "breitbart.com",
+      "bostonherald.com"
     ],
     "revjet.com": [
-      "homedepot.com",
-      "expedia.com",
       "bankrate.com"
     ],
     "rezync.com": [
@@ -6990,12 +8753,9 @@
       "investopedia.com"
     ],
     "rfihub.com": [
-      "dropbox.com",
-      "tinyurl.com",
-      "npr.org",
       "forbes.com",
-      "yellowpages.com",
-      "gopro.com"
+      "npr.org",
+      "economist.com"
     ],
     "rhombusads.com": [
       "adweek.com"
@@ -7006,120 +8766,75 @@
     "richmetrics.com": [
       "nj.com",
       "oregonlive.com",
-      "mlive.com",
-      "nola.com"
+      "cleveland.com"
     ],
     "richrelevance.com": [
-      "hbr.org",
-      "kohls.com"
-    ],
-    "rightnowtech.com": [
-      "oracle.com"
+      "hbr.org"
     ],
     "rkdms.com": [
-      "time.com",
       "wired.com",
-      "cbsnews.com",
-      "zdnet.com",
-      "thebalance.com",
-      "gizmodo.com"
+      "npr.org",
+      "cbsnews.com"
     ],
     "rlcdn.com": [
       "adobe.com",
-      "yahoo.com",
       "sourceforge.net",
-      "reddit.com",
-      "thehindu.com",
-      "box.com"
+      "reddit.com"
     ],
     "rnengage.com": [
-      "oracle.com",
       "thinkgeek.com"
     ],
     "rockyou.net": [
       "springer.com"
     ],
-    "roomkey.com": [
-      "hilton.com",
-      "ihg.com"
-    ],
-    "roymorgan.com": [
-      "smh.com.au"
-    ],
     "rqtrk.eu": [
-      "dropbox.com"
-    ],
-    "rtb.com.ru": [
-      "radikal.ru",
-      "diary.ru"
+      "npr.org"
     ],
     "rtk.io": [
-      "post-gazette.com",
-      "azcentral.com",
-      "freep.com"
+      "seattletimes.com",
+      "startribune.com",
+      "azcentral.com"
     ],
     "ru4.com": [
-      "dropbox.com",
       "bloomberg.com",
-      "uci.edu"
+      "npr.org"
     ],
     "rubiconproject.com": [
-      "yahoo.com",
-      "amazon.com",
-      "sourceforge.net",
-      "cnn.com",
-      "thehindu.com",
-      "pitchfork.com"
-    ],
-    "rundsp.com": [
-      "hpe.com",
-      "alternet.org"
+      "nytimes.com",
+      "forbes.com",
+      "wsj.com"
     ],
     "rutarget.ru": [
       "rambler.ru",
-      "radikal.ru"
+      "ria.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
-      "codepen.io",
-      "tvtropes.org"
-    ],
-    "s3xified.com": [
-      "venturebeat.com",
-      "livescience.com",
-      "lycos.com"
+      "bell-labs.com",
+      "hwg.org"
     ],
     "sabavision.com": [
       "mihanblog.com"
     ],
     "salesforceliveagent.com": [
-      "constantcontact.com",
       "marriott.com",
-      "prweb.com",
       "teamviewer.us",
-      "salesforce.com",
-      "eset.com"
+      "prweb.com"
     ],
     "salesloft.com": [
+      "wpengine.com",
       "techtarget.com",
-      "upwork.com",
-      "wpengine.com"
+      "upwork.com"
     ],
     "salesmanago.pl": [
       "home.pl"
     ],
     "samba.tv": [
-      "imdb.com",
       "gizmodo.com",
-      "lifehacker.com"
+      "lifehacker.com",
+      "history.com"
     ],
-    "sape.ru": [
-      "radikal.ru"
-    ],
-    "sbal4kp.com": [
-      "dropbox.com"
-    ],
-    "scarabresearch.com": [
-      "tate.org.uk"
+    "samplicio.us": [
+      "go.com"
     ],
     "scholarlyiq.com": [
       "oup.com"
@@ -7132,210 +8847,133 @@
       "sciencedirect.com"
     ],
     "sciverse.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
-    ],
-    "scoop.it": [
-      "investorseurope.technology"
+      "thelancet.com",
+      "cell.com"
     ],
     "scopus.com": [
-      "sciencedirect.com",
-      "cell.com",
-      "thelancet.com"
+      "thelancet.com",
+      "cell.com"
     ],
     "scorecardresearch.com": [
-      "linkedin.com",
       "yahoo.com",
       "tumblr.com",
-      "nytimes.com",
-      "thehindu.com",
-      "gizmodo.com"
+      "flickr.com"
     ],
     "scribblelive.com": [
       "cbslocal.com",
-      "startribune.com",
-      "ctvnews.ca"
+      "startribune.com"
     ],
-    "sddan.com": [
-      "upwork.com"
+    "scribd.com": [
+      "macrumors.com"
     ],
-    "seadform.net": [
-      "bloomberg.com"
-    ],
-    "searchmarketing.com": [
-      "macys.com"
+    "sdp-campaign.de": [
+      "t-online.de"
     ],
     "securedvisit.com": [
-      "cafepress.com",
-      "staples.com"
-    ],
-    "seekingalpha.com": [
-      "ytimg.com"
+      "cafepress.com"
     ],
     "sekindo.com": [
       "allafrica.com"
     ],
     "selectablemedia.com": [
-      "fortune.com",
-      "people.com",
-      "ew.com",
       "time.com",
-      "allrecipes.com"
+      "fortune.com",
+      "people.com"
     ],
     "self.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
-    "semasio.net": [
-      "bloomberg.com"
-    ],
     "sendtonews.com": [
-      "canada.com",
       "bostonherald.com"
     ],
     "servebom.com": [
-      "venturebeat.com",
       "livescience.com",
       "space.com",
-      "xda-developers.com",
-      "dailydot.com"
-    ],
-    "servedby-buysellads.com": [
-      "dribbble.com"
+      "howtogeek.com"
     ],
     "serverbid.com": [
-      "coindesk.com"
+      "sciencedaily.com"
     ],
     "serving-sys.com": [
       "dropbox.com",
-      "t-online.de",
-      "nbcnews.com",
       "businessinsider.com",
-      "nintendo.com",
-      "hgtv.com"
+      "npr.org"
     ],
     "sessioncam.com": [
       "ama-assn.org",
       "fitbit.com"
     ],
+    "sf14g.com": [
+      "panasonic.com"
+    ],
     "shareaholic.com": [
-      "washingtontimes.com",
-      "turnerpublishing.com"
+      "washingtontimes.com"
     ],
     "sharethis.com": [
-      "www.uk.com",
-      "whatsapp.com",
-      "lycos.com",
-      "uci.edu",
-      "dailycaller.com"
+      "uk.com",
+      "us.org",
+      "www.vic.gov.au"
     ],
     "sharethrough.com": [
-      "yahoo.com",
-      "cnn.com",
+      "cnet.com",
       "time.com",
-      "forbes.com",
-      "home.pl",
-      "walgreens.com"
-    ],
-    "sheego.de": [
-      "t-online.de"
+      "wired.com"
     ],
     "shop.pe": [
-      "dyn.com",
-      "bluehost.com",
-      "fourseasons.com"
+      "dyn.com"
     ],
-    "shopify.com": [
-      "codepen.io",
-      "raspberrypi.org"
-    ],
-    "simplereach.com": [
-      "theatlantic.com"
+    "siftscience.com": [
+      "kickstarter.com",
+      "flickr.com",
+      "shutterstock.com"
     ],
     "simpli.fi": [
-      "symantec.com",
       "washingtontimes.com",
-      "thinkgeek.com"
+      "thinkgeek.com",
+      "tampabay.com"
     ],
     "sina.cn": [
       "sina.com.cn"
     ],
     "sina.com.cn": [
-      "weibo.com",
-      "dzwww.com",
-      "sina.com"
-    ],
-    "sinoptik.ua": [
-      "kharkov.ua",
-      "kh.ua"
-    ],
-    "sitehelix.com": [
-      "overstock.com"
+      "weibo.com"
     ],
     "siteimprove.com": [
-      "usda.gov",
-      "verisign.com",
-      "udel.edu",
       "berkeley.edu",
-      "emory.edu",
-      "ucsc.edu",
-      "helsinki.fi",
-      "case.edu",
-      "oclc.org"
+      "verisign.com",
+      "udel.edu"
     ],
     "siteimproveanalytics.io": [
       "in.gov"
     ],
-    "sitelabweb.com": [
-      "lenovo.com",
-      "upwork.com"
-    ],
     "sitelock.com": [
-      "joomla.org",
-      "netfirms.com"
+      "joomla.org"
     ],
     "sitescout.com": [
-      "barnesandnoble.com",
-      "tinypic.com",
-      "seattletimes.com",
-      "usatoday.com",
-      "thehindu.com",
-      "networksolutions.com"
+      "forbes.com",
+      "tinyurl.com",
+      "time.com"
     ],
     "skimresources.com": [
       "businessinsider.com",
       "engadget.com",
-      "gizmodo.com",
-      "fastcompany.com",
-      "mentalfloss.com",
-      "coindesk.com"
+      "gizmodo.com"
     ],
     "sky.com": [
-      "skygroup.sky",
-      "skysports.com"
+      "skygroup.sky"
     ],
     "slashdotmedia.com": [
       "slashdot.org"
     ],
     "smartadserver.com": [
       "springer.com",
-      "skyrock.com",
-      "sapo.pt",
       "elpais.com",
-      "home.pl"
-    ],
-    "smartclip.net": [
-      "infoplease.com"
+      "skyrock.com"
     ],
     "smashing-delivery.herokuapp.com": [
       "smashingmagazine.com"
-    ],
-    "smi2.net": [
-      "rbc.ru"
     ],
     "smi2.ru": [
       "rbc.ru"
@@ -7344,30 +8982,15 @@
       "si.edu",
       "smithsonianmag.com"
     ],
-    "smyte.com": [
-      "indiegogo.com",
-      "zendesk.com"
-    ],
     "snapchat.com": [
-      "jimdo.com",
-      "overstock.com",
-      "complex.com",
       "wsj.com",
-      "redbubble.com",
-      "zappos.com"
-    ],
-    "snapwidget.com": [
-      "udel.edu"
-    ],
-    "snplow.net": [
-      "wetransfer.com"
+      "giphy.com",
+      "walmart.com"
     ],
     "so.com": [
       "360.cn"
     ],
     "socdm.com": [
-      "rakuten.co.jp",
-      "biglobe.ne.jp",
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
@@ -7378,71 +9001,31 @@
     "soflopxl.com": [
       "howstuffworks.com"
     ],
-    "softonic-analytics.net": [
-      "softonic.com"
-    ],
     "sogou.com": [
-      "soso.com"
-    ],
-    "sohu.com": [
       "ifeng.com",
-      "ctrip.com",
-      "focus.cn"
-    ],
-    "sojern.com": [
-      "ihg.com",
-      "hyatt.com",
-      "gopro.com"
+      "soso.com"
     ],
     "sokrati.com": [
       "business-standard.com"
     ],
-    "soliditet.se": [
-      "jalbum.net"
-    ],
-    "solocpm.com": [
-      "edx.org"
-    ],
     "sonobi.com": [
-      "photobucket.com",
-      "deviantart.com",
-      "springer.com",
       "myspace.com",
-      "home.pl",
-      "detroitnews.com"
-    ],
-    "sonyentertainmentnetwork.com": [
-      "playstation.com"
+      "cnet.com",
+      "usatoday.com"
     ],
     "soundcloud.com": [
       "harvard.edu",
-      "spiegel.de",
       "bmj.com",
+      "ea.com",
       "mo.gov"
-    ],
-    "sourceforge.net": [
-      "libpng.org"
-    ],
-    "sp.global.ssl.fastly.net": [
-      "theglobeandmail.com"
-    ],
-    "spectate.com": [
-      "emory.edu"
     ],
     "sphereup.com": [
       "jpost.com"
     ],
     "spiceworks.com": [
-      "cloudflare.com",
-      "symantec.com",
-      "sophos.com",
-      "hp.com"
-    ],
-    "spineuniverse.com": [
-      "psychcentral.com"
-    ],
-    "spingo.com": [
-      "detroitnews.com"
+      "hp.com",
+      "slack.com",
+      "sophos.com"
     ],
     "sportz.io": [
       "gulfnews.com"
@@ -7451,18 +9034,13 @@
       "engadget.com",
       "denverpost.com"
     ],
-    "spotify.com": [
-      "oregonstate.edu"
-    ],
     "spots.im": [
       "denverpost.com"
     ],
     "spotxchange.com": [
-      "amazon.com",
-      "dropbox.com",
+      "imdb.com",
       "dailymotion.com",
-      "express.co.uk",
-      "bostonherald.com"
+      "npr.org"
     ],
     "spoutable.com": [
       "alternet.org",
@@ -7470,246 +9048,144 @@
     ],
     "springernature.com": [
       "nature.com",
-      "biomedcentral.com",
-      "springer.com"
+      "springer.com",
+      "biomedcentral.com"
     ],
     "springserve.com": [
-      "tinypic.com",
-      "liveuamap.com",
-      "magento.com"
+      "tinypic.com"
     ],
-    "sprinklr.com": [
-      "autodesk.com"
+    "springserve.net": [
+      "tinypic.com"
     ],
     "srx.com.sg": [
       "straitstimes.com"
     ],
     "stackadapt.com": [
-      "thehill.com",
-      "farfetch.com",
-      "threadless.com"
-    ],
-    "staples-sparx.com": [
-      "staples.com"
-    ],
-    "staples-static.com": [
-      "staples.com"
-    ],
-    "starfieldtech.com": [
-      "scamnumbers.info"
+      "shopify.com",
+      "farfetch.com"
     ],
     "statcounter.com": [
       "hugedomains.com",
       "dropcatch.com",
-      "man7.org",
-      "cbslocal.com",
-      "zerohedge.com"
-    ],
-    "staticimgfarm.com": [
-      "excite.com"
-    ],
-    "staybridge.com": [
-      "ihg.com"
+      "freepik.com"
     ],
     "steelhousemedia.com": [
-      "prezi.com",
       "wpengine.com",
-      "istockphoto.com",
-      "newegg.com",
-      "careerbuilder.com"
-    ],
-    "steepto.com": [
-      "liveleak.com"
+      "prezi.com",
+      "gettyimages.com"
     ],
     "stg-sp.global.ssl.fastly.net": [
       "theglobeandmail.com"
     ],
-    "stg8.com": [
-      "sina.com.cn"
-    ],
     "stickyadstv.com": [
-      "bloomberg.com",
       "dailymotion.com",
-      "feedburner.com"
+      "discovery.com",
+      "thinkgeek.com"
     ],
     "storage.googleapis.com": [
       "bostonglobe.com"
     ],
     "storygize.net": [
-      "autodesk.com",
-      "squareup.com",
-      "dn.ua"
-    ],
-    "streem.com.au": [
-      "smh.com.au",
-      "theage.com.au"
-    ],
-    "streetscout.com": [
-      "azcentral.com"
+      "squareup.com"
     ],
     "stripe.com": [
-      "iconfinder.com",
+      "smashballoon.com",
       "presscustomizr.com",
       "themezee.com",
-      "feedly.com",
       "documentcloud.org"
     ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
-      "studiopress.com",
-      "sitepoint.com",
-      "makezine.com"
+      "studiopress.com"
     ],
     "sundaysky.com": [
-      "overstock.com",
-      "alternet.org",
-      "infoplease.com",
+      "fiverr.com",
+      "jpost.com",
       "dailydot.com"
     ],
     "suning.com": [
       "qq.com",
-      "ifeng.com",
-      "sohu.com"
-    ],
-    "sunrtb.com": [
-      "yesky.com"
+      "ifeng.com"
     ],
     "supplyframe.com": [
-      "ti.com",
-      "arduino.cc"
+      "arduino.cc",
+      "ti.com"
     ],
     "survata.com": [
       "tripadvisor.com"
     ],
     "surveymonkey.com": [
       "cambridge.org",
-      "investopedia.com",
-      "foreignpolicy.com",
-      "iop.org"
+      "iop.org",
+      "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
-      "metacafe.com",
-      "indianexpress.com",
-      "springer.com",
       "thehindu.com"
     ],
     "symantec.com": [
-      "norton.com",
-      "opinionlab.com"
-    ],
-    "synacor.com": [
-      "att.net"
+      "norton.com"
     ],
     "taboola.com": [
       "weebly.com",
-      "dropbox.com",
-      "t-online.de",
       "msn.com",
-      "ajc.com",
-      "infoplease.com"
+      "wsj.com"
     ],
     "tacdn.com": [
       "tripadvisor.com"
     ],
-    "tag4arm.com": [
-      "norton.com"
-    ],
-    "tagdelivery.com": [
-      "overstock.com"
-    ],
     "tailtarget.com": [
-      "uol.com.br"
+      "uol.com.br",
+      "variety.com"
     ],
     "tamgrt.com": [
       "tripadvisor.com",
       "hotels.com"
     ],
     "tanx.com": [
-      "sina.com.cn",
-      "alibaba.com",
+      "sohu.com",
       "ifeng.com",
-      "tmall.com",
-      "2345.com"
+      "tmall.com"
     ],
     "taobao.com": [
       "sina.com.cn",
-      "1688.com",
-      "tmall.com",
       "alibaba.com",
-      "2345.com"
+      "tmall.com"
     ],
     "tapad.com": [
-      "adobe.com",
-      "yahoo.com",
-      "soundcloud.com",
-      "dropbox.com",
-      "globalnews.ca",
-      "networksolutions.com"
-    ],
-    "targetimg1.com": [
-      "target.com"
+      "tinyurl.com",
+      "wsj.com",
+      "paypal.com"
     ],
     "tawk.to": [
       "cba.pl"
     ],
-    "tcell.io": [
-      "sophos.com"
-    ],
-    "teads.tv": [
-      "alternet.org",
-      "networksolutions.com"
+    "taylorandfrancis.com": [
+      "tandfonline.com"
     ],
     "tealiumiq.com": [
       "ibm.com",
-      "cbsnews.com",
-      "evernote.com",
       "cnet.com",
-      "ancestry.com",
-      "usmagazine.com"
-    ],
-    "technolutions.net": [
-      "illinois.edu",
-      "upenn.edu",
-      "uci.edu"
+      "samsung.com"
     ],
     "techweb.com": [
       "informationweek.com"
     ],
     "teenvogue.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
-    ],
-    "telegraph.co.uk": [
-      "wordpress.com"
-    ],
-    "telekom.de": [
-      "t-online.de"
-    ],
-    "tenmax.io": [
-      "biglobe.ne.jp"
     ],
     "theadex.com": [
       "t-online.de",
-      "gnu.org",
       "spiegel.de",
-      "focus.de"
-    ],
-    "theatlas.com": [
-      "qz.com"
+      "sueddeutsche.de"
     ],
     "thebrighttag.com": [
       "netflix.com",
-      "wufoo.com",
       "playstation.com",
-      "zappos.com"
-    ],
-    "thecut.com": [
-      "nymag.com"
+      "washingtontimes.com"
     ],
     "theglobeandmail.ca": [
       "theglobeandmail.com"
@@ -7717,50 +9193,35 @@
     "theguardian.com": [
       "videojs.com"
     ],
-    "thesaurus.com": [
-      "dictionary.com"
+    "thrtle.com": [
+      "sourceforge.net"
     ],
-    "thomsonreuters.com": [
-      "reuters.com"
+    "tianqi.com": [
+      "qianlong.com"
     ],
     "tidaltv.com": [
-      "dailymotion.com",
-      "nationalgeographic.com",
-      "xfinity.com"
+      "dailymotion.com"
     ],
     "tidelinedata.io": [
       "deviantart.com"
     ],
     "timecommerce.net": [
-      "fortune.com",
-      "people.com",
-      "ew.com",
       "time.com",
-      "allrecipes.com"
+      "fortune.com",
+      "people.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
     ],
     "tinypass.com": [
-      "businessinsider.com",
-      "techcrunch.com",
-      "kickstarter.com",
       "bloomberg.com",
-      "thenation.com",
-      "gizmodo.com"
+      "businessinsider.com",
+      "techcrunch.com"
     ],
     "tiqcdn.com": [
-      "cisco.com",
-      "nbcnews.com",
-      "ibm.com",
       "wsj.com",
-      "hpe.com",
-      "orange.fr",
-      "francetvinfo.fr"
-    ],
-    "tl813.com": [
-      "panasonic.com",
-      "squareup.com"
+      "cisco.com",
+      "marketwatch.com"
     ],
     "tm-awx.com": [
       "mirror.co.uk"
@@ -7769,45 +9230,21 @@
       "taobao.com"
     ],
     "tns-counter.ru": [
-      "livejournal.com",
       "vk.com",
-      "yandex.ru",
-      "mail.ru",
-      "ria.ru",
-      "radikal.ru"
+      "livejournal.com",
+      "yandex.ru"
     ],
     "toutapp.com": [
       "qualtrics.com"
     ],
-    "tracc.it": [
-      "france24.com",
-      "rfi.fr"
-    ],
-    "trackad.cz": [
-      "idnes.cz"
-    ],
-    "trackalyzer.com": [
-      "squareup.com"
-    ],
-    "tradedoubler.com": [
-      "lemonde.fr",
-      "interia.pl"
-    ],
     "tradelab.fr": [
-      "eklablog.com",
-      "leparisien.fr"
-    ],
-    "traffic-media.co": [
-      "radikal.ru"
-    ],
-    "trafficgate.net": [
-      "rakuten.co.jp"
-    ],
-    "trafficjam.cn": [
-      "youku.com"
+      "eklablog.com"
     ],
     "trafficjunky.net": [
       "pornhub.com"
+    ],
+    "travelsmarter.net": [
+      "tripadvisor.com"
     ],
     "travelzoo.com": [
       "philly.com"
@@ -7815,30 +9252,24 @@
     "trb.com": [
       "latimes.com",
       "chicagotribune.com",
-      "nydailynews.com"
+      "baltimoresun.com"
     ],
     "treasuredata.com": [
-      "biglobe.ne.jp",
-      "nintendo.com",
-      "exblog.jp"
-    ],
-    "tremorhub.com": [
-      "usatoday.com",
-      "azcentral.com",
-      "freep.com",
-      "detroitnews.com"
+      "exblog.jp",
+      "hatena.ne.jp",
+      "nintendo.com"
     ],
     "tribalfusion.com": [
       "dailymotion.com",
-      "pastebin.com",
-      "liveleak.com",
-      "usatoday.com",
-      "thehindu.com"
+      "marriott.com",
+      "pastebin.com"
     ],
     "tribl.io": [
-      "prezi.com",
-      "zimbra.com",
-      "prnewswire.com"
+      "prnewswire.com",
+      "zimbra.com"
+    ],
+    "triblive.com": [
+      "bleacherreport.com"
     ],
     "tripadvisor.com": [
       "accorhotels.com"
@@ -7846,106 +9277,66 @@
     "tronc.com": [
       "latimes.com",
       "chicagotribune.com",
-      "nydailynews.com"
+      "baltimoresun.com"
     ],
     "trumba.com": [
       "ucdavis.edu",
-      "utah.edu",
       "emory.edu"
     ],
     "truoptik.com": [
-      "slashdot.org",
-      "infoplease.com"
+      "slashdot.org"
     ],
     "trustarc.com": [
       "skynet.be"
     ],
-    "trustev.com": [
-      "lenovo.com"
-    ],
     "trustpilot.com": [
-      "jalbum.net",
-      "avira.com",
-      "moonfruit.com"
-    ],
-    "trvl-px.com": [
-      "hotels.com",
-      "expedia.com"
-    ],
-    "tumblr.com": [
-      "dailydot.com"
+      "jalbum.net"
     ],
     "turn.com": [
-      "bloomberg.com",
-      "wired.com",
-      "webmd.com",
+      "forbes.com",
       "hp.com",
-      "gq.com",
-      "pitchfork.com"
+      "wired.com"
     ],
     "tutorialize.me": [
       "ucsf.edu"
     ],
     "tvsquared.com": [
-      "telegraph.co.uk",
+      "wsj.com",
       "jimdo.com",
-      "squarespace.com",
-      "economist.com"
+      "squarespace.com"
     ],
     "twimg.com": [
       "coe.int",
-      "ey.com",
       "dol.gov"
     ],
     "twitter.com": [
       "wordpress.org",
-      "yahoo.com",
-      "chicagotribune.com",
       "nytimes.com",
-      "cnn.com",
-      "msn.com",
-      "haaretz.com",
-      "medicinenet.com",
-      "lexisnexis.com",
-      "edmunds.com"
+      "dropbox.com"
     ],
     "tynt.com": [
-      "accuweather.com",
       "investopedia.com",
-      "washingtontimes.com",
-      "dailycaller.com"
+      "accuweather.com",
+      "washingtontimes.com"
     ],
-    "ubi.com": [
-      "ubisoft.com"
+    "uc.se": [
+      "jalbum.net"
     ],
     "uciservice.com": [
-      "hotels.com",
-      "expedia.com"
+      "hotels.com"
     ],
     "ucoz.net": [
       "narod.ru"
     ],
     "udmserve.net": [
-      "colourlovers.com",
-      "dailydot.com",
       "washingtonexaminer.com"
-    ],
-    "udnfunlife.com": [
-      "udn.com"
-    ],
-    "uefa.com": [
-      "bleacherreport.com"
-    ],
-    "ufpcdn.com": [
-      "brothersoft.com"
     ],
     "ugdturner.com": [
       "cnn.com",
       "nba.com"
     ],
     "undertone.com": [
-      "dallasnews.com",
-      "alternet.org"
+      "dallasnews.com"
     ],
     "unicc.org": [
       "ohchr.org"
@@ -7955,42 +9346,24 @@
     ],
     "unrulymedia.com": [
       "nypost.com",
-      "earthlink.net",
-      "boingboing.net"
-    ],
-    "upravel.com": [
-      "rambler.ru",
-      "tomsk.ru",
-      "radikal.ru"
+      "boingboing.net",
+      "bell-labs.com"
     ],
     "upsellit.com": [
       "samsung.com",
-      "garmin.com",
       "motorola.com"
-    ],
-    "uptolike.com": [
-      "live4fun.ru"
     ],
     "urbandictionary.store": [
       "urbandictionary.com"
     ],
     "usa.gov": [
-      "transportation.gov",
-      "dhs.gov",
-      "usembassy.gov"
-    ],
-    "useproof.com": [
-      "iconosquare.com"
+      "transportation.gov"
     ],
     "usergram.info": [
       "ocn.ne.jp"
     ],
-    "userreport.com": [
-      "scotsman.com"
-    ],
     "uservoice.com": [
-      "scoop.it",
-      "theknot.com"
+      "scoop.it"
     ],
     "ustream.tv": [
       "ibm.com"
@@ -7999,93 +9372,65 @@
       "radikal.ru"
     ],
     "utarget.ru": [
-      "radikal.ru",
-      "diary.ru"
+      "radikal.ru"
     ],
     "uuidksinc.net": [
-      "radikal.ru",
-      "diary.ru"
+      "radikal.ru"
     ],
-    "v12group.com": [
-      "tinyurl.com",
-      "shopko.com"
+    "v-biz.com.ua": [
+      "novostimira.com"
     ],
     "vanityfair.com": [
       "wired.com",
-      "newyorker.com",
       "vogue.com",
-      "gq.com",
       "pitchfork.com"
     ],
     "veinteractive.com": [
-      "prweb.com",
-      "logitech.com",
-      "wnd.com"
+      "prweb.com"
     ],
     "velaro.com": [
-      "lg.com",
-      "eff.org"
-    ],
-    "velemh.com": [
-      "liveuamap.com"
-    ],
-    "verticalhealth.net": [
-      "psychcentral.com"
-    ],
-    "veruta.com": [
-      "shopko.com"
+      "lg.com"
     ],
     "viafoura.co": [
       "cbc.ca",
-      "columbia.edu",
       "nj.com",
-      "nola.com"
+      "irishtimes.com"
+    ],
+    "viafoura.com": [
+      "irishtimes.com"
     ],
     "viafoura.net": [
       "cbc.ca"
     ],
-    "videoamp.com": [
-      "hpe.com"
-    ],
     "videohub.tv": [
-      "liveuamap.com",
       "wsj.com",
-      "uci.edu"
+      "bloomberg.com"
     ],
     "vidible.tv": [
+      "huffingtonpost.com",
       "aol.com",
-      "nydailynews.com",
-      "autoblog.com",
-      "techcrunch.com"
+      "autoblog.com"
     ],
     "viglink.com": [
-      "zdnet.com",
-      "softonic.com",
-      "techrepublic.com",
       "cnet.com",
-      "dailycaller.com"
+      "zdnet.com",
+      "thedailybeast.com"
     ],
     "vilynx.com": [
+      "cbsnews.com",
       "nbcnews.com",
-      "olympic.org",
-      "tmz.com"
+      "olympic.org"
     ],
     "vimeo.com": [
       "creativecommons.org",
       "dotdash.com",
-      "livestream.com",
       "wufoo.com",
-      "heroku.com",
-      "emarketer.com",
-      "designboom.com"
+      "oclc.org"
     ],
     "vindicosuite.com": [
       "myspace.com",
-      "fortune.com",
-      "people.com",
       "time.com",
-      "allrecipes.com",
-      "zappos.com"
+      "fortune.com"
     ],
     "virgilio.it": [
       "libero.it"
@@ -8093,67 +9438,38 @@
     "visualstudio.com": [
       "microsoft.com"
     ],
-    "vizury.com": [
-      "dreamstime.com"
-    ],
     "vk.com": [
-      "rt.com",
-      "templatemonster.com",
-      "ria.ru",
       "yandex.ru",
-      "sonymobile.com"
-    ],
-    "vmmpxl.com": [
-      "networksolutions.com"
+      "rt.com",
+      "ria.ru"
     ],
     "vogue.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
       "pitchfork.com"
-    ],
-    "volvelle.tech": [
-      "prweb.com",
-      "logitech.com"
     ],
     "voxmedia.com": [
       "theverge.com",
       "vox.com",
       "recode.net",
-      "sbnation.com",
       "polygon.com"
     ],
-    "vtracy.de": [
-      "bloomberg.com"
-    ],
-    "vulture.com": [
-      "nymag.com"
-    ],
     "w55c.net": [
-      "hpe.com",
-      "ebay.com",
-      "sourceforge.net",
-      "hp.com"
+      "forbes.com",
+      "hp.com",
+      "businessinsider.com"
+    ],
+    "wal.co": [
+      "walmart.com"
     ],
     "wallst.com": [
       "reuters.com"
     ],
-    "walmartimages.com": [
-      "walmart.com"
-    ],
-    "waptime.cn": [
-      "tianqi.com"
-    ],
-    "warnerbros.com": [
-      "tmz.com"
-    ],
     "wbtrk.net": [
-      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
     "wcfbc.net": [
+      "repubblica.it",
       "bild.de",
       "goethe.de"
     ],
@@ -8167,7 +9483,6 @@
     "weborama.fr": [
       "lemonde.fr",
       "rbc.ru",
-      "lexpress.fr",
       "leparisien.fr"
     ],
     "webpush.jp": [
@@ -8181,23 +9496,17 @@
       "freewebs.com"
     ],
     "webspectator.com": [
-      "goal.com",
-      "guinnessworldrecords.com"
+      "goal.com"
     ],
     "webtrekk.net": [
       "springer.com",
-      "localiser-ip.com",
-      "welt.de",
+      "repubblica.it",
       "goethe.de"
     ],
     "webtrendslive.com": [
-      "nature.com",
       "abc.net.au",
       "oup.com",
-      "dhl.com"
-    ],
-    "webvisor.org": [
-      "kharkov.ua"
+      "ethz.ch"
     ],
     "weibo.com": [
       "sina.com.cn"
@@ -8214,36 +9523,24 @@
     "wikimedia.org": [
       "wikipedia.org",
       "wiktionary.org",
-      "mediawiki.org",
-      "wikisource.org",
-      "wikibooks.org"
+      "wikisource.org"
     ],
     "wired.com": [
-      "newyorker.com",
-      "vanityfair.com",
       "vogue.com",
-      "gq.com",
       "pitchfork.com"
-    ],
-    "wise.space": [
-      "purevolume.com"
     ],
     "wishabi.com": [
       "nationalpost.com",
       "suntimes.com",
-      "canada.com",
       "globalnews.ca",
-      "bostonherald.com"
+      "vancouversun.com"
     ],
     "wishpond.com": [
       "discovermagazine.com"
     ],
-    "wishpond.net": [
-      "discovermagazine.com"
-    ],
     "wistia.com": [
-      "zendesk.com",
       "typeform.com",
+      "buffer.com",
       "photoshelter.com"
     ],
     "wistia.net": [
@@ -8253,20 +9550,16 @@
       "deviantart.com"
     ],
     "wkxppshj-qx.global.ssl.fastly.net": [
-      "upwork.com",
-      "zappos.com",
-      "redbubble.com"
+      "redbubble.com",
+      "upwork.com"
     ],
     "wmagazine.com": [
       "wired.com",
-      "newyorker.com",
-      "vanityfair.com",
-      "gq.com",
+      "vogue.com",
       "pitchfork.com"
     ],
     "wnyc.org": [
-      "newyorker.com",
-      "qq.com"
+      "newyorker.com"
     ],
     "wolfram.com": [
       "wolframalpha.com"
@@ -8275,256 +9568,146 @@
       "tinypic.com"
     ],
     "woopic.com": [
-      "orange.fr",
-      "2345.com"
+      "orange.fr"
     ],
     "wordpress.com": [
       "time.com",
-      "prnewswire.com",
-      "cbslocal.com",
       "fortune.com",
-      "akismet.com",
-      "nypost.com",
-      "news.com.au",
-      "variety.com"
+      "akismet.com"
     ],
     "wrating.com": [
-      "163.com",
       "jrj.com.cn",
       "weather.com.cn"
     ],
-    "wsj.com": [
+    "wsj.net": [
+      "wsj.com",
       "marketwatch.com"
     ],
-    "wsj.net": [
-      "marketwatch.com",
-      "sfgate.com",
-      "wsj.com"
-    ],
     "wsod.com": [
-      "seekingalpha.com",
       "zerohedge.com"
     ],
     "wt-eu02.net": [
-      "virgilio.it",
-      "libero.it"
-    ],
-    "wurfl.io": [
-      "dw.com",
-      "bartleby.com"
-    ],
-    "wywyuserservice.com": [
-      "vmware.com"
+      "libero.it",
+      "virgilio.it"
     ],
     "xad.com": [
       "vt.edu"
     ],
-    "xg4ken.com": [
-      "bluehost.com",
-      "redbubble.com"
-    ],
-    "xinhuanet.com": [
-      "news.cn"
-    ],
     "xiti.com": [
       "lemonde.fr",
-      "unblog.fr",
-      "uefa.com",
       "skyrock.com",
-      "ovh.com",
-      "leparisien.fr"
+      "faz.net"
     ],
     "xlisting.jp": [
-      "rakuten.co.jp",
-      "biglobe.ne.jp",
       "goo.ne.jp",
       "ocn.ne.jp"
     ],
     "xplosion.de": [
-      "t-online.de",
       "spiegel.de",
-      "faz.net",
-      "focus.de"
+      "sueddeutsche.de",
+      "zeit.de"
     ],
     "xs4all.net": [
       "xs4all.nl"
     ],
-    "xxxlutz.de": [
-      "t-online.de"
-    ],
     "yadro.ru": [
       "vk.com",
-      "novostimira.com",
       "mail.ru",
-      "narod.ru",
-      "ria.ru",
-      "radikal.ru"
+      "rt.com"
     ],
     "yahoo.co.jp": [
       "dropbox.com",
-      "exblog.jp",
-      "rakuten.co.jp",
       "economist.com",
-      "ocn.ne.jp"
+      "exblog.jp"
     ],
     "yahoo.com": [
-      "amazon.com",
       "vimeo.com",
-      "flickr.com",
-      "sourceforge.net",
-      "ancestry.com",
-      "eset.com"
+      "tumblr.com",
+      "flickr.com"
     ],
     "yandex.ru": [
-      "livejournal.com",
       "opera.com",
-      "stanford.edu",
-      "ning.com",
-      "ria.ru",
-      "qip.ru",
-      "radikal.ru",
-      "kharkov.ua"
-    ],
-    "yandex.ua": [
-      "kharkov.ua",
-      "kh.ua"
+      "livejournal.com",
+      "ning.com"
     ],
     "yastatic.net": [
-      "qip.ru",
-      "tass.ru",
-      "radikal.ru"
-    ],
-    "yieldify.com": [
-      "logitech.com"
+      "liveinternet.ru",
+      "sputniknews.com",
+      "ria.ru"
     ],
     "yieldlab.net": [
-      "spiegel.de",
-      "heise.de",
-      "faz.net",
+      "t-online.de",
       "springer.com",
-      "home.pl",
-      "focus.de"
+      "spiegel.de"
     ],
     "yieldoptimizer.com": [
-      "ihg.com",
-      "hyatt.com",
-      "philly.com"
+      "philly.com",
+      "groupon.com"
     ],
     "yimg.com": [
-      "yahoo.com",
       "flickr.com",
       "nytimes.com",
-      "dropbox.com",
-      "iop.org",
-      "cnet.com",
-      "sbs.com.au",
-      "eset.com"
+      "dropbox.com"
     ],
     "yldbt.com": [
-      "wired.com",
-      "arstechnica.com",
-      "newyorker.com",
-      "pcworld.com",
-      "infoworld.com"
-    ],
-    "ymetrica1.com": [
-      "kharkov.ua",
-      "kh.ua",
-      "ucoz.ru"
-    ],
-    "yoox.it": [
-      "net-a-porter.com"
-    ],
-    "yotpo.com": [
-      "gopro.com"
+      "biography.com",
+      "freep.com",
+      "jsonline.com"
     ],
     "youtube-nocookie.com": [
-      "epa.gov",
       "moodle.org",
       "popsci.com",
       "uscourts.gov"
     ],
     "youtube.com": [
-      "vimeo.com",
       "google.com",
-      "godaddy.com",
+      "mozilla.org",
       "nih.gov",
-      "telegraph.co.uk",
-      "caltech.edu",
-      "ucr.edu",
-      "onet.pl",
       "honeywell.com"
     ],
     "youvisit.com": [
       "osu.edu",
-      "oregonstate.edu",
       "fsu.edu"
     ],
     "ypcdn.com": [
       "yellowpages.com"
     ],
-    "yudu.co.nz": [
-      "nzherald.co.nz"
-    ],
     "zdbb.net": [
       "mashable.com",
       "pcmag.com",
-      "ign.com",
-      "everydayhealth.com"
+      "ign.com"
     ],
     "zedo.com": [
       "tinypic.com",
-      "thehindu.com",
-      "infoplease.com"
+      "thehindu.com"
     ],
     "zemanta.com": [
-      "independent.co.uk",
-      "thehill.com",
-      "farfetch.com",
-      "paypal.com",
-      "orange.fr",
-      "infoplease.com"
-    ],
-    "zendesk.com": [
-      "jugem.jp",
-      "in.gov",
-      "hobbyking.com"
+      "variety.com",
+      "lemonde.fr",
+      "standard.co.uk"
     ],
     "zergnet.com": [
       "imdb.com",
-      "pcmag.com",
-      "rollingstone.com",
-      "marketwatch.com"
-    ],
-    "zhaopin.cn": [
-      "zhaopin.com"
-    ],
-    "zhiziyun.com": [
-      "ctrip.com"
+      "marketwatch.com",
+      "weather.com"
     ],
     "zidtech.com": [
       "coindesk.com"
     ],
     "ziffdavis.com": [
-      "ign.com",
       "extremetech.com"
     ],
-    "zoho.com": [
-      "zoho.in"
-    ],
-    "zohopublic.com": [
-      "zoho.com"
-    ],
     "zoomph.com": [
-      "udel.edu",
-      "biglobe.ne.jp",
       "uga.edu"
     ],
     "zprk.io": [
       "news.com.au",
       "theaustralian.com.au",
       "heraldsun.com.au"
+    ],
+    "zynbit.com": [
+      "parallels.com"
     ]
   },
-  "version": "2018.8.27"
+  "version": "2018.9.26"
 }

--- a/results.json
+++ b/results.json
@@ -3,7 +3,7 @@
     "107-coj-713.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598197544,
+      "nextUpdateTime": 1535788795191,
       "userAction": ""
     },
     "112.2o7.net": {
@@ -27,31 +27,31 @@
     "194-vvc-221.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535671078852,
+      "nextUpdateTime": 1535401551141,
       "userAction": ""
     },
     "20798148p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535760970927,
+      "nextUpdateTime": 1535675926040,
       "userAction": ""
     },
     "2771890.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535477982326,
+      "nextUpdateTime": 1535526413536,
       "userAction": ""
     },
     "2912a.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535520902504,
+      "nextUpdateTime": 1535446296434,
       "userAction": ""
     },
     "2ecd5.v.fwmrm.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535508988871,
+      "nextUpdateTime": 1535464900319,
       "userAction": ""
     },
     "2o7.net": {
@@ -69,157 +69,163 @@
     "4272175.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535388856176,
+      "nextUpdateTime": 1535761492828,
       "userAction": ""
     },
     "4292932.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535492182388,
+      "nextUpdateTime": 1535388823758,
       "userAction": ""
     },
     "4303900.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535709815906,
+      "nextUpdateTime": 1535478816612,
       "userAction": ""
     },
     "4351288.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535690936934,
+      "nextUpdateTime": 1535759188077,
       "userAction": ""
     },
     "4635217.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535282712221,
+      "nextUpdateTime": 1535688182526,
       "userAction": ""
     },
     "4645712.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535642991767,
+      "nextUpdateTime": 1535386344298,
       "userAction": ""
     },
     "4d.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526803320,
+      "nextUpdateTime": 1535654852731,
       "userAction": ""
     },
     "516-dgm-318.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535662787551,
+      "nextUpdateTime": 1535777195298,
       "userAction": ""
     },
     "5420914.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535488582093,
+      "nextUpdateTime": 1535469873107,
       "userAction": ""
     },
     "5496506.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535328095043,
+      "nextUpdateTime": 1535673581756,
       "userAction": ""
     },
     "5779616.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535323766046,
+      "nextUpdateTime": 1535389517664,
       "userAction": ""
     },
     "6901690.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535614886406,
+      "nextUpdateTime": 1535862929541,
       "userAction": ""
     },
     "6954342.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535360379630,
+      "nextUpdateTime": 1535450680018,
       "userAction": ""
     },
     "8117415.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535440566618,
+      "nextUpdateTime": 1535699002706,
       "userAction": ""
     },
     "8242400.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535299551431,
+      "nextUpdateTime": 1535735755008,
       "userAction": ""
     },
     "8758559.fls.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535315581112,
+      "nextUpdateTime": 1535856801759,
       "userAction": ""
     },
     "899-ihp-202.mktoresp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535376693594,
+      "nextUpdateTime": 1535737606634,
       "userAction": ""
     },
     "a.postrelease.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535719315712,
+      "nextUpdateTime": 1535694525374,
       "userAction": ""
     },
     "a.rfihub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535589740320,
+      "nextUpdateTime": 1535541776370,
       "userAction": ""
     },
     "a.wishabi.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535470877593,
+      "nextUpdateTime": 1535586462406,
       "userAction": ""
     },
     "a2364010203.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535702667567,
+      "nextUpdateTime": 1535692286771,
       "userAction": ""
     },
     "a6250770393.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535724954686,
+      "nextUpdateTime": 1535584735036,
+      "userAction": ""
+    },
+    "a6264210458.cdn.optimizely.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535775205652,
       "userAction": ""
     },
     "a7718922374.cdn.optimizely.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535483154043,
+      "nextUpdateTime": 1535709114205,
       "userAction": ""
     },
     "aa.agkn.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535780115828,
+      "nextUpdateTime": 1535877883165,
       "userAction": ""
     },
     "aax-eu.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535779559578,
+      "nextUpdateTime": 1535710239051,
       "userAction": ""
     },
     "aax.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535412607145,
+      "nextUpdateTime": 1535526366481,
       "userAction": ""
     },
     "accounts.google.com": {
@@ -231,13 +237,13 @@
     "accounts.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434218229,
+      "nextUpdateTime": 1535397748018,
       "userAction": ""
     },
     "acdn.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535660982750,
+      "nextUpdateTime": 1535499002047,
       "userAction": ""
     },
     "acpm.fr": {
@@ -249,37 +255,37 @@
     "action.media6degrees.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535490888501,
+      "nextUpdateTime": 1535492709945,
       "userAction": ""
     },
     "activenetwork-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535404713512,
+      "nextUpdateTime": 1535703175969,
       "userAction": ""
     },
     "activenetworks-d.openx.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535641831031,
-      "userAction": ""
-    },
-    "ad-score.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535624113348,
       "userAction": ""
     },
     "ad.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535379331728,
+      "nextUpdateTime": 1535795181462,
+      "userAction": ""
+    },
+    "ad.turn.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535645779490,
       "userAction": ""
     },
     "ad.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535307543537,
+      "nextUpdateTime": 1535465359379,
       "userAction": ""
     },
     "addthis.com": {
@@ -315,7 +321,7 @@
     "ado.pro-market.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535527859438,
+      "nextUpdateTime": 1535496181306,
       "userAction": ""
     },
     "adroll.com": {
@@ -324,46 +330,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "ads.creative-serving.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535547437788,
+      "userAction": ""
+    },
     "ads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535445477120,
+      "nextUpdateTime": 1535622785616,
       "userAction": ""
     },
     "ads.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535585934820,
-      "userAction": ""
-    },
-    "ads.scorecardresearch.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535744320295,
+      "nextUpdateTime": 1535644312504,
       "userAction": ""
     },
     "ads.servebom.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535694008167,
+      "nextUpdateTime": 1535374198969,
+      "userAction": ""
+    },
+    "ads.twitter.com": {
+      "dnt": false,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1535698534424,
       "userAction": ""
     },
     "ads.yap.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535577473176,
+      "nextUpdateTime": 1535762468415,
       "userAction": ""
     },
     "adserver-us.adtech.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711402958,
+      "nextUpdateTime": 1535801173589,
       "userAction": ""
     },
     "adservice.google.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535726386777,
+      "nextUpdateTime": 1535805192169,
       "userAction": ""
     },
     "adsnative.com": {
@@ -398,8 +410,8 @@
     },
     "aimfar.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535609624527,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535411075710,
       "userAction": ""
     },
     "allure.com": {
@@ -423,31 +435,31 @@
     "ampcid.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535691963120,
+      "nextUpdateTime": 1535875271545,
       "userAction": ""
     },
     "amplify.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535516989467,
+      "nextUpdateTime": 1535627226385,
       "userAction": ""
     },
     "amplifypixel.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535284316576,
+      "nextUpdateTime": 1535453996514,
       "userAction": ""
     },
     "an.facebook.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535285639223,
+      "nextUpdateTime": 1535666267445,
       "userAction": ""
     },
     "analytics.twitter.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535540660259,
+      "nextUpdateTime": 1535406703135,
       "userAction": ""
     },
     "answerscloud.com": {
@@ -459,67 +471,61 @@
     "ap.lijit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535751809759,
+      "nextUpdateTime": 1535677918307,
       "userAction": ""
     },
     "apex.go.sonobi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535472792249,
+      "nextUpdateTime": 1535404214200,
       "userAction": ""
     },
     "api-iam.intercom.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535501927149,
-      "userAction": ""
-    },
-    "api-public.addthis.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535762945972,
+      "nextUpdateTime": 1535728889831,
       "userAction": ""
     },
     "api-v3.tinypass.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535704572492,
+      "nextUpdateTime": 1535824772269,
       "userAction": ""
     },
     "api.adsnative.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535558537040,
+      "nextUpdateTime": 1535869432705,
       "userAction": ""
     },
     "api.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535711849116,
+      "nextUpdateTime": 1535382298584,
       "userAction": ""
     },
     "api.flyertown.ca": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535630848647,
+      "nextUpdateTime": 1535785037169,
       "userAction": ""
     },
     "api.nanigans.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535780608617,
+      "nextUpdateTime": 1535718185775,
       "userAction": ""
     },
     "api.pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535442958777,
+      "nextUpdateTime": 1535527024950,
       "userAction": ""
     },
     "api.viglink.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535461454234,
+      "nextUpdateTime": 1535637161762,
       "userAction": ""
     },
     "apis.google.com": {
@@ -531,7 +537,7 @@
     "app.link": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535346277488,
+      "nextUpdateTime": 1535495358983,
       "userAction": ""
     },
     "architecturaldigest.com": {
@@ -543,7 +549,7 @@
     "as-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535661299224,
+      "nextUpdateTime": 1535541366255,
       "userAction": ""
     },
     "attservicesinc.tt.omtrdc.net": {
@@ -555,49 +561,49 @@
     "au.audience.newscgp.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535726850586,
+      "nextUpdateTime": 1535814559640,
       "userAction": ""
     },
     "au.pixel.newscgp.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535553365774,
+      "nextUpdateTime": 1535677376528,
       "userAction": ""
     },
     "b-code.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535469524850,
+      "nextUpdateTime": 1535872214563,
       "userAction": ""
     },
     "b.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535654763789,
+      "nextUpdateTime": 1535424935792,
       "userAction": ""
     },
     "b1sync.zemanta.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535637344742,
+      "nextUpdateTime": 1535376045654,
       "userAction": ""
     },
     "bam.nr-data.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535524792139,
+      "nextUpdateTime": 1535517044616,
       "userAction": ""
     },
     "bat.bing.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535726960200,
+      "nextUpdateTime": 1535856575288,
       "userAction": ""
     },
     "beacon.krxd.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535432389781,
+      "nextUpdateTime": 1535852563130,
       "userAction": ""
     },
     "bfmio.com": {
@@ -609,19 +615,19 @@
     "bh.contextweb.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535784224054,
+      "nextUpdateTime": 1535415374852,
       "userAction": ""
     },
     "bid.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535573293865,
+      "nextUpdateTime": 1535474628495,
       "userAction": ""
     },
     "bidder.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535551251160,
+      "nextUpdateTime": 1535431025536,
       "userAction": ""
     },
     "bidswitch.net": {
@@ -669,7 +675,7 @@
     "boxinc.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535478347303,
+      "nextUpdateTime": 1535712697947,
       "userAction": ""
     },
     "brides.com": {
@@ -681,61 +687,61 @@
     "bs.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535315840766,
+      "nextUpdateTime": 1535842806454,
       "userAction": ""
     },
     "btlr.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535306900694,
+      "nextUpdateTime": 1535399016694,
       "userAction": ""
     },
     "bttrack.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535302383139,
+      "nextUpdateTime": 1535736023435,
       "userAction": ""
     },
     "c.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535392133905,
+      "nextUpdateTime": 1535782500293,
       "userAction": ""
     },
     "c.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535503302723,
+      "nextUpdateTime": 1535392363633,
       "userAction": ""
     },
     "c.deployads.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535412362928,
+      "nextUpdateTime": 1535786966647,
       "userAction": ""
     },
     "c.liadm.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584173633,
+      "nextUpdateTime": 1535852907247,
       "userAction": ""
     },
     "c.statcounter.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535597776860,
+      "nextUpdateTime": 1535445294990,
       "userAction": ""
     },
     "c2.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535690141366,
+      "nextUpdateTime": 1535750341028,
       "userAction": ""
     },
     "cache.vindicosuite.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535279594967,
+      "nextUpdateTime": 1535798036507,
       "userAction": ""
     },
     "calendar.google.com": {
@@ -747,13 +753,13 @@
     "canwestglobal.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535327513388,
+      "nextUpdateTime": 1535524141208,
       "userAction": ""
     },
     "capture.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535568142694,
+      "nextUpdateTime": 1535434052072,
       "userAction": ""
     },
     "casalemedia.com": {
@@ -765,37 +771,31 @@
     "cdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517244578,
+      "nextUpdateTime": 1535430074265,
       "userAction": ""
     },
     "cdn.bizible.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535517807139,
+      "nextUpdateTime": 1535636853472,
       "userAction": ""
     },
     "cdn.digitru.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535755634406,
-      "userAction": ""
-    },
-    "cdn.inquisitr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535779331445,
+      "nextUpdateTime": 1535554773399,
       "userAction": ""
     },
     "cdn.justuno.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535713763814,
+      "nextUpdateTime": 1535689602008,
       "userAction": ""
     },
     "cdn.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535528231483,
+      "nextUpdateTime": 1535464365388,
       "userAction": ""
     },
     "cdn.native.ai": {
@@ -807,31 +807,31 @@
     "cdn.oas-c18.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535560444094,
+      "nextUpdateTime": 1535592534219,
       "userAction": ""
     },
     "cdn.taboola.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535368051541,
+      "nextUpdateTime": 1535840819214,
       "userAction": ""
     },
     "cdn.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535608113749,
+      "nextUpdateTime": 1535447686266,
       "userAction": ""
     },
     "cdn1-res.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535644505799,
+      "nextUpdateTime": 1535589550351,
       "userAction": ""
     },
     "cdns.gigya.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535455708662,
+      "nextUpdateTime": 1535647245640,
       "userAction": ""
     },
     "checkout.google.com": {
@@ -843,7 +843,7 @@
     "checkout.stripe.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535567467824,
+      "nextUpdateTime": 1535574432947,
       "userAction": ""
     },
     "clients1.google.com": {
@@ -861,13 +861,13 @@
     "cm.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535483839903,
+      "nextUpdateTime": 1535663337899,
       "userAction": ""
     },
     "cnid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535365976800,
+      "nextUpdateTime": 1535553091314,
       "userAction": ""
     },
     "cntraveler.com": {
@@ -879,7 +879,7 @@
     "collecte.audience.acpm.fr": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535444044156,
+      "nextUpdateTime": 1535827604724,
       "userAction": ""
     },
     "company-target.com": {
@@ -891,7 +891,7 @@
     "condenast.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535682892731,
+      "nextUpdateTime": 1535374260391,
       "userAction": ""
     },
     "condenastdigital.com": {
@@ -903,7 +903,7 @@
     "connect.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535296279568,
+      "nextUpdateTime": 1535847059054,
       "userAction": ""
     },
     "consensu.org": {
@@ -921,13 +921,13 @@
     "consumer.krxd.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535506369860,
+      "nextUpdateTime": 1535761812068,
       "userAction": ""
     },
     "contextual.media.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535701071745,
+      "nextUpdateTime": 1535878685866,
       "userAction": ""
     },
     "contextweb.com": {
@@ -939,12 +939,18 @@
     "counter.yadro.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535424975290,
+      "nextUpdateTime": 1535679702748,
       "userAction": ""
     },
     "cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "creative-serving.com": {
+      "dnt": false,
+      "heuristicAction": "allow",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -960,10 +966,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "csm2waycm-atl.netmng.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535410980550,
+      "userAction": ""
+    },
     "cstatic.weborama.fr": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535762279418,
+      "nextUpdateTime": 1535439755325,
       "userAction": ""
     },
     "cxense.com": {
@@ -975,73 +987,67 @@
     "d.adroll.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535342840522,
+      "nextUpdateTime": 1535430010745,
       "userAction": ""
     },
     "d.agkn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535565611927,
+      "nextUpdateTime": 1535878099411,
       "userAction": ""
     },
     "d.company-target.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535713060726,
+      "nextUpdateTime": 1535631040531,
       "userAction": ""
     },
     "d.df-srv.de": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535364087304,
+      "nextUpdateTime": 1535827462928,
       "userAction": ""
     },
     "d.la1-c2-dfw.salesforceliveagent.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535674921575,
+      "nextUpdateTime": 1535848586849,
       "userAction": ""
     },
     "d.turn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535487468755,
+      "nextUpdateTime": 1535668347467,
       "userAction": ""
     },
     "d3kkw-y716t.ads.tremorhub.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606881689,
-      "userAction": ""
-    },
-    "data.ad-score.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535303631043,
+      "nextUpdateTime": 1535504240917,
       "userAction": ""
     },
     "datacloud-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535379877739,
+      "nextUpdateTime": 1535749458146,
       "userAction": ""
     },
     "datacloud.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535357000518,
+      "nextUpdateTime": 1535454047672,
       "userAction": ""
     },
     "dc.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535668414319,
+      "nextUpdateTime": 1535863673793,
       "userAction": ""
     },
     "de.ioam.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535731438109,
+      "nextUpdateTime": 1535379626780,
       "userAction": ""
     },
     "deepintent.com": {
@@ -1083,19 +1089,19 @@
     "dis.us.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535432116374,
+      "nextUpdateTime": 1535628369138,
       "userAction": ""
     },
     "display.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535319875858,
+      "nextUpdateTime": 1535449581444,
       "userAction": ""
     },
     "districtm-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535721504755,
+      "nextUpdateTime": 1535854298539,
       "userAction": ""
     },
     "districtm.io": {
@@ -1107,7 +1113,7 @@
     "dmx.districtm.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535293970894,
+      "nextUpdateTime": 1535378721840,
       "userAction": ""
     },
     "docs.google.com": {
@@ -1131,7 +1137,7 @@
     "dpm.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535778123280,
+      "nextUpdateTime": 1535831172248,
       "userAction": ""
     },
     "drive.google.com": {
@@ -1143,19 +1149,13 @@
     "dsum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535544929225,
+      "nextUpdateTime": 1535678767436,
       "userAction": ""
     },
     "dsum.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535728636063,
-      "userAction": ""
-    },
-    "dxpmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535609816884,
       "userAction": ""
     },
     "dynamicyield.com": {
@@ -1167,7 +1167,7 @@
     "eb2.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535569655087,
+      "nextUpdateTime": 1535722569370,
       "userAction": ""
     },
     "ebayrtm.com": {
@@ -1179,7 +1179,7 @@
     "edge.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535525806664,
+      "nextUpdateTime": 1535753398903,
       "userAction": ""
     },
     "effectivemeasure.net": {
@@ -1203,19 +1203,19 @@
     "eset.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535726564765,
+      "nextUpdateTime": 1535856865212,
       "userAction": ""
     },
     "eus.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535399555453,
+      "nextUpdateTime": 1535641546461,
       "userAction": ""
     },
     "events.mediarithmics.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535428968914,
+      "nextUpdateTime": 1535653806247,
       "userAction": ""
     },
     "everesttech.net": {
@@ -1227,7 +1227,7 @@
     "everydayhealth.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535403017484,
+      "nextUpdateTime": 1535738201505,
       "userAction": ""
     },
     "exelator.com": {
@@ -1239,7 +1239,7 @@
     "experience.tinypass.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535646811319,
+      "nextUpdateTime": 1535558917724,
       "userAction": ""
     },
     "eyeota.net": {
@@ -1250,7 +1250,7 @@
     },
     "eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
@@ -1263,13 +1263,13 @@
     "fastlane-adv.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535725073044,
+      "nextUpdateTime": 1535510602994,
       "userAction": ""
     },
     "fastlane.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535696802415,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535503704591,
       "userAction": ""
     },
     "feedburner.google.com": {
@@ -1293,13 +1293,13 @@
     "foxnet.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535786271610,
+      "nextUpdateTime": 1535786137485,
       "userAction": ""
     },
     "freestar-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535281885570,
+      "nextUpdateTime": 1535672050463,
       "userAction": ""
     },
     "fusiontables.google.com": {
@@ -1314,58 +1314,58 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "g.cn.miaozhen.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535453186928,
+      "userAction": ""
+    },
     "g2.gumgum.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535692750885,
+      "nextUpdateTime": 1535882689211,
       "userAction": ""
     },
     "gads.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535691303682,
+      "nextUpdateTime": 1535656273590,
       "userAction": ""
     },
     "gakogedifoda.ru": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535691097103,
+      "nextUpdateTime": 1535727758035,
       "userAction": ""
     },
     "gannett-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535545531677,
+      "nextUpdateTime": 1535797268646,
       "userAction": ""
     },
     "gannett.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535587812182,
+      "nextUpdateTime": 1535705787427,
       "userAction": ""
     },
     "gannett.hb.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535649331173,
+      "nextUpdateTime": 1535540739730,
       "userAction": ""
     },
     "gateway.answerscloud.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535491753062,
+      "nextUpdateTime": 1535730629382,
       "userAction": ""
     },
     "geolocation.onetrust.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535307250586,
-      "userAction": ""
-    },
-    "geosync.solution.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535284522122,
+      "nextUpdateTime": 1535626747902,
       "userAction": ""
     },
     "gigya.com": {
@@ -1401,7 +1401,7 @@
     "googleads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535317462506,
+      "nextUpdateTime": 1535826656370,
       "userAction": ""
     },
     "gq.com": {
@@ -1413,7 +1413,7 @@
     "graph.facebook.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535648552872,
+      "nextUpdateTime": 1535759414387,
       "userAction": ""
     },
     "groups.google.com": {
@@ -1425,19 +1425,19 @@
     "gscounters.us1.gigya.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535453629901,
+      "nextUpdateTime": 1535507099814,
       "userAction": ""
     },
     "gslbeacon.lijit.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535367472545,
+      "nextUpdateTime": 1535649797924,
       "userAction": ""
     },
     "gum.criteo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535629285942,
+      "nextUpdateTime": 1535648232623,
       "userAction": ""
     },
     "gumgum.com": {
@@ -1455,49 +1455,49 @@
     "hbopenbid.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535465563548,
+      "nextUpdateTime": 1535553980236,
       "userAction": ""
     },
     "hpr.outbrain.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535418833610,
+      "nextUpdateTime": 1535743743028,
       "userAction": ""
     },
     "i.liadm.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535364247788,
+      "nextUpdateTime": 1535512774273,
       "userAction": ""
     },
     "i.po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535423720799,
+      "nextUpdateTime": 1535584943973,
       "userAction": ""
     },
     "ib.3lift.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418433351,
+      "nextUpdateTime": 1535787032117,
       "userAction": ""
     },
     "ib.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535791087893,
+      "nextUpdateTime": 1535513900580,
       "userAction": ""
     },
     "ic.tynt.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535533568374,
+      "nextUpdateTime": 1535842083486,
       "userAction": ""
     },
     "id.rlcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535505218565,
+      "nextUpdateTime": 1535758065418,
       "userAction": ""
     },
     "imrworldwide.com": {
@@ -1509,19 +1509,13 @@
     "infinityid.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535334042860,
-      "userAction": ""
-    },
-    "inquisitr.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1535808038725,
       "userAction": ""
     },
     "insight.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535515823670,
+      "nextUpdateTime": 1535671726914,
       "userAction": ""
     },
     "insightexpressai.com": {
@@ -1533,7 +1527,7 @@
     "insticator-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535619321717,
+      "nextUpdateTime": 1535612904028,
       "userAction": ""
     },
     "intercom.io": {
@@ -1545,7 +1539,13 @@
     "investing-channel-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535538084696,
+      "nextUpdateTime": 1535735061426,
+      "userAction": ""
+    },
+    "io.narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 1535606837889,
       "userAction": ""
     },
     "ioam.de": {
@@ -1563,13 +1563,13 @@
     "ips-invite.iperceptions.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535461878087,
+      "nextUpdateTime": 1535375027028,
       "userAction": ""
     },
     "jadserve.postrelease.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535692870860,
+      "nextUpdateTime": 1535770127897,
       "userAction": ""
     },
     "js.matheranalytics.com": {
@@ -1668,12 +1668,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "live.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -1689,61 +1683,49 @@
     "load77.exelator.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535681411551,
+      "nextUpdateTime": 1535428983326,
       "userAction": ""
     },
     "loadm.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535321905319,
+      "nextUpdateTime": 1535568292353,
       "userAction": ""
     },
     "loadus.exelator.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535566793461,
+      "nextUpdateTime": 1535748410763,
       "userAction": ""
     },
     "log.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418449649,
+      "nextUpdateTime": 1535370949838,
       "userAction": ""
     },
     "login-ds.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535561002865,
+      "nextUpdateTime": 1535825469673,
       "userAction": ""
     },
     "login.dotomi.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535755600759,
-      "userAction": ""
-    },
-    "login.live.com": {
-      "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535388260240,
+      "nextUpdateTime": 1535874272649,
       "userAction": ""
     },
     "logp2.xiti.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535584230515,
+      "nextUpdateTime": 1535689077144,
       "userAction": ""
     },
     "m.addthis.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535708708425,
-      "userAction": ""
-    },
-    "map.dxpmedia.com": {
-      "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535628695462,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535461732087,
       "userAction": ""
     },
     "maps-api-ssl.google.com": {
@@ -1767,19 +1749,19 @@
     "match.adsrvr.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535652945157,
+      "nextUpdateTime": 1535538905152,
       "userAction": ""
     },
     "match.deepintent.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535460992471,
+      "nextUpdateTime": 1535666184280,
       "userAction": ""
     },
     "match.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535663791310,
+      "nextUpdateTime": 1535472065106,
       "userAction": ""
     },
     "mathtag.com": {
@@ -1791,13 +1773,13 @@
     "mc.webvisor.org": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535286232291,
+      "nextUpdateTime": 1535487104791,
       "userAction": ""
     },
     "mc.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535536846686,
+      "nextUpdateTime": 1535384523811,
       "userAction": ""
     },
     "media.net": {
@@ -1815,7 +1797,7 @@
     "mediadc-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535302299674,
+      "nextUpdateTime": 1535521562609,
       "userAction": ""
     },
     "mediarithmics.com": {
@@ -1824,16 +1806,16 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "messenger.live.com": {
+    "miaozhen.com": {
       "dnt": false,
-      "heuristicAction": "cookieblock",
+      "heuristicAction": "block",
       "nextUpdateTime": 0,
       "userAction": ""
     },
     "mid.rkdms.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606263682,
+      "nextUpdateTime": 1535678969255,
       "userAction": ""
     },
     "mktoresp.com": {
@@ -1845,7 +1827,7 @@
     "ml314.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535387249359,
+      "nextUpdateTime": 1535583104262,
       "userAction": ""
     },
     "mt0.google.com": {
@@ -1896,10 +1878,22 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
+    "narrative.io": {
+      "dnt": false,
+      "heuristicAction": "allow",
+      "nextUpdateTime": 0,
+      "userAction": ""
+    },
     "native.sharethrough.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535381874834,
+      "nextUpdateTime": 1535370153417,
+      "userAction": ""
+    },
+    "netmng.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 0,
       "userAction": ""
     },
     "newscgp.com": {
@@ -1911,7 +1905,7 @@
     "newscorpau.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535311629687,
+      "nextUpdateTime": 1535570964190,
       "userAction": ""
     },
     "newyorker.com": {
@@ -1923,13 +1917,13 @@
     "nexus-websocket-a.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535376489955,
+      "nextUpdateTime": 1535589900794,
       "userAction": ""
     },
     "nexus-websocket-b.intercom.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535418451285,
+      "nextUpdateTime": 1535639927435,
       "userAction": ""
     },
     "nr-data.net": {
@@ -1941,7 +1935,7 @@
     "oclc.112.2o7.net": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535785645386,
+      "nextUpdateTime": 1535764787069,
       "userAction": ""
     },
     "omtrdc.net": {
@@ -1971,7 +1965,7 @@
     "optimize-stats.voxmedia.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535785571775,
+      "nextUpdateTime": 1535776170008,
       "userAction": ""
     },
     "optimizely.com": {
@@ -1995,43 +1989,43 @@
     "p.adsymptotic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535329796782,
+      "nextUpdateTime": 1535464989725,
       "userAction": ""
     },
     "p.cpx.to": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535520890292,
+      "nextUpdateTime": 1535587202023,
       "userAction": ""
     },
     "p.dlx.addthis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389036499,
+      "nextUpdateTime": 1535753838397,
       "userAction": ""
     },
     "p.rfihub.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535511748310,
+      "nextUpdateTime": 1535599122136,
       "userAction": ""
     },
     "p.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535711083150,
+      "nextUpdateTime": 1535416241814,
       "userAction": ""
     },
     "p.yieldlab.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535505388228,
+      "nextUpdateTime": 1535444945040,
       "userAction": ""
     },
     "p2.keywee.co": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535641328780,
+      "nextUpdateTime": 1535521835134,
       "userAction": ""
     },
     "pardot.com": {
@@ -2049,19 +2043,19 @@
     "pbid.pro-market.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535336231323,
+      "nextUpdateTime": 1535764673436,
       "userAction": ""
     },
     "pd.sharethis.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535496198612,
+      "nextUpdateTime": 1535470402299,
       "userAction": ""
     },
     "pi.pardot.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535546381760,
+      "nextUpdateTime": 1535690679472,
       "userAction": ""
     },
     "picasaweb.google.com": {
@@ -2079,73 +2073,73 @@
     "pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535775677065,
+      "nextUpdateTime": 1535419137841,
       "userAction": ""
     },
     "pixel-geo.prfct.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535759777976,
+      "nextUpdateTime": 1535473701074,
       "userAction": ""
     },
     "pixel.advertising.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535462179315,
+      "nextUpdateTime": 1535791753209,
       "userAction": ""
     },
     "pixel.condenastdigital.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535427198698,
+      "nextUpdateTime": 1535454724028,
       "userAction": ""
     },
     "pixel.keywee.co": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535373297517,
+      "nextUpdateTime": 1535584375101,
       "userAction": ""
     },
     "pixel.mathtag.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535355242307,
+      "nextUpdateTime": 1535431775060,
       "userAction": ""
     },
     "pixel.quantserve.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535647714316,
+      "nextUpdateTime": 1535470366014,
       "userAction": ""
     },
     "pixel.rubiconproject.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535525085673,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535494298982,
       "userAction": ""
     },
     "pixel.sitescout.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535665286918,
+      "nextUpdateTime": 1535827732761,
       "userAction": ""
     },
     "pixel.tapad.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535312220420,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535550390073,
       "userAction": ""
     },
     "pixeltrack.eyeviewads.com": {
       "dnt": false,
-      "heuristicAction": "allow",
-      "nextUpdateTime": 1535543028633,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535443656582,
       "userAction": ""
     },
     "platform.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535298519588,
+      "nextUpdateTime": 1535862853985,
       "userAction": ""
     },
     "platform.twitter.com": {
@@ -2163,13 +2157,13 @@
     "player.vimeo.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535737640371,
+      "nextUpdateTime": 1535634741658,
       "userAction": ""
     },
     "playwire-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535668829519,
+      "nextUpdateTime": 1535602138418,
       "userAction": ""
     },
     "plus.google.com": {
@@ -2181,13 +2175,13 @@
     "po.st": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535606931325,
+      "nextUpdateTime": 1535694456088,
       "userAction": ""
     },
     "postmedia.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535421638602,
+      "nextUpdateTime": 1535608927078,
       "userAction": ""
     },
     "postrelease.com": {
@@ -2199,7 +2193,7 @@
     "pr-bh.ybp.yahoo.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535293929134,
+      "nextUpdateTime": 1535721998785,
       "userAction": ""
     },
     "prfct.co": {
@@ -2217,25 +2211,25 @@
     "profile.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535623328400,
+      "nextUpdateTime": 1535868066793,
       "userAction": ""
     },
     "proximus.demdex.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535551954716,
+      "nextUpdateTime": 1535775857188,
       "userAction": ""
     },
     "ps.eyeota.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535593545310,
+      "nextUpdateTime": 1535440273805,
       "userAction": ""
     },
     "pubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535583692664,
+      "nextUpdateTime": 1535537986452,
       "userAction": ""
     },
     "pubmatic.com": {
@@ -2247,49 +2241,55 @@
     "purch-match.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535370162061,
+      "nextUpdateTime": 1535447877021,
+      "userAction": ""
+    },
+    "purch-sync.go.sonobi.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535442782846,
       "userAction": ""
     },
     "px.ads.linkedin.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535542087750,
+      "nextUpdateTime": 1535475285092,
       "userAction": ""
     },
     "px.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535646457589,
+      "nextUpdateTime": 1535501609306,
       "userAction": ""
     },
     "px.owneriq.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535403538242,
+      "nextUpdateTime": 1535800014348,
       "userAction": ""
     },
     "px.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535353388308,
+      "nextUpdateTime": 1535366852912,
       "userAction": ""
     },
     "pymx5.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535419488708,
+      "nextUpdateTime": 1535668867614,
       "userAction": ""
     },
     "q.quora.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535369878735,
+      "nextUpdateTime": 1535644633942,
       "userAction": ""
     },
     "qcx.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535360796345,
+      "nextUpdateTime": 1535552433183,
       "userAction": ""
     },
     "quantserve.com": {
@@ -2307,7 +2307,7 @@
     "r.skimresources.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535352011476,
+      "nextUpdateTime": 1535814046934,
       "userAction": ""
     },
     "rambler.ru": {
@@ -2319,31 +2319,31 @@
     "rand.d1.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535286295528,
+      "nextUpdateTime": 1535373600303,
       "userAction": ""
     },
     "rcom.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535306518026,
+      "nextUpdateTime": 1535496894433,
       "userAction": ""
     },
     "reachms.bfmio.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535694908698,
+      "nextUpdateTime": 1535666183003,
       "userAction": ""
     },
     "registercom.sc.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535378845796,
+      "nextUpdateTime": 1535584949059,
       "userAction": ""
     },
     "registercom.tt.omtrdc.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535430722611,
+      "nextUpdateTime": 1535711947766,
       "userAction": ""
     },
     "rfihub.com": {
@@ -2366,20 +2366,20 @@
     },
     "rp.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535722022072,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535845692253,
       "userAction": ""
     },
     "rs.gwallet.com": {
       "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535789545771,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535583943990,
       "userAction": ""
     },
     "rtb.districtm.io": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535426725737,
+      "nextUpdateTime": 1535699311885,
       "userAction": ""
     },
     "rubiconproject.com": {
@@ -2397,79 +2397,73 @@
     "s.adroll.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535544352908,
+      "nextUpdateTime": 1535807522405,
       "userAction": ""
     },
     "s.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535604512693,
+      "nextUpdateTime": 1535399131116,
       "userAction": ""
     },
     "s.cpx.to": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535629576922,
+      "nextUpdateTime": 1535856992384,
       "userAction": ""
     },
     "s.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535598595757,
+      "nextUpdateTime": 1535407116454,
       "userAction": ""
     },
     "s.jsrdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535337571271,
+      "nextUpdateTime": 1535517735871,
       "userAction": ""
     },
     "s.po.st": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535309914794,
+      "nextUpdateTime": 1535601704447,
       "userAction": ""
     },
     "s.skimresources.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535468509231,
+      "nextUpdateTime": 1535470740234,
       "userAction": ""
     },
     "s.thebrighttag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535566474727,
-      "userAction": ""
-    },
-    "s.yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535661147872,
+      "nextUpdateTime": 1535548076811,
       "userAction": ""
     },
     "s1061485456.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535527772076,
+      "nextUpdateTime": 1535650294754,
       "userAction": ""
     },
     "s118899503.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535375732663,
+      "nextUpdateTime": 1535442162234,
       "userAction": ""
     },
     "s2208.t.eloqua.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535418939591,
+      "nextUpdateTime": 1535683133775,
       "userAction": ""
     },
     "s7.addthis.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535312742531,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535436416136,
       "userAction": ""
     },
     "salesforceliveagent.com": {
@@ -2481,25 +2475,25 @@
     "sb-stage.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535671086115,
+      "nextUpdateTime": 1535554044154,
       "userAction": ""
     },
     "sb.scorecardresearch.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535415217899,
+      "nextUpdateTime": 1535640650960,
       "userAction": ""
     },
     "sbnationbidder-d.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535520014307,
+      "nextUpdateTime": 1535622073754,
       "userAction": ""
     },
     "scdn.cxense.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535492741324,
+      "nextUpdateTime": 1535641445518,
       "userAction": ""
     },
     "scorecardresearch.com": {
@@ -2511,7 +2505,7 @@
     "scripps.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535722846588,
+      "nextUpdateTime": 1535699162400,
       "userAction": ""
     },
     "script.ioam.de": {
@@ -2523,7 +2517,7 @@
     "search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535778464447,
+      "nextUpdateTime": 1535406047367,
       "userAction": ""
     },
     "search.yahoo.com": {
@@ -2535,85 +2529,85 @@
     "seccdn-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535511738519,
+      "nextUpdateTime": 1535475183501,
       "userAction": ""
     },
     "secfld.vmmpxl.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535642980054,
+      "nextUpdateTime": 1535590066515,
       "userAction": ""
     },
     "secure-assets.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535738150884,
+      "nextUpdateTime": 1535681640966,
       "userAction": ""
     },
     "secure-ds.serving-sys.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535510232378,
+      "nextUpdateTime": 1535516546452,
       "userAction": ""
     },
     "secure-gl.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535389044916,
+      "nextUpdateTime": 1535508368840,
       "userAction": ""
     },
     "secure-it.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535444722549,
+      "nextUpdateTime": 1535791057311,
       "userAction": ""
     },
     "secure-us.imrworldwide.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535337220991,
+      "nextUpdateTime": 1535711269325,
       "userAction": ""
     },
     "secure.adnxs.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535346501751,
+      "nextUpdateTime": 1535537879488,
       "userAction": ""
     },
     "secure.insightexpressai.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535490196521,
+      "nextUpdateTime": 1535460219033,
       "userAction": ""
     },
     "secure.livechatinc.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535340041154,
+      "nextUpdateTime": 1535643556045,
       "userAction": ""
     },
     "secure.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535662738397,
+      "nextUpdateTime": 1535879474697,
       "userAction": ""
     },
     "securepubads.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535494946898,
+      "nextUpdateTime": 1535619679394,
       "userAction": ""
     },
     "segapi.quantserve.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535708162903,
+      "nextUpdateTime": 1535654613358,
       "userAction": ""
     },
     "segments.company-target.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535436904126,
+      "nextUpdateTime": 1535573504719,
       "userAction": ""
     },
     "self.com": {
@@ -2649,7 +2643,7 @@
     "simage2.pubmatic.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535443540105,
+      "nextUpdateTime": 1535633318133,
       "userAction": ""
     },
     "siteimprove.com": {
@@ -2679,7 +2673,7 @@
     "smartlock.google.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535591895325,
+      "nextUpdateTime": 1535372330669,
       "userAction": ""
     },
     "snapchat.com": {
@@ -2703,7 +2697,7 @@
     "sp.analytics.yahoo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535500469983,
+      "nextUpdateTime": 1535631243909,
       "userAction": ""
     },
     "spotxchange.com": {
@@ -2718,52 +2712,52 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "srv-2018-08-25-09.config.parsely.com": {
+    "srv-2018-08-26-09.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535320516701,
+      "nextUpdateTime": 1535415293805,
       "userAction": ""
     },
-    "srv-2018-08-25-09.pixel.parsely.com": {
+    "srv-2018-08-26-09.pixel.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535492273466,
+      "nextUpdateTime": 1535541971804,
       "userAction": ""
     },
-    "srv-2018-08-25-10.config.parsely.com": {
+    "srv-2018-08-26-10.config.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535675261339,
+      "nextUpdateTime": 1535427058911,
       "userAction": ""
     },
     "srv.au.ebayrtm.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535327444761,
+      "nextUpdateTime": 1535673135301,
       "userAction": ""
     },
     "ssl.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535590743011,
+      "nextUpdateTime": 1535545018325,
       "userAction": ""
     },
     "sslwidget.criteo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535583569862,
+      "nextUpdateTime": 1535743749252,
       "userAction": ""
     },
     "ssum-sec.casalemedia.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535766135977,
+      "nextUpdateTime": 1535749834287,
       "userAction": ""
     },
     "st.dynamicyield.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535591035984,
+      "nextUpdateTime": 1535393160160,
       "userAction": ""
     },
     "statcounter.com": {
@@ -2781,19 +2775,19 @@
     "static.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535419436462,
+      "nextUpdateTime": 1535471382942,
       "userAction": ""
     },
     "static.parsely.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535526724439,
+      "nextUpdateTime": 1535539060159,
       "userAction": ""
     },
     "static.quantcast.mgr.consensu.org": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535354675061,
+      "nextUpdateTime": 1535587267608,
       "userAction": ""
     },
     "staticxx.facebook.com": {
@@ -2805,13 +2799,13 @@
     "stats.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535449503047,
+      "nextUpdateTime": 1535416632424,
       "userAction": ""
     },
     "statse.webtrendslive.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535353496047,
+      "nextUpdateTime": 1535669657331,
       "userAction": ""
     },
     "steelhousemedia.com": {
@@ -2829,7 +2823,7 @@
     "sumo.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535385706713,
+      "nextUpdateTime": 1535410096945,
       "userAction": ""
     },
     "sundaysky.com": {
@@ -2841,67 +2835,61 @@
     "survey.g.doubleclick.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535466735514,
+      "nextUpdateTime": 1535775576457,
       "userAction": ""
     },
     "sw88.go.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535402210709,
+      "nextUpdateTime": 1535509470133,
       "userAction": ""
     },
     "sync-tm.everesttech.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535601519697,
+      "nextUpdateTime": 1535599232106,
       "userAction": ""
     },
     "sync.adaptv.advertising.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535354555122,
+      "nextUpdateTime": 1535727505148,
       "userAction": ""
     },
     "sync.adkernel.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535721836756,
+      "nextUpdateTime": 1535386374072,
       "userAction": ""
     },
     "sync.bfmio.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535707308539,
-      "userAction": ""
-    },
-    "sync.go.sonobi.com": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535279621142,
+      "nextUpdateTime": 1535823492565,
       "userAction": ""
     },
     "sync.mathtag.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535481640591,
+      "nextUpdateTime": 1535499554312,
       "userAction": ""
     },
     "sync.multiview.com": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535782023227,
+      "nextUpdateTime": 1535446837680,
       "userAction": ""
     },
     "sync.search.spotxchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535286963228,
+      "nextUpdateTime": 1535533239526,
       "userAction": ""
     },
     "sync.teads.tv": {
       "dnt": false,
       "heuristicAction": "allow",
-      "nextUpdateTime": 1535597792238,
+      "nextUpdateTime": 1535693045071,
       "userAction": ""
     },
     "syndication.twitter.com": {
@@ -2919,7 +2907,7 @@
     "tag.bounceexchange.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535325417249,
+      "nextUpdateTime": 1535695664896,
       "userAction": ""
     },
     "talkgadget.google.com": {
@@ -2931,13 +2919,19 @@
     "tap-secure.rubiconproject.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535448475939,
+      "nextUpdateTime": 1535750776402,
       "userAction": ""
     },
     "tapad.com": {
       "dnt": false,
       "heuristicAction": "block",
       "nextUpdateTime": 0,
+      "userAction": ""
+    },
+    "tapestry.tapad.com": {
+      "dnt": false,
+      "heuristicAction": "block",
+      "nextUpdateTime": 1535791510610,
       "userAction": ""
     },
     "teads.tv": {
@@ -2973,13 +2967,13 @@
     "thunder.adnxs.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535452783142,
+      "nextUpdateTime": 1535800953607,
       "userAction": ""
     },
     "timeuk.demdex.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535746635108,
+      "nextUpdateTime": 1535498571655,
       "userAction": ""
     },
     "tinypass.com": {
@@ -2991,7 +2985,7 @@
     "tlx.3lift.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535550935721,
+      "nextUpdateTime": 1535433221586,
       "userAction": ""
     },
     "tns-counter.ru": {
@@ -3003,19 +2997,25 @@
     "top100.rambler.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535684529979,
+      "nextUpdateTime": 1535878948535,
+      "userAction": ""
+    },
+    "tr.outbrain.com": {
+      "dnt": false,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535529445629,
       "userAction": ""
     },
     "tr.snapchat.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535544639408,
+      "nextUpdateTime": 1535691727010,
       "userAction": ""
     },
     "track.adform.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535567234151,
+      "nextUpdateTime": 1535502278546,
       "userAction": ""
     },
     "translate.google.com": {
@@ -3027,7 +3027,7 @@
     "trc.taboola.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535732628184,
+      "nextUpdateTime": 1535381700109,
       "userAction": ""
     },
     "tremorhub.com": {
@@ -3045,7 +3045,7 @@
     "tt.onthe.io": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535545230967,
+      "nextUpdateTime": 1535459821318,
       "userAction": ""
     },
     "turn.com": {
@@ -3069,37 +3069,37 @@
     "u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535784547100,
+      "nextUpdateTime": 1535420971761,
       "userAction": ""
     },
     "ups.xplosion.de": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535314703086,
+      "nextUpdateTime": 1535483153937,
       "userAction": ""
     },
     "us-u.openx.net": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535688937954,
+      "nextUpdateTime": 1535571457788,
       "userAction": ""
     },
     "us4.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535597114866,
+      "nextUpdateTime": 1535862306211,
       "userAction": ""
     },
     "us5.siteimprove.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535432676742,
+      "nextUpdateTime": 1535560041560,
       "userAction": ""
     },
     "va.v.liveperson.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535729794135,
+      "nextUpdateTime": 1535510754633,
       "userAction": ""
     },
     "vanityfair.com": {
@@ -3135,7 +3135,7 @@
     "visitor-service-us-east-1.tealiumiq.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535434926452,
+      "nextUpdateTime": 1535374260274,
       "userAction": ""
     },
     "vmmpxl.com": {
@@ -3147,7 +3147,7 @@
     "vmss.boldchat.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535472656099,
+      "nextUpdateTime": 1535879370927,
       "userAction": ""
     },
     "vogue.com": {
@@ -3159,7 +3159,7 @@
     "vop.sundaysky.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535338852200,
+      "nextUpdateTime": 1535532865527,
       "userAction": ""
     },
     "voxmedia.com": {
@@ -3171,25 +3171,19 @@
     "w.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535690600138,
-      "userAction": ""
-    },
-    "wam-yahoo.solution.weborama.fr": {
-      "dnt": false,
-      "heuristicAction": "",
-      "nextUpdateTime": 1535775196955,
+      "nextUpdateTime": 1535786495983,
       "userAction": ""
     },
     "wamfactory.solution.weborama.fr": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 1535325407427,
+      "heuristicAction": "",
+      "nextUpdateTime": 1535427771016,
       "userAction": ""
     },
     "web.hb.ad.cpe.dotomi.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535709876484,
+      "nextUpdateTime": 1535518923351,
       "userAction": ""
     },
     "weborama.fr": {
@@ -3213,7 +3207,7 @@
     "widgets.outbrain.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535679663540,
+      "nextUpdateTime": 1535766647842,
       "userAction": ""
     },
     "wired.com": {
@@ -3237,25 +3231,25 @@
     "ws.sharethis.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535335492897,
+      "nextUpdateTime": 1535445893357,
       "userAction": ""
     },
     "ww.steelhousemedia.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535556921277,
+      "nextUpdateTime": 1535369602618,
       "userAction": ""
     },
     "www.allure.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535475009981,
+      "nextUpdateTime": 1535680288285,
       "userAction": ""
     },
     "www.architecturaldigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535491915288,
+      "nextUpdateTime": 1535572118422,
       "userAction": ""
     },
     "www.bing.com": {
@@ -3267,25 +3261,25 @@
     "www.bonappetit.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535370836192,
+      "nextUpdateTime": 1535662491591,
       "userAction": ""
     },
     "www.brides.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535367117721,
+      "nextUpdateTime": 1535456082317,
       "userAction": ""
     },
     "www.cntraveler.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535557439829,
+      "nextUpdateTime": 1535602597669,
       "userAction": ""
     },
     "www.epicurious.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535356981005,
+      "nextUpdateTime": 1535383347016,
       "userAction": ""
     },
     "www.facebook.com": {
@@ -3297,13 +3291,13 @@
     "www.glamour.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535304134792,
+      "nextUpdateTime": 1535684316433,
       "userAction": ""
     },
     "www.golfdigest.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535654060736,
+      "nextUpdateTime": 1535777753978,
       "userAction": ""
     },
     "www.google.com": {
@@ -3315,97 +3309,97 @@
     "www.gq.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535557201033,
+      "nextUpdateTime": 1535533301706,
       "userAction": ""
     },
     "www.justuno.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535439526561,
+      "nextUpdateTime": 1535835623263,
       "userAction": ""
     },
     "www.lightboxcdn.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535774798008,
+      "nextUpdateTime": 1535634668073,
       "userAction": ""
     },
     "www.linkedin.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535438867974,
+      "nextUpdateTime": 1535647703467,
       "userAction": ""
     },
     "www.newyorker.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535786649584,
+      "nextUpdateTime": 1535713896951,
       "userAction": ""
     },
     "www.pitchfork.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535513903637,
+      "nextUpdateTime": 1535717161877,
       "userAction": ""
     },
     "www.self.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535483680212,
+      "nextUpdateTime": 1535472362868,
       "userAction": ""
     },
     "www.teenvogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535581539395,
+      "nextUpdateTime": 1535775225012,
       "userAction": ""
     },
     "www.tns-counter.ru": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535452630744,
+      "nextUpdateTime": 1535779192331,
       "userAction": ""
     },
     "www.vanityfair.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535391747796,
+      "nextUpdateTime": 1535854231963,
       "userAction": ""
     },
     "www.vogue.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535721812757,
+      "nextUpdateTime": 1535683085556,
       "userAction": ""
     },
     "www.wired.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535369389550,
+      "nextUpdateTime": 1535492902964,
       "userAction": ""
     },
     "www.wmagazine.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535752078138,
+      "nextUpdateTime": 1535633330954,
       "userAction": ""
     },
     "www.yandex.ru": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535659930279,
+      "nextUpdateTime": 1535622719621,
       "userAction": ""
     },
     "www.youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 1535279092662,
+      "nextUpdateTime": 1535870220028,
       "userAction": ""
     },
     "x.bidswitch.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535589911304,
+      "nextUpdateTime": 1535717582854,
       "userAction": ""
     },
     "xiti.com": {
@@ -3417,7 +3411,7 @@
     "xpl.theadex.com": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535345322663,
+      "nextUpdateTime": 1535552741878,
       "userAction": ""
     },
     "xplosion.de": {
@@ -3456,12 +3450,6 @@
       "nextUpdateTime": 0,
       "userAction": ""
     },
-    "yimg.com": {
-      "dnt": false,
-      "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
-      "userAction": ""
-    },
     "youtube.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
@@ -3471,19 +3459,19 @@
     "z-na.amazon-adsystem.com": {
       "dnt": false,
       "heuristicAction": "",
-      "nextUpdateTime": 1535353268865,
+      "nextUpdateTime": 1535731599614,
       "userAction": ""
     },
     "za-cdn.effectivemeasure.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535603698010,
+      "nextUpdateTime": 1535474370166,
       "userAction": ""
     },
     "zdbb.net": {
       "dnt": false,
       "heuristicAction": "block",
-      "nextUpdateTime": 1535719784949,
+      "nextUpdateTime": 1535712458694,
       "userAction": ""
     },
     "zemanta.com": {
@@ -3535,6 +3523,7 @@
       "fastcompany.com",
       "earthlink.net",
       "qz.com",
+      "philips.com",
       "oclc.org"
     ],
     "33across.com": [
@@ -3554,13 +3543,13 @@
     "3gl.net": [
       "istockphoto.com",
       "gettyimages.com",
-      "thedailybeast.com"
+      "economist.com"
     ],
     "3lift.com": [
       "nature.com",
       "springer.com",
       "theverge.com",
-      "wunderground.com",
+      "deviantart.com",
       "focus.de"
     ],
     "4dsply.com": [
@@ -3639,9 +3628,6 @@
     "ad-hatena.com": [
       "hatena.ne.jp"
     ],
-    "ad-score.com": [
-      "wnd.com"
-    ],
     "ad-stir.com": [
       "sakura.ne.jp",
       "biglobe.ne.jp",
@@ -3666,7 +3652,8 @@
     "addroplet.com": [
       "wallinside.com",
       "wnd.com",
-      "washingtonexaminer.com"
+      "washingtonexaminer.com",
+      "tinypic.com"
     ],
     "addthis.com": [
       "nasa.gov",
@@ -3686,7 +3673,7 @@
       "t-online.de",
       "bloomberg.com",
       "springer.com",
-      "shutterstock.com",
+      "sciencemag.org",
       "helsinki.fi"
     ],
     "adfox.ru": [
@@ -3712,7 +3699,8 @@
       "bloomberg.com",
       "dailymotion.com",
       "spiegel.de",
-      "t-online.de"
+      "t-online.de",
+      "lemonde.fr"
     ],
     "adjust-net.jp": [
       "goo.ne.jp",
@@ -3722,6 +3710,7 @@
       "venturebeat.com",
       "livescience.com",
       "space.com",
+      "t-online.de",
       "dailydot.com"
     ],
     "adlmerge.com": [
@@ -3729,7 +3718,8 @@
     ],
     "admaster.com.cn": [
       "autohome.com.cn",
-      "bshare.cn"
+      "bshare.cn",
+      "youku.com"
     ],
     "admission.net": [
       "edmunds.com"
@@ -3742,6 +3732,7 @@
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
+      "telegraph.co.uk",
       "rfi.fr"
     ],
     "adobe.com": [
@@ -3757,7 +3748,8 @@
     ],
     "adotmob.com": [
       "standard.co.uk",
-      "upwork.com"
+      "upwork.com",
+      "nypost.com"
     ],
     "adriver.ru": [
       "ria.ru",
@@ -3790,7 +3782,8 @@
       "yahoo.com",
       "googletagmanager.com",
       "sourceforge.net",
-      "hgtv.com"
+      "cnet.com",
+      "gizmodo.com"
     ],
     "adswizz.com": [
       "iheart.com",
@@ -3801,7 +3794,7 @@
       "tinyurl.com",
       "etsy.com",
       "tripadvisor.com",
-      "foursquare.com",
+      "economist.com",
       "realtor.com"
     ],
     "adtags.pro": [
@@ -3815,6 +3808,7 @@
       "sourceforge.net",
       "dropbox.com",
       "wsj.com",
+      "dailymotion.com",
       "walgreens.com"
     ],
     "advertur.ru": [
@@ -3866,8 +3860,7 @@
       "voanews.com",
       "repubblica.it",
       "iyfubh.com",
-      "forbes.com",
-      "francetvinfo.fr"
+      "forbes.com"
     ],
     "akamaized.net": [
       "tamu.edu",
@@ -3887,7 +3880,7 @@
       "sina.com.cn",
       "alibaba.com",
       "youku.com",
-      "tmall.com",
+      "aliexpress.com",
       "1688.com"
     ],
     "alipay.com": [
@@ -3914,6 +3907,7 @@
       "nytimes.com",
       "reddit.com",
       "cnn.com",
+      "telegraph.co.uk",
       "bostonherald.com"
     ],
     "amazon.co.uk": [
@@ -3939,7 +3933,6 @@
       "worldbank.org",
       "acs.org",
       "fbi.gov",
-      "nasa.gov",
       "walgreens.com"
     ],
     "antdsp.com": [
@@ -3951,7 +3944,8 @@
     "aol.com": [
       "engadget.com",
       "indiatimes.com",
-      "autoblog.com"
+      "autoblog.com",
+      "techcrunch.com"
     ],
     "ap.org": [
       "post-gazette.com"
@@ -3968,6 +3962,7 @@
       "foursquare.com",
       "history.com",
       "nbc.com",
+      "airbnb.com",
       "strava.com"
     ],
     "appdynamics.com": [
@@ -4011,7 +4006,8 @@
     "atdmt.com": [
       "facebook.com",
       "yahoo.com",
-      "msn.com"
+      "msn.com",
+      "t-online.de"
     ],
     "atemda.com": [
       "springer.com",
@@ -4047,7 +4043,7 @@
       "sina.com.cn",
       "163.com",
       "ifeng.com",
-      "51.la"
+      "sohu.com"
     ],
     "bam-x.com": [
       "gq.com"
@@ -4117,7 +4113,8 @@
       "google.com",
       "amazon.com",
       "forbes.com",
-      "bostonherald.com"
+      "npr.org",
+      "newatlas.com"
     ],
     "bigmining.com": [
       "hatena.ne.jp"
@@ -4131,6 +4128,8 @@
       "cnn.com",
       "weebly.com",
       "msn.com",
+      "telegraph.co.uk",
+      "office.com",
       "pingdom.com"
     ],
     "bitbucket.org": [
@@ -4140,12 +4139,11 @@
       "eventbrite.com",
       "cloudflare.com",
       "zendesk.com",
-      "shutterstock.com",
+      "ibm.com",
       "gitlab.com"
     ],
     "bizibly.com": [
-      "eventbrite.com",
-      "cloudflare.com"
+      "eventbrite.com"
     ],
     "bizographics.com": [
       "zend.com",
@@ -4156,8 +4154,7 @@
     "bizrate.com": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com"
+      "ew.com"
     ],
     "blogos.com": [
       "livedoor.com"
@@ -4167,7 +4164,8 @@
     ],
     "bluecava.com": [
       "history.com",
-      "biography.com"
+      "biography.com",
+      "jimdo.com"
     ],
     "blueconic.net": [
       "nationalgeographic.com",
@@ -4198,8 +4196,7 @@
       "pitchfork.com"
     ],
     "boston.com": [
-      "bostonglobe.com",
-      "bleacherreport.com"
+      "bostonglobe.com"
     ],
     "bostonglobemedia.com": [
       "boston.com"
@@ -4236,14 +4233,13 @@
     "brightcove.net": [
       "lefigaro.fr",
       "politico.com",
-      "bostonglobe.com",
-      "techtarget.com"
+      "bostonglobe.com"
     ],
     "bttrack.com": [
       "yahoo.com",
       "independent.co.uk",
       "zendesk.com",
-      "uci.edu",
+      "nypost.com",
       "dailydot.com"
     ],
     "btttag.com": [
@@ -4286,6 +4282,7 @@
       "dropbox.com",
       "myspace.com",
       "washingtonpost.com",
+      "dailymail.co.uk",
       "pitchfork.com"
     ],
     "cbsi.com": [
@@ -4362,7 +4359,8 @@
     ],
     "clicktale.net": [
       "xbox.com",
-      "office.com"
+      "office.com",
+      "microsoft.com"
     ],
     "clicktripz.com": [
       "tripadvisor.com",
@@ -4377,9 +4375,6 @@
       "sciencemag.org",
       "nginx.com",
       "allaboutcookies.org"
-    ],
-    "cmgdigital.com": [
-      "ajc.com"
     ],
     "cnet.com": [
       "zdnet.com"
@@ -4461,6 +4456,9 @@
     "consumable.com": [
       "xfinity.com"
     ],
+    "content.ad": [
+      "tinypic.com"
+    ],
     "contentabc.com": [
       "pornhub.com"
     ],
@@ -4469,7 +4467,8 @@
       "myspace.com",
       "bloomberg.com",
       "forbes.com",
-      "walgreens.com"
+      "samsung.com",
+      "coindesk.com"
     ],
     "convertful.com": [
       "lifehack.org"
@@ -4507,6 +4506,9 @@
     "cr-nielsen.com": [
       "youku.com"
     ],
+    "creative-serving.com": [
+      "newatlas.com"
+    ],
     "creativecdn.com": [
       "ria.ru",
       "udn.com"
@@ -4519,6 +4521,7 @@
       "washingtonpost.com",
       "dailymail.co.uk",
       "dropbox.com",
+      "cnet.com",
       "sedo.com"
     ],
     "croissed.info": [
@@ -4550,6 +4553,7 @@
       "talktalk.co.uk",
       "gizmodo.com",
       "wsj.com",
+      "cbc.ca",
       "allafrica.com"
     ],
     "d1af033869koo7.cloudfront.net": [
@@ -4613,6 +4617,7 @@
       "yahoo.com",
       "amazon.com",
       "soundcloud.com",
+      "telegraph.co.uk",
       "skynet.be"
     ],
     "departapp.com": [
@@ -4663,6 +4668,7 @@
       "britannica.com",
       "lifehacker.com",
       "express.co.uk",
+      "gizmodo.com",
       "bostonherald.com"
     ],
     "disney.com": [
@@ -4701,13 +4707,15 @@
     "domdex.com": [
       "adobe.com",
       "sourceforge.net",
-      "tinypic.com"
+      "tinypic.com",
+      "slashdot.org"
     ],
     "dotomi.com": [
       "tinyurl.com",
       "samsung.com",
       "webmd.com",
       "forbes.com",
+      "economist.com",
       "walgreens.com"
     ],
     "dotsub.com": [
@@ -4718,6 +4726,7 @@
       "twitter.com",
       "linkedin.com",
       "sourceforge.net",
+      "telegraph.co.uk",
       "focus.de"
     ],
     "doublemax.net": [
@@ -4730,17 +4739,11 @@
       "military.com",
       "allafrica.com"
     ],
-    "dowjones.io": [
-      "marketwatch.com"
-    ],
     "dpmsrv.com": [
       "boston.com",
       "theregister.co.uk",
       "techtarget.com",
       "adweek.com"
-    ],
-    "dxpmedia.com": [
-      "autohome.com.cn"
     ],
     "dynad.net": [
       "uol.com.br"
@@ -4836,9 +4839,6 @@
       "vanityfair.com",
       "pitchfork.com"
     ],
-    "epital.gdn": [
-      "4shared.com"
-    ],
     "equalstyle.com": [
       "hubpages.com"
     ],
@@ -4853,9 +4853,6 @@
       "canalblog.com",
       "lefigaro.fr",
       "sfgate.com"
-    ],
-    "etahub.com": [
-      "pornhub.com"
     ],
     "etracker.de": [
       "sedo.com"
@@ -4874,6 +4871,7 @@
       "yahoo.com",
       "sourceforge.net",
       "tinyurl.com",
+      "telegraph.co.uk",
       "newatlas.com"
     ],
     "everyaction.com": [
@@ -4906,7 +4904,7 @@
       "soundcloud.com",
       "forbes.com",
       "bloomberg.com",
-      "businessinsider.com",
+      "surveymonkey.com",
       "gizmodo.com"
     ],
     "exosrv.com": [
@@ -4919,7 +4917,7 @@
       "sourceforge.net",
       "forbes.com",
       "bloomberg.com",
-      "gizmodo.com",
+      "news.com.au",
       "heraldsun.com.au"
     ],
     "eyereturn.com": [
@@ -4928,6 +4926,7 @@
     ],
     "eyeviewads.com": [
       "staples.com",
+      "nypost.com",
       "walgreens.com"
     ],
     "ezoic.net": [
@@ -4939,6 +4938,7 @@
       "wordpress.org",
       "adobe.com",
       "nytimes.com",
+      "telegraph.co.uk",
       "focus.de"
     ],
     "facetz.net": [
@@ -4979,7 +4979,8 @@
     "flashtalking.com": [
       "adobe.com",
       "samsung.com",
-      "msu.edu"
+      "msu.edu",
+      "bmj.com"
     ],
     "flickr.com": [
       "state.gov",
@@ -5006,6 +5007,9 @@
       "moonfruit.com",
       "webex.com",
       "sitepoint.com"
+    ],
+    "foreignpolicy.com": [
+      "onecount.net"
     ],
     "foresee.com": [
       "epa.gov",
@@ -5047,9 +5051,6 @@
     ],
     "friendbuy.com": [
       "lulu.com"
-    ],
-    "fuel451.com": [
-      "prezi.com"
     ],
     "funcaptcha.com": [
       "axs.com"
@@ -5156,7 +5157,7 @@
       "linkedin.com",
       "google.de",
       "sourceforge.net",
-      "google.ca",
+      "telegraph.co.uk",
       "scmp.com",
       "chromium.org",
       "focus.de"
@@ -5199,6 +5200,7 @@
       "adobe.com",
       "ox.ac.uk",
       "ihg.com",
+      "economist.com",
       "business2community.com"
     ],
     "gwmtracking.com": [
@@ -5338,7 +5340,8 @@
     "im-apps.net": [
       "exblog.jp",
       "rakuten.co.jp",
-      "biglobe.ne.jp"
+      "biglobe.ne.jp",
+      "economist.com"
     ],
     "imagetopng.club": [
       "4shared.com"
@@ -5357,13 +5360,15 @@
     "impact-ad.jp": [
       "rakuten.co.jp",
       "yahoo.co.jp",
-      "goo.ne.jp"
+      "goo.ne.jp",
+      "economist.com"
     ],
     "imrworldwide.com": [
       "cnn.com",
       "theguardian.com",
       "bbc.com",
       "wsj.com",
+      "cnet.com",
       "gizmodo.com"
     ],
     "infinity-tracking.net": [
@@ -5382,8 +5387,7 @@
       "ups.com"
     ],
     "inquisitr.com": [
-      "www.poznan.pl",
-      "flipboard.com"
+      "www.poznan.pl"
     ],
     "inside-graph.com": [
       "staples.com"
@@ -5392,13 +5396,15 @@
       "unsplash.com",
       "standard.co.uk",
       "motorola.com",
+      "giphy.com",
       "gopro.com"
     ],
     "instagram.com": [
       "cam.ac.uk",
       "illinois.edu",
       "cbslocal.com",
-      "arizona.edu"
+      "arizona.edu",
+      "tmz.com"
     ],
     "instinctiveads.com": [
       "variety.com",
@@ -5408,7 +5414,8 @@
     ],
     "intentiq.com": [
       "sourceforge.net",
-      "symantec.com"
+      "symantec.com",
+      "slashdot.org"
     ],
     "intentmedia.net": [
       "hotels.com",
@@ -5467,7 +5474,8 @@
       "indianexpress.com"
     ],
     "janrainsso.com": [
-      "vancouversun.com"
+      "vancouversun.com",
+      "nationalpost.com"
     ],
     "jd.com": [
       "163.com",
@@ -5519,6 +5527,7 @@
       "nationalgeographic.com",
       "chicagotribune.com",
       "nytimes.com",
+      "rollingstone.com",
       "zappos.com"
     ],
     "kinja.com": [
@@ -5534,6 +5543,7 @@
       "bgr.com",
       "jalopnik.com",
       "cnn.com",
+      "usatoday.com",
       "gizmodo.com"
     ],
     "ladsp.com": [
@@ -5559,6 +5569,7 @@
       "nj.com",
       "patch.com",
       "bloomberg.com",
+      "economist.com",
       "washingtonexaminer.com"
     ],
     "libero.it": [
@@ -5579,7 +5590,7 @@
       "zdnet.com",
       "fastcompany.com",
       "adweek.com",
-      "gizmodo.com",
+      "mashable.com",
       "dailycaller.com"
     ],
     "lijit.com": [
@@ -5600,7 +5611,8 @@
       "adobe.com",
       "vimeo.com",
       "sourceforge.net",
-      "msn.com",
+      "forbes.com",
+      "hp.com",
       "lexisnexis.com"
     ],
     "linksynergy.com": [
@@ -5618,9 +5630,9 @@
       "paypal.com",
       "skype.com",
       "msn.com",
+      "microsoft.com",
       "bing.com",
-      "office.com",
-      "microsoft.com"
+      "office.com"
     ],
     "livechatinc.com": [
       "ning.com",
@@ -5691,7 +5703,8 @@
     "mailchimp.com": [
       "colorlib.com",
       "fas.org",
-      "tias.com"
+      "tias.com",
+      "nap.edu"
     ],
     "mantisadnetwork.com": [
       "tvtropes.org"
@@ -5712,8 +5725,6 @@
       "nokia.com",
       "panasonic.com",
       "dyn.com",
-      "searchengineland.com",
-      "hootsuite.com",
       "domaintools.com"
     ],
     "matheranalytics.com": [
@@ -5726,6 +5737,7 @@
       "vimeo.com",
       "sourceforge.net",
       "forbes.com",
+      "usatoday.com",
       "pitchfork.com"
     ],
     "media.net": [
@@ -5733,6 +5745,7 @@
       "dropbox.com",
       "forbes.com",
       "reuters.com",
+      "npr.org",
       "cracked.com"
     ],
     "media6degrees.com": [
@@ -5752,7 +5765,8 @@
     "mediaplex.com": [
       "dell.com",
       "shutterfly.com",
-      "military.com"
+      "military.com",
+      "economist.com"
     ],
     "mediarithmics.com": [
       "orange.fr",
@@ -5783,7 +5797,11 @@
     ],
     "metadsp.co.uk": [
       "nypost.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "variety.com"
+    ],
+    "mfadsrvr.com": [
+      "forbes.com"
     ],
     "mg2connext.com": [
       "mercurynews.com",
@@ -5801,7 +5819,8 @@
     "miaozhen.com": [
       "sina.com.cn",
       "163.com",
-      "dzwww.com"
+      "dzwww.com",
+      "autohome.com.cn"
     ],
     "microad.jp": [
       "rakuten.co.jp",
@@ -5828,7 +5847,7 @@
       "parallels.com",
       "prnewswire.com",
       "zend.com",
-      "nginx.com",
+      "oreilly.com",
       "pingdom.com"
     ],
     "ml314.com": [
@@ -5836,6 +5855,7 @@
       "forbes.com",
       "bloomberg.com",
       "wsj.com",
+      "businessinsider.com",
       "zerohedge.com"
     ],
     "mlb.com": [
@@ -5932,7 +5952,8 @@
       "soundcloud.com",
       "surveymonkey.com",
       "spotify.com",
-      "paypal.com"
+      "paypal.com",
+      "economist.com"
     ],
     "nanigans.com": [
       "thinkgeek.com",
@@ -5942,7 +5963,7 @@
     ],
     "narrative.io": [
       "sourceforge.net",
-      "gizmodo.com"
+      "business2community.com"
     ],
     "nasdaq.com": [
       "globenewswire.com"
@@ -5985,7 +6006,8 @@
     "netmng.com": [
       "lenovo.com",
       "theknot.com",
-      "shopko.com"
+      "shopko.com",
+      "pitchfork.com"
     ],
     "newatlas.com": [
       "flipboard.com"
@@ -6012,6 +6034,7 @@
       "nypost.com",
       "thesun.co.uk",
       "wsj.com",
+      "news.com.au",
       "heraldsun.com.au"
     ],
     "newsinc.com": [
@@ -6057,6 +6080,7 @@
       "wsj.com",
       "oracle.com",
       "huffingtonpost.com",
+      "harvard.edu",
       "helsinki.fi"
     ],
     "nsaudience.pl": [
@@ -6129,7 +6153,7 @@
       "springer.com",
       "standard.co.uk",
       "home.pl",
-      "skyrock.com"
+      "variety.com"
     ],
     "omtrdc.net": [
       "adobe.com",
@@ -6152,6 +6176,7 @@
       "bitbucket.org",
       "namecheap.com",
       "cnn.com",
+      "thesun.co.uk",
       "active.com"
     ],
     "onevision.com.tw": [
@@ -6186,6 +6211,7 @@
       "amazon.com",
       "nytimes.com",
       "forbes.com",
+      "telegraph.co.uk",
       "active.com"
     ],
     "opinionstage.com": [
@@ -6201,24 +6227,20 @@
       "cnn.com",
       "creativecommons.org",
       "webs.com",
-      "nytimes.com",
-      "bbc.com",
-      "live.com",
       "ibm.com",
-      "hp.com",
+      "microsoft.com",
+      "bbc.com",
       "wiley.com",
       "npr.org",
       "springer.com",
       "cbsnews.com",
-      "foxnews.com",
-      "constantcontact.com",
       "imageshack.us",
       "wikihow.com",
       "newyorker.com",
       "evernote.com",
-      "box.com",
       "prezi.com",
       "prweb.com",
+      "ign.com",
       "dictionary.com",
       "bitbucket.org",
       "gotomeeting.com",
@@ -6247,6 +6269,7 @@
       "fourseasons.com",
       "couchsurfing.com",
       "gitlab.com",
+      "box.com",
       "fox.com"
     ],
     "optimove.events": [
@@ -6257,7 +6280,8 @@
       "alternet.org"
     ],
     "oracleimg.com": [
-      "dyn.com"
+      "dyn.com",
+      "oracle.com"
     ],
     "orangeads.fr": [
       "orange.fr"
@@ -6279,6 +6303,7 @@
       "scribd.com",
       "foxnews.com",
       "cnn.com",
+      "telegraph.co.uk",
       "focus.de"
     ],
     "ovh.com": [
@@ -6307,6 +6332,7 @@
       "wired.com",
       "wikia.com",
       "wsj.com",
+      "techcrunch.com",
       "dezeen.com"
     ],
     "paypal.com": [
@@ -6401,12 +6427,14 @@
       "independent.co.uk",
       "chicagotribune.com",
       "wsj.com",
+      "marketwatch.com",
       "bostonherald.com"
     ],
     "powerlinks.com": [
       "lemonde.fr",
       "livescience.com",
-      "standard.co.uk"
+      "standard.co.uk",
+      "variety.com"
     ],
     "pressboard.ca": [
       "observer.com"
@@ -6498,8 +6526,7 @@
     "qq.com": [
       "sina.com.cn",
       "ctrip.com",
-      "weather.com.cn",
-      "tencent.com"
+      "weather.com.cn"
     ],
     "qsstats.com": [
       "serverwatch.com",
@@ -6519,6 +6546,7 @@
       "vimeo.com",
       "reddit.com",
       "soundcloud.com",
+      "jimdo.com",
       "gizmodo.com"
     ],
     "quantummetric.com": [
@@ -6614,17 +6642,15 @@
     ],
     "rezync.com": [
       "economist.com",
-      "salon.com"
+      "investopedia.com"
     ],
     "rfihub.com": [
       "dropbox.com",
       "tinyurl.com",
       "npr.org",
-      "foursquare.com",
+      "forbes.com",
+      "economist.com",
       "gopro.com"
-    ],
-    "rhombusads.com": [
-      "adweek.com"
     ],
     "ria.ru": [
       "sputniknews.com"
@@ -6653,6 +6679,7 @@
       "yahoo.com",
       "sourceforge.net",
       "reddit.com",
+      "hp.com",
       "box.com"
     ],
     "rnengage.com": [
@@ -6675,28 +6702,27 @@
     ],
     "rtk.io": [
       "post-gazette.com",
-      "azcentral.com",
       "freep.com"
     ],
     "ru4.com": [
       "dropbox.com",
       "bloomberg.com",
-      "uci.edu"
+      "npr.org"
     ],
     "rubiconproject.com": [
       "yahoo.com",
       "amazon.com",
       "sourceforge.net",
       "nytimes.com",
-      "pitchfork.com"
+      "dailymail.co.uk",
+      "gizmodo.com"
     ],
     "rundsp.com": [
       "hpe.com",
       "alternet.org"
     ],
     "rutarget.ru": [
-      "rambler.ru",
-      "ria.ru"
+      "rambler.ru"
     ],
     "s3-us-west-2.amazonaws.com": [
       "codepen.io",
@@ -6709,9 +6735,6 @@
     ],
     "sabavision.com": [
       "mihanblog.com"
-    ],
-    "salecycle.com": [
-      "talktalk.co.uk"
     ],
     "salesforceliveagent.com": [
       "constantcontact.com",
@@ -6767,6 +6790,7 @@
       "yahoo.com",
       "tumblr.com",
       "nytimes.com",
+      "telegraph.co.uk",
       "gizmodo.com"
     ],
     "scribblelive.com": [
@@ -6831,7 +6855,7 @@
       "dropbox.com",
       "t-online.de",
       "nbcnews.com",
-      "npr.org",
+      "businessinsider.com",
       "hgtv.com"
     ],
     "sessioncam.com": [
@@ -6853,6 +6877,7 @@
       "yahoo.com",
       "cnn.com",
       "time.com",
+      "forbes.com",
       "cnet.com",
       "walgreens.com"
     ],
@@ -6867,9 +6892,6 @@
     "shopify.com": [
       "codepen.io",
       "raspberrypi.org"
-    ],
-    "sibautomation.com": [
-      "themeisle.com"
     ],
     "simplereach.com": [
       "theatlantic.com"
@@ -6900,6 +6922,7 @@
       "udel.edu",
       "berkeley.edu",
       "jhu.edu",
+      "ethz.ch",
       "helsinki.fi",
       "case.edu",
       "oclc.org"
@@ -6926,7 +6949,7 @@
       "businessinsider.com",
       "engadget.com",
       "gizmodo.com",
-      "arstechnica.com",
+      "jimdo.com",
       "coindesk.com"
     ],
     "sky.com": [
@@ -6967,6 +6990,7 @@
       "overstock.com",
       "complex.com",
       "wsj.com",
+      "giphy.com",
       "zappos.com"
     ],
     "snapwidget.com": [
@@ -7019,8 +7043,9 @@
       "photobucket.com",
       "deviantart.com",
       "springer.com",
-      "forbes.com",
-      "detroitnews.com"
+      "myspace.com",
+      "cnet.com",
+      "edmunds.com"
     ],
     "sonyentertainmentnetwork.com": [
       "playstation.com"
@@ -7029,7 +7054,7 @@
       "harvard.edu",
       "spiegel.de",
       "bmj.com",
-      "independent.ie",
+      "irishtimes.com",
       "mo.gov"
     ],
     "sourceforge.net": [
@@ -7073,7 +7098,7 @@
       "amazon.com",
       "dropbox.com",
       "dailymotion.com",
-      "thenextweb.com",
+      "npr.org",
       "bostonherald.com"
     ],
     "spoutable.com": [
@@ -7114,6 +7139,7 @@
       "hugedomains.com",
       "dropcatch.com",
       "man7.org",
+      "cbslocal.com",
       "zerohedge.com"
     ],
     "staticimgfarm.com": [
@@ -7164,6 +7190,9 @@
       "feedly.com",
       "documentcloud.org"
     ],
+    "stripe.network": [
+      "smashballoon.com"
+    ],
     "sumo.com": [
       "snopes.com",
       "cdbaby.com",
@@ -7194,13 +7223,13 @@
     "surveymonkey.com": [
       "cambridge.org",
       "investopedia.com",
-      "foreignpolicy.com",
-      "iop.org"
+      "foreignpolicy.com"
     ],
     "switchadhub.com": [
       "lycos.com",
       "metacafe.com",
-      "indianexpress.com"
+      "indianexpress.com",
+      "springer.com"
     ],
     "symantec.com": [
       "norton.com",
@@ -7214,6 +7243,7 @@
       "dropbox.com",
       "t-online.de",
       "msn.com",
+      "telegraph.co.uk",
       "edmunds.com"
     ],
     "tacdn.com": [
@@ -7226,8 +7256,7 @@
       "overstock.com"
     ],
     "tailtarget.com": [
-      "uol.com.br",
-      "variety.com"
+      "uol.com.br"
     ],
     "tamgrt.com": [
       "tripadvisor.com",
@@ -7250,7 +7279,8 @@
       "yahoo.com",
       "soundcloud.com",
       "paypal.com",
-      "networksolutions.com"
+      "jimdo.com",
+      "bostonherald.com"
     ],
     "targetimg1.com": [
       "target.com"
@@ -7275,8 +7305,7 @@
     "technolutions.net": [
       "illinois.edu",
       "upenn.edu",
-      "uci.edu",
-      "udel.edu"
+      "uci.edu"
     ],
     "techweb.com": [
       "informationweek.com"
@@ -7334,8 +7363,7 @@
     "timecommerce.net": [
       "fortune.com",
       "people.com",
-      "ew.com",
-      "time.com"
+      "ew.com"
     ],
     "timewarnercable.com": [
       "ncsu.edu"
@@ -7345,6 +7373,7 @@
       "techcrunch.com",
       "kickstarter.com",
       "bloomberg.com",
+      "cnbc.com",
       "gizmodo.com"
     ],
     "tiqcdn.com": [
@@ -7352,6 +7381,7 @@
       "nbcnews.com",
       "ibm.com",
       "wsj.com",
+      "marketwatch.com",
       "hpe.com",
       "francetvinfo.fr"
     ],
@@ -7475,6 +7505,7 @@
       "wired.com",
       "webmd.com",
       "tinyurl.com",
+      "hp.com",
       "pitchfork.com"
     ],
     "tutorialize.me": [
@@ -7498,13 +7529,15 @@
       "nytimes.com",
       "cnn.com",
       "msn.com",
-      "lexisnexis.com"
+      "hp.com",
+      "sfgate.com",
+      "lexisnexis.com",
+      "edmunds.com"
     ],
     "tynt.com": [
       "accuweather.com",
       "investopedia.com",
       "washingtontimes.com",
-      "salon.com",
       "dailycaller.com"
     ],
     "ubi.com": [
@@ -7551,7 +7584,8 @@
     "unrulymedia.com": [
       "nypost.com",
       "earthlink.net",
-      "boingboing.net"
+      "boingboing.net",
+      "networkadvertising.org"
     ],
     "upravel.com": [
       "rambler.ru",
@@ -7583,6 +7617,7 @@
       "scotsman.com"
     ],
     "uservoice.com": [
+      "scoop.it",
       "theknot.com"
     ],
     "ustream.tv": [
@@ -7636,8 +7671,7 @@
       "cbc.ca"
     ],
     "videoamp.com": [
-      "hpe.com",
-      "alternet.org"
+      "hpe.com"
     ],
     "videohub.tv": [
       "liveuamap.com",
@@ -7675,7 +7709,6 @@
       "myspace.com",
       "fortune.com",
       "people.com",
-      "time.com",
       "zappos.com"
     ],
     "virgilio.it": [
@@ -7715,6 +7748,9 @@
     "vtracy.de": [
       "bloomberg.com"
     ],
+    "vulture.com": [
+      "nymag.com"
+    ],
     "w55c.net": [
       "hpe.com",
       "ebay.com",
@@ -7726,6 +7762,9 @@
     ],
     "wallst.com": [
       "reuters.com"
+    ],
+    "walmartimages.com": [
+      "walmart.com"
     ],
     "waptime.cn": [
       "tianqi.com"
@@ -7777,6 +7816,7 @@
       "nature.com",
       "abc.net.au",
       "oup.com",
+      "ethz.ch",
       "dhl.com"
     ],
     "webvisor.org": [
@@ -7950,6 +7990,7 @@
       "vimeo.com",
       "flickr.com",
       "sourceforge.net",
+      "hp.com",
       "eset.com"
     ],
     "yandex.ru": [
@@ -7978,6 +8019,7 @@
       "heise.de",
       "faz.net",
       "t-online.de",
+      "springer.com",
       "focus.de"
     ],
     "yieldoptimizer.com": [
@@ -7988,11 +8030,7 @@
     "yimg.com": [
       "yahoo.com",
       "flickr.com",
-      "nytimes.com",
-      "dropbox.com",
-      "iop.org",
-      "sbs.com.au",
-      "eset.com"
+      "nytimes.com"
     ],
     "yldbt.com": [
       "wired.com",
@@ -8023,8 +8061,9 @@
       "godaddy.com",
       "nih.gov",
       "telegraph.co.uk",
+      "harvard.edu",
       "caltech.edu",
-      "dailykos.com",
+      "francetvinfo.fr",
       "honeywell.com"
     ],
     "youvisit.com": [
@@ -8053,7 +8092,7 @@
       "independent.co.uk",
       "thehill.com",
       "farfetch.com",
-      "paypal.com",
+      "lemonde.fr",
       "infoplease.com"
     ],
     "zendesk.com": [
@@ -8065,7 +8104,7 @@
       "imdb.com",
       "pcmag.com",
       "rollingstone.com",
-      "wunderground.com"
+      "marketwatch.com"
     ],
     "zhaopin.cn": [
       "zhaopin.com"
@@ -8097,5 +8136,5 @@
       "heraldsun.com.au"
     ]
   },
-  "version": "2018.8.25"
+  "version": "2018.8.26"
 }


### PR DESCRIPTION
Refactor `crawler.py` to be a stateful object with methods rather than passing `driver` around between functions. 

In addition, this PR integrates the changes from the https://github.com/EFForg/badger-sett/tree/rich-pb-snitch-map branch as a subclass of the Crawler object. This branch allows badger-sett to work with the rich reporting branch in Privacy Badger (https://github.com/EFForg/privacybadger/tree/store-tracking-type-in-snitch-map), which saves info about all the trackers PB comes across and doesn't block anything. This is useful for testing out new heuristics and for measuring the prevalence of certain kinds of trackers around the web.

To use the survey feature, run
```
$ PB_BRANCH=store-tracking-type-in-snitch-map ./runscan.sh --survey
```