### PR TITLE
Improve logging

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -108,7 +108,7 @@ def get_domain_list(n_sites, exclude_option):
     tranco_domains = Tranco(cache=False).list(TRANCO_VERSION).top()
     extract = TLDExtract(cache_file=False)
     domains = []
-    
+
     if not n_sites:
         n_sites = DEFAULT_NUM_SITES
 
@@ -185,6 +185,11 @@ class Crawler:
             self.logger.addHandler(sh)
 
         self.storage_objects = ['snitch_map', 'action_map']
+
+        # create an XVFB virtual display (to avoid opening an actual browser)
+        self.vdisplay = Xvfb(width=1280, height=720)
+        self.vdisplay.start()
+        self.start_browser()
 
         self.logger.info(
             (
@@ -439,11 +444,6 @@ class Crawler:
 
         domains = get_domain_list(self.n_sites, self.exclude)
 
-        # create an XVFB virtual display (to avoid opening an actual browser)
-        self.vdisplay = Xvfb(width=1280, height=720)
-        self.vdisplay.start()
-        self.start_browser()
-
         # list of domains we actually visited
         visited = []
         old_snitches = {}
@@ -646,11 +646,6 @@ chrome.runtime.sendMessage({
             domains = self.domain_list
         else:
             domains = get_domain_list(self.n_sites, self.exclude)
-
-        # create an XVFB virtual display (to avoid opening an actual browser)
-        self.vdisplay = Xvfb(width=1280, height=720)
-        self.vdisplay.start()
-        self.start_browser()
 
         # list of domains we actually visited
         visited = []

--- a/crawler.py
+++ b/crawler.py
@@ -195,19 +195,24 @@ class Crawler:
         browser_version = self.driver.capabilities["browserVersion"]
 
         # returns most recent commit hash
-        def get_hash(path):
+        def bundle_git_info(path):
+            git_info = []
             git_dir = pathlib.Path(path) / '.git'
             with (git_dir / 'HEAD').open('r') as head:
                 ref = head.readline().split(' ')[-1].strip()
+                git_info.append(ref.split('/')[2])
 
             with (git_dir / ref).open('r') as git_hash:
-                return git_hash.readline().strip()
+                git_info.append(git_hash.readline().strip())
 
-        badger_hash = get_hash(self.pb_path)
+            return git_info
+
+        git_data = bundle_git_info(self.pb_path)
 
         self.logger.info(
             (
                 "Starting new crawl:\n"
+                "\tBadger branch: %s\n"
                 "\tBadger hash: %s\n"
                 "\ttimeout: %ss\n"
                 "\twait time: %ss\n"
@@ -218,7 +223,8 @@ class Crawler:
                 "\tdomains to crawl: %d\n"
                 "\tTLDs to exclude: %s"
             ),
-            badger_hash,
+            git_data[0],
+            git_data[1],
             self.timeout,
             self.wait_time,
             self.browser,

--- a/crawler.py
+++ b/crawler.py
@@ -11,6 +11,7 @@ import os
 import sys
 import tempfile
 import time
+import pathlib
 
 from datetime import datetime, timedelta
 from shutil import copytree
@@ -193,9 +194,21 @@ class Crawler:
 
         browser_version = self.driver.capabilities["browserVersion"]
 
+        # returns most recent commit hash
+        def get_hash(path):
+            git_dir = pathlib.Path(path) / '.git'
+            with (git_dir / 'HEAD').open('r') as head:
+                ref = head.readline().split(' ')[-1].strip()
+
+            with (git_dir / ref).open('r') as git_hash:
+                return git_hash.readline().strip()
+
+        badger_hash = get_hash(self.pb_path)
+
         self.logger.info(
             (
                 "Starting new crawl:\n"
+                "\tBadger hash: %s\n"
                 "\ttimeout: %ss\n"
                 "\twait time: %ss\n"
                 "\tbrowser: %s (v. %s)\n"
@@ -205,6 +218,7 @@ class Crawler:
                 "\tdomains to crawl: %d\n"
                 "\tTLDs to exclude: %s"
             ),
+            badger_hash,
             self.timeout,
             self.wait_time,
             self.browser,

--- a/crawler.py
+++ b/crawler.py
@@ -195,8 +195,12 @@ class Crawler:
         browser_version = self.driver.capabilities["browserVersion"]
 
         # gathers up git info for logging
-        def bundle_git_info(path):
-            git_info = {}
+        def get_git_info(path):
+            git_info = {
+                'branch': None,
+                'commit_hash': None
+            }
+
             git_dir = pathlib.Path(path) / '.git'
 
             try:
@@ -206,14 +210,16 @@ class Crawler:
 
                 with (git_dir / ref).open('r') as git_hash:
                     git_info['commit_hash'] = git_hash.readline().strip()
+
             except FileNotFoundError as err:
-                self.logger.info('error during git info retrieval : %s ',err)
-                git_info['branch'] = 'unable to retrieve git info: please check that this is a git directory'
-                git_info['commit_hash'] = 'unable to retrive git info: please check that this is a git directory'
+                self.logger.warning(
+                    "Unable to retrieve git repository info "
+                    "for Privacy Badger:\n"
+                    "\t%s", err)
 
             return git_info
 
-        git_data = bundle_git_info(self.pb_path)
+        git_data = get_git_info(self.pb_path)
 
         self.logger.info(
             (

--- a/crawler.py
+++ b/crawler.py
@@ -8,10 +8,10 @@ import copy
 import json
 import logging
 import os
+import pathlib
 import sys
 import tempfile
 import time
-import pathlib
 
 from datetime import datetime, timedelta
 from shutil import copytree
@@ -194,16 +194,16 @@ class Crawler:
 
         browser_version = self.driver.capabilities["browserVersion"]
 
-        # returns most recent commit hash
+        # gathers up git info for logging
         def bundle_git_info(path):
-            git_info = []
+            git_info = {}
             git_dir = pathlib.Path(path) / '.git'
             with (git_dir / 'HEAD').open('r') as head:
                 ref = head.readline().split(' ')[-1].strip()
-                git_info.append(ref.split('/')[2])
+                git_info['branch'] = ref.split('/')[2]
 
             with (git_dir / ref).open('r') as git_hash:
-                git_info.append(git_hash.readline().strip())
+                git_info['commit_hash'] = git_hash.readline().strip()
 
             return git_info
 
@@ -223,8 +223,8 @@ class Crawler:
                 "\tdomains to crawl: %d\n"
                 "\tTLDs to exclude: %s"
             ),
-            git_data[0],
-            git_data[1],
+            git_data['branch'],
+            git_data['commit_hash'],
             self.timeout,
             self.wait_time,
             self.browser,

--- a/crawler.py
+++ b/crawler.py
@@ -191,12 +191,14 @@ class Crawler:
         self.vdisplay.start()
         self.start_browser()
 
+        browser_version = self.driver.capabilities["browserVersion"]
+
         self.logger.info(
             (
                 "Starting new crawl:\n"
                 "\ttimeout: %ss\n"
                 "\twait time: %ss\n"
-                "\tbrowser: %s\n"
+                "\tbrowser: %s (v. %s)\n"
                 "\tFirefox ETP: %s\n"
                 "\tsurvey mode: %s\n"
                 "\tTranco version: %s\n"
@@ -206,6 +208,7 @@ class Crawler:
             self.timeout,
             self.wait_time,
             self.browser,
+            browser_version,
             self.firefox_tracking_protection,
             args.survey,
             TRANCO_VERSION,

--- a/crawler.py
+++ b/crawler.py
@@ -198,12 +198,18 @@ class Crawler:
         def bundle_git_info(path):
             git_info = {}
             git_dir = pathlib.Path(path) / '.git'
-            with (git_dir / 'HEAD').open('r') as head:
-                ref = head.readline().split(' ')[-1].strip()
-                git_info['branch'] = ref.split('/')[2]
 
-            with (git_dir / ref).open('r') as git_hash:
-                git_info['commit_hash'] = git_hash.readline().strip()
+            try:
+                with (git_dir / 'HEAD').open('r') as head:
+                    ref = head.readline().split(' ')[-1].strip()
+                    git_info['branch'] = ref.split('/')[2]
+
+                with (git_dir / ref).open('r') as git_hash:
+                    git_info['commit_hash'] = git_hash.readline().strip()
+            except FileNotFoundError as err:
+                self.logger.info('error during git info retrieval : %s ',err)
+                git_info['branch'] = 'unable to retrieve git info: please check that this is a git directory'
+                git_info['commit_hash'] = 'unable to retrive git info: please check that this is a git directory'
 
             return git_info
 


### PR DESCRIPTION
Fixes #52 by including the most recent commit hash in the `runscan.sh` script terminal output, as well as logging the browser type and version in the `crawler.py` file.

Might circle back and reduce the amount of redundant output in both areas, but for now this is the MVP to fix the aforementioned issue.