### PR TITLE
Update of PyFunceble's version and behavior

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -43,6 +43,8 @@ MAJESTIC_URL = "http://downloads.majesticseo.com/majestic_million.csv"
 WEEK_IN_SECONDS = 604800
 RESTART_RETRIES = 5
 
+OUR_PYFUNCEBLE_CONFIG = {"share_logs": False}
+
 ap = argparse.ArgumentParser()
 ap.add_argument('--browser', choices=[FIREFOX, CHROME], default=CHROME,
                 help='Browser to use for the scan')
@@ -124,7 +126,7 @@ def get_domain_list(logger, n_sites, out_path):
                 if pyfunc_cache[domain] == 'ACTIVE':
                     domains.append(domain)
             else:
-                status = PyFunceble(domain)
+                status = PyFunceble(domain, config=OUR_PYFUNCEBLE_CONFIG)
                 logger.info('PyFunceble: %s is %s', domain, status)
                 if status == 'ACTIVE':
                     domains.append(domain)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ selenium==3.12.0
 tldextract==2.2.0
 xvfbwrapper==0.2.9
 GitPython==2.1.11
-PyFunceble==1.7.0
+PyFunceble==1.8.0


### PR DESCRIPTION
Since very recently I allowed the update of the configuration when programming on top of PyFunceble.

This patch updates to the latest version (The one which include the configuration update) and deactivates the logs sharing as mentioned at https://github.com/EFForg/badger-sett/pull/23#issuecomment-418537430.

Between because I never really answered your question, If you do a DNS lookup and get inactive and once you use PyFunceble you get active it is because I do like follow.

1. Try to get the WHOIS record.
2. Could we get the RECORD?
    * YES: Move to point 3.
    * NO: Move to point 4.
3. Could we extract the expiration date from the record?
    * YES: Set the domain as `ACTIVE` and move to the next domain to test.
    * NO: Move to point 4.
4. Try to do a DNS lookup.
5. Do we get an error while trying to run the lookup?
    * YES: Set the domain as `INACTIVE` and move to the next domain to test.
    * NO: Set the domain as `ACTIVE` and move to the next domain to test.
 
Of course, if it is not what you want you simply have to add `"no_whois": True` to the newly created `OUR_PYFUNCEBLE_CONFIG` variable which will bypass point 1, 2 and 3 to get to point 4 directly.

Please let me know if I can help or if you need more information about PyFunceble.

Cheers, 
Nissar