### PR TITLE
Replace hardcoded chown user with USER variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install --user -r requirements.txt
 COPY crawler.py validate.py docker-entry.sh $HOME/
 COPY domain-lists $HOME/domain-lists
 COPY results.json $HOME/old-results.json
-COPY --chown=bennett:bennett privacybadger $PBPATH
+COPY --chown=$USER:$USER privacybadger $PBPATH
 RUN mkdir -p $OUTPATH
 
 ENTRYPOINT ["./docker-entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ RUN pip3 install --user -r requirements.txt
 COPY crawler.py validate.py docker-entry.sh $HOME/
 COPY domain-lists $HOME/domain-lists
 COPY results.json $HOME/old-results.json
-COPY --chown=$USER:$USER privacybadger $PBPATH
+COPY privacybadger $PBPATH
+
+USER root
+RUN chown -R $USER:$USER $PBPATH
+USER $UNAME
 RUN mkdir -p $OUTPATH
 
 ENTRYPOINT ["./docker-entry.sh"]


### PR DESCRIPTION
I tried running this on a machine of mine and I got an error because there was no `bennett` user on my host machine. Changing this to use `$USER` made the docker build step work without erroring out and applied the correct permissions to the privacybadger directory so that the application could write to it in the docker container and I could view it on the host machine.