### PR TITLE
add cli arg option for loading parallel extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.sw?
+parallel-extensions/*.crx
+parallel-extensions/*.xpi

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ENV USER=$UNAME
 ENV HOME=/home/$USER
 ENV OUTPATH=$HOME/out/
 ENV PBPATH=$HOME/privacybadger/
+ENV EXTENSIONS=$HOME/parallel-extensions/
 
 WORKDIR $HOME
 
@@ -43,6 +44,7 @@ COPY crawler.py validate.py docker-entry.sh $HOME/
 COPY domain-lists $HOME/domain-lists
 COPY results.json $HOME/old-results.json
 COPY privacybadger $PBPATH
+COPY parallel-extensions $EXTENSIONS
 
 USER root
 RUN chown -R $USER:$USER $PBPATH

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ See the following eff.org blog post for more information: [Giving Privacy Badger
    $ ./runscan.sh --exclude org,net
    ```
 
+   You can load another extension to run in parallel to Privacy Badger during a scan.
+   Use the `--load-extension` flag and pass along the filepath for the `.crx` or `.xpi`
+   file that you want to load. For example:
+   ```
+   $ ./runscan.sh --load-extension parallel-extensions/ublock.crx
+   ```
+
 3. Monitor the scan
 
    To have the scan print verbose output about which sites it's visiting, use

--- a/crawler.py
+++ b/crawler.py
@@ -267,6 +267,7 @@ class Crawler:
             opts.add_argument('--no-sandbox')
             opts.add_argument("--load-extension=" + new_extension_path)
 
+            # loads parallel extension to run alongside pb
             if self.load_extension:
                 opts.add_extension(self.load_extension)
 
@@ -324,6 +325,10 @@ class Crawler:
             # load Privacy Badger
             unpacked_addon_path = os.path.join(self.pb_path, 'src')
             self.driver.install_addon(unpacked_addon_path, temporary=True)
+
+            # loads parallel extension to run alongside pb
+            if self.load_extension:
+                self.driver.install_addon(self.load_extension)
 
         # apply timeout settings
         self.driver.set_page_load_timeout(self.timeout)

--- a/crawler.py
+++ b/crawler.py
@@ -328,7 +328,9 @@ class Crawler:
 
             # loads parallel extension to run alongside pb
             if self.load_extension:
-                self.driver.install_addon(self.load_extension)
+                # make the path to the firefox extension absolute
+                parallel_extension_url = os.path.abspath(self.load_extension)
+                self.driver.install_addon(parallel_extension_url)
 
         # apply timeout settings
         self.driver.set_page_load_timeout(self.timeout)

--- a/crawler.py
+++ b/crawler.py
@@ -72,6 +72,8 @@ ap.add_argument('--wait-time', type=float, default=5, help=(
 ))
 ap.add_argument('--log-stdout', action='store_true', default=False,
                 help='If set, log to stdout as well as log.txt')
+ap.add_argument('--load-extension', default=None,
+                help='If set, load arbitrary extension to run in parallel to PB')
 
 ap.add_argument('--survey', action='store_true', default=False,
                 help="If set, don't block anything or store action_map data")
@@ -157,6 +159,7 @@ class Crawler:
         self.chromedriver_path = args.chromedriver_path
         self.firefox_path = args.firefox_path
         self.firefox_tracking_protection = args.firefox_tracking_protection
+        self.load_extension = args.load_extension
 
         # version is based on when the crawl started
         self.version = time.strftime('%Y.%-m.%-d', time.localtime())
@@ -220,6 +223,7 @@ class Crawler:
                 "  domain list: %s\n"
                 "  domains to crawl: %d\n"
                 "  TLDs to exclude: %s\n"
+                "  parallel extension: %s\n"
                 "  Firefox ETP: %s\n"
                 "  driver capabilities:\n\n%s\n"
             ),
@@ -231,6 +235,7 @@ class Crawler:
             self.domain_list if self.domain_list else "Tranco " + TRANCO_VERSION,
             self.n_sites,
             self.exclude,
+            self.load_extension,
             self.firefox_tracking_protection,
             pformat(self.driver.capabilities)
         )

--- a/crawler.py
+++ b/crawler.py
@@ -267,6 +267,9 @@ class Crawler:
             opts.add_argument('--no-sandbox')
             opts.add_argument("--load-extension=" + new_extension_path)
 
+            if self.load_extension:
+                opts.add_extension(self.load_extension)
+
             prefs = {"profile.block_third_party_cookies": False}
             opts.add_experimental_option("prefs", prefs)
             opts.add_argument('--dns-prefetch-disable')


### PR DESCRIPTION
fixes #54 by allowing loading of an arbitrary extension alongside privacy badger in the headless browser